### PR TITLE
fix(ci): add bootstrap-sha to ignore old release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release v${version}",
+  "bootstrap-sha": "83a549268431040904cc3bb209bcf26bcfcd43db",
   "packages": {
     "apps/web": {
       "release-type": "node",


### PR DESCRIPTION
Adds bootstrap-sha to release-please config to ignore PR #42 which has the old title format and is causing release-please to abort with 'untagged merged release PRs outstanding'.