### PR TITLE
fix(ci): change release PR title pattern to avoid matching old PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore: release v${version}",
-  "bootstrap-sha": "83a549268431040904cc3bb209bcf26bcfcd43db",
+  "pull-request-title-pattern": "release: v${version}",
+  "last-release-sha": "83a549268431040904cc3bb209bcf26bcfcd43db",
   "packages": {
     "apps/web": {
       "release-type": "node",


### PR DESCRIPTION
Changes:
- Title pattern from `chore: release v${version}` to `release: v${version}`
- This prevents PR #42 ('chore: release main') from being matched
- Also uses `last-release-sha` instead of `bootstrap-sha`

PR #42 won't match because it starts with 'chore:' not 'release:'.