### PR TITLE
fix(ai): switch to official OpenRouter provider for AI SDK 5 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3242,6 +3242,31 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@openrouter/ai-sdk-provider": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-1.5.4.tgz",
+      "integrity": "sha512-xrSQPUIH8n9zuyYZR0XK7Ba0h2KsjJcMkxnwaYfmv13pKs3sDkjPzVPPhlhzqBGddHb5cFEwJ9VFuFeDcxCDSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openrouter/sdk": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ai": "^5.0.0",
+        "zod": "^3.24.1 || ^v4"
+      }
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.1.27.tgz",
+      "integrity": "sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -17611,6 +17636,7 @@
         "@langchain/community": "^1.1.3",
         "@langchain/core": "^1.1.12",
         "@langchain/textsplitters": "^1.0.0",
+        "@openrouter/ai-sdk-provider": "^1.5.4",
         "@types/pdf-parse": "^1.1.4",
         "ai": "^5.0.52",
         "js-tiktoken": "^1.0.12",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -10,16 +10,17 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.89",
-    "ai": "^5.0.52",
-    "langchain": "^1.2.10",
     "@langchain/community": "^1.1.3",
     "@langchain/core": "^1.1.12",
     "@langchain/textsplitters": "^1.0.0",
+    "@openrouter/ai-sdk-provider": "^1.5.4",
+    "@types/pdf-parse": "^1.1.4",
+    "ai": "^5.0.52",
+    "js-tiktoken": "^1.0.12",
+    "langchain": "^1.2.10",
     "mammoth": "^1.8.0",
     "nanoid": "^5.0.9",
-    "pdf-parse": "^1.1.1",
-    "js-tiktoken": "^1.0.12",
-    "@types/pdf-parse": "^1.1.4"
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/ai/src/openrouter-client.ts
+++ b/packages/ai/src/openrouter-client.ts
@@ -1,3 +1,4 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateText, embed, streamText } from "ai";
 
@@ -13,7 +14,7 @@ export type SupportedModel = (typeof SUPPORTED_MODELS)[number];
 
 // OpenRouter client configuration
 export class OpenRouterClient {
-  private client: ReturnType<typeof createOpenAI>;
+  private client: ReturnType<typeof createOpenRouter>;
   private openaiClient: ReturnType<typeof createOpenAI> | null = null;
 
   constructor(apiKey: string, openaiApiKey?: string) {
@@ -21,9 +22,10 @@ export class OpenRouterClient {
       throw new Error("OpenRouter API key is required");
     }
 
-    this.client = createOpenAI({
+    // Use official OpenRouter provider which defaults to 'compatible' mode
+    // This uses the chat completions API format instead of the responses API
+    this.client = createOpenRouter({
       apiKey,
-      baseURL: "https://openrouter.ai/api/v1",
     });
 
     // OpenRouter doesn't support embeddings, so use OpenAI directly if key is provided


### PR DESCRIPTION
## Summary
- Switches from `@ai-sdk/openai` with custom baseURL to the official `@openrouter/ai-sdk-provider`
- Fixes ZodError that occurred on multi-turn conversations after AI SDK 5.0 upgrade
- The official provider defaults to 'compatible' mode which uses chat completions API format

## Problem
AI SDK 5.0 removed the `compatibility` option and defaults to OpenAI's responses API format (`/api/v1/responses`), which OpenRouter doesn't fully support for conversation history. This caused a ZodError on the second message in any conversation.

## Test plan
- [x] Send first message to chatbot - should work
- [x] Send second message in same conversation - should now work without ZodError
- [x] Verify streaming responses work correctly