### PR TITLE
ci: add production deployment to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,8 @@ jobs:
     needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,11 +45,20 @@ jobs:
 
       - name: Setup Git User
         run: |
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "actions@github.com"
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
 
       - name: Merge main into production branch
         run: |
-          git checkout production || git checkout -b production
-          git merge --no-ff main -m "chore: deploy release ${{ needs.release-please.outputs.tag_name }} to production"
+          set -e
+          # Fetch remote production branch if it exists
+          git fetch origin production || true
+          # Checkout production: track remote if exists, else create from main
+          if git show-ref --verify --quiet refs/remotes/origin/production; then
+            git checkout --track origin/production || git checkout production
+          else
+            git checkout -b production main
+          fi
+          # Merge main with theirs strategy to handle any conflicts
+          git merge --no-ff -X theirs main -m "chore: deploy release ${{ needs.release-please.outputs.tag_name }} to production"
           git push origin production


### PR DESCRIPTION
## Summary
- Adds a `deploy-production` job to the release-please workflow
- Only runs when `release_created == 'true'` (i.e., when release-please PR is merged)
- Merges `main` into `production` branch, triggering Vercel prod deployment

## How it works
| Action | Deployment |
|--------|------------|
| Open PR | Preview deployment |
| Merge PR to main | Preview deployment |
| Merge release-please PR | Production deployment |

## Setup required
Configure Vercel Project Settings → Git:
- Set **Production Branch** to `production`