### PR TITLE
fix(files): increase file upload rate limit from 5 to 20 per minute

### DIFF
--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -19,10 +19,10 @@ export const publicChatRateLimit = new Ratelimit({
 });
 
 // Rate limiter for file uploads
-// 5 uploads per minute per user
+// 20 uploads per minute per user
 export const fileUploadRateLimit = new Ratelimit({
   redis,
-  limiter: Ratelimit.slidingWindow(5, "1 m"),
+  limiter: Ratelimit.slidingWindow(20, "1 m"),
   analytics: true,
   prefix: "@ratelimit/file-upload",
 });


### PR DESCRIPTION
## Summary
- Increased file upload rate limit from 5 to 20 uploads per minute per user
- Addresses feedback from professors hitting rate limits when uploading multiple files at once

## Test plan
- [ ] Verify users can upload 6+ files in quick succession without hitting rate limit
- [ ] Confirm rate limiting still kicks in after 20 uploads per minute