### PR TITLE
chore(ci): add GitHub automation for dependabot, labels, and CI improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,116 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    # Let package releases bake for a bit before updating,
+    # in case there is a bad release
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 4
+      semver-patch-days: 2
+      include:
+        - "*"
+      exclude:
+        - "@teachanything/*"
+        - "ai"
+        - "@ai-sdk/*"
+    groups:
+      trpc:
+        patterns:
+          - "@trpc/*"
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+      drizzle:
+        patterns:
+          - "drizzle-kit"
+          - "drizzle-orm"
+      ai-sdk:
+        patterns:
+          - "ai"
+          - "@ai-sdk/*"
+      langchain:
+        patterns:
+          - "langchain"
+          - "@langchain/*"
+      next:
+        patterns:
+          - "next"
+          - "@next/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      upstash:
+        patterns:
+          - "@upstash/*"
+      supabase:
+        patterns:
+          - "@supabase/*"
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "typescript-eslint"
+          - "eslint-plugin-*"
+          - "eslint-config-*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "tailwind-*"
+          - "@tailwindcss/*"
+          - "postcss"
+          - "autoprefixer"
+      small-safe-packages:
+        # These are generally safe to update unconditionally
+        patterns:
+          - "lucide-react"
+          - "prettier"
+          - "clsx"
+          - "class-variance-authority"
+          - "tailwind-merge"
+          - "zod"
+          - "superjson"
+          - "nanoid"
+          - "pino"
+          - "pino-pretty"
+          - "sonner"
+          - "framer-motion"
+      markdown:
+        patterns:
+          - "marked"
+          - "react-markdown"
+          - "remark-*"
+      turbo:
+        patterns:
+          - "turbo"
+          - "@turbo/*"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,119 @@
+# GitHub labels configuration (see .github/workflows/automation-labels.yml)
+
+# Area labels - which part of the codebase
+- name: "area: web"
+  color: "26b5ce"
+  description: "Changes to the web app (apps/web)"
+
+- name: "area: db"
+  color: "26b5ce"
+  description: "Changes to the database package (packages/db)"
+
+- name: "area: ai"
+  color: "26b5ce"
+  description: "Changes to the AI package (packages/ai)"
+
+- name: "area: documentation"
+  color: "26b5ce"
+  description: "Improvements or additions to documentation"
+
+- name: "area: github actions"
+  color: "26b5ce"
+  description: "Changes to GitHub Actions workflows"
+
+- name: "area: config"
+  color: "26b5ce"
+  description: "Changes to repository configuration files"
+
+# Change labels - conventional commit type
+- name: "change: feat"
+  color: "32e52f"
+  description: "New feature"
+
+- name: "change: fix"
+  color: "158c01"
+  description: "Bug fix"
+
+- name: "change: chore"
+  color: "ededed"
+  description: "Maintenance and chores"
+
+- name: "change: docs"
+  color: "0075ca"
+  description: "Documentation changes"
+
+- name: "change: refactor"
+  color: "fbca04"
+  description: "Code refactoring"
+
+- name: "change: test"
+  color: "bfd4f2"
+  description: "Test changes"
+
+- name: "change: ci"
+  color: "000000"
+  description: "CI/CD changes"
+
+- name: "change: perf"
+  color: "f9d0c4"
+  description: "Performance improvements"
+
+- name: "change: deps"
+  color: "0366d6"
+  description: "Dependency updates"
+
+# Status labels
+- name: "status: do not merge"
+  color: "e11d21"
+  description: "PR should not be merged"
+
+- name: "status: blocked"
+  color: "e11d21"
+  description: "This issue or pull request is blocked"
+
+- name: "status: in progress"
+  color: "cccccc"
+  description: "Work is currently being done"
+
+- name: "status: triage"
+  color: "fef2c0"
+  description: "Needs to be triaged by a maintainer"
+
+- name: "status: help wanted"
+  color: "008672"
+  description: "Needs assistance and is ready for work"
+
+# Type labels
+- name: "type: bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: "type: enhancement"
+  color: "a2eeef"
+  description: "New feature or request"
+
+- name: "type: question"
+  color: "d876e3"
+  description: "Further information is requested"
+
+# Priority labels
+- name: "priority: critical"
+  color: "b60205"
+  description: "Critical priority"
+
+- name: "priority: high"
+  color: "d93f0b"
+  description: "High priority"
+
+- name: "priority: medium"
+  color: "eab308"
+  description: "Medium priority"
+
+- name: "priority: low"
+  color: "0e8a16"
+  description: "Low priority"
+
+# Community labels
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"

--- a/.github/workflows/automation-labels.yml
+++ b/.github/workflows/automation-labels.yml
@@ -1,0 +1,146 @@
+name: Automation / Labels
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+  issues:
+    types: [opened]
+
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/automation-labels.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  meta:
+    name: "Meta"
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      areas: ${{ steps.files_changed.outputs.changed_keys || '[]' }}
+      change_type: ${{ steps.change_type.outputs.change_type }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Determine Change Type
+        id: change_type
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: "${{ github.event.pull_request.title }}"
+        run: |
+          # Extract conventional commit type from PR title
+          CHANGE_TYPE=""
+          if [[ "${PR_TITLE}" =~ ^(feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert|deps)(\(.+\))?!?:.*$ ]]; then
+            CHANGE_TYPE="${BASH_REMATCH[1]}"
+          fi
+          echo "change_type=${CHANGE_TYPE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Determine Areas
+        id: files_changed
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: tj-actions/changed-files@v47
+        with:
+          json: true
+          escape_json: false
+          files_yaml: |
+            web:
+              - "apps/web/**"
+            db:
+              - "packages/db/**"
+            ai:
+              - "packages/ai/**"
+            config:
+              - "turbo.json"
+              - ".prettierrc"
+              - "*.config.{js,cjs,mjs,ts,cts,mts,json}"
+            documentation:
+              - "**/*.md"
+              - "**/README.*"
+            github_actions:
+              - ".github/workflows/**"
+              - ".github/labels.yml"
+
+  repo-labels:
+    name: "Repository Labels"
+    runs-on: ubuntu-latest
+    needs: [meta]
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Labels
+        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        if: contains(fromJson(needs.meta.outputs.areas || '[]'), 'github_actions')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-delete: true
+          yaml-file: .github/labels.yml
+
+  do-not-merge:
+    name: "Do Not Merge"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Check
+        env:
+          DO_NOT_MERGE: "${{ contains(github.event.pull_request.labels.*.name, 'status: do not merge') }}"
+        run: |
+          if [[ "${DO_NOT_MERGE}" == "true" ]]; then
+            echo "##[error]Cannot merge when 'status: do not merge' label is present."
+            exit 1
+          fi
+
+  sync-labels:
+    name: "Sync Labels"
+    needs: [meta]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'issues'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine and Apply Labels
+        env:
+          EXISTING_LABELS: "${{ toJson(github.event.issue.labels || github.event.pull_request.labels || '[]') }}"
+          DATA_AREAS: "${{ needs.meta.outputs.areas }}"
+          DATA_CHANGE: "${{ needs.meta.outputs.change_type }}"
+          PR_OR_ISSUE_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+          GH_SUBCOMMAND: ${{ github.event_name == 'pull_request' && 'pr' || 'issue' }}
+        run: |
+          set +e
+
+          # Area labels
+          for AREA in $(echo "${DATA_AREAS}" | jq -r '.[]' 2>/dev/null); do
+            LABEL_NAME="area: ${AREA//_/ }"
+            echo "Adding label: ${LABEL_NAME}"
+            gh $GH_SUBCOMMAND edit "$PR_OR_ISSUE_NUMBER" --add-label "$LABEL_NAME" 2>/dev/null || true
+          done
+
+          # Change type label
+          if [[ -n "${DATA_CHANGE}" ]]; then
+            LABEL_NAME="change: ${DATA_CHANGE}"
+            echo "Adding label: ${LABEL_NAME}"
+            gh $GH_SUBCOMMAND edit "$PR_OR_ISSUE_NUMBER" --add-label "$LABEL_NAME" 2>/dev/null || true
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -17,7 +17,7 @@ jobs:
       checks: write
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/pr-conventional-commits@1.4.2
+        uses: ytanikin/pr-conventional-commits@1.5.1
         with:
           task_types: '["feat","fix","perf","deps","revert","docs","style","chore","refactor","test","build","ci"]'
           add_label: "false"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration with smart grouping, cooldown periods, and conventional commit prefixes
- Add automated PR labeling based on changed files and conventional commit types
- Add repository label definitions for areas, change types, status, and priority
- Improve CI workflow with concurrency to cancel duplicate runs

## Why
Sets up GitHub automation to reduce manual toil: automatic dependency updates with grouped PRs, automatic labeling of PRs/issues by area and type, and faster CI by canceling redundant workflow runs.

## Test Plan
- [ ] Verify Dependabot creates grouped PRs on schedule
- [ ] Open a PR touching `apps/web/` and verify `area: web` label is added
- [ ] Open a PR with title `feat(chat): ...` and verify `change: feat` label is added
- [ ] Push two commits quickly and verify the first CI run is canceled