### PR TITLE
feat(email): add do-not-reply footer to all automated emails

### DIFF
--- a/apps/web/src/components/emails/AccountDeleted.tsx
+++ b/apps/web/src/components/emails/AccountDeleted.tsx
@@ -67,6 +67,15 @@ export function AccountDeleted({
                 <br />
                 Teach anything Team
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -122,4 +131,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/AccountDisabled.tsx
+++ b/apps/web/src/components/emails/AccountDisabled.tsx
@@ -59,7 +59,16 @@ export function AccountDisabled({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Support Team
+                Teach anything Team
+              </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
               </p>
             </td>
           </tr>
@@ -116,4 +125,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/AccountEnabled.tsx
+++ b/apps/web/src/components/emails/AccountEnabled.tsx
@@ -3,9 +3,14 @@ import * as React from "react";
 interface AccountEnabledProps {
   userName: string;
   loginUrl: string;
+  supportEmail: string;
 }
 
-export function AccountEnabled({ userName, loginUrl }: AccountEnabledProps) {
+export function AccountEnabled({
+  userName,
+  loginUrl,
+  supportEmail,
+}: AccountEnabledProps) {
   return (
     <html>
       {/* eslint-disable-next-line @next/next/no-head-element */}
@@ -55,6 +60,15 @@ export function AccountEnabled({ userName, loginUrl }: AccountEnabledProps) {
                 Best regards,
                 <br />
                 Teach anything Team
+              </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
               </p>
             </td>
           </tr>
@@ -111,4 +125,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/ApprovalConfirmation.tsx
+++ b/apps/web/src/components/emails/ApprovalConfirmation.tsx
@@ -3,11 +3,13 @@ import * as React from "react";
 interface ApprovalConfirmationProps {
   userName: string;
   loginUrl: string;
+  supportEmail: string;
 }
 
 export function ApprovalConfirmation({
   userName,
   loginUrl,
+  supportEmail,
 }: ApprovalConfirmationProps) {
   return (
     <html>
@@ -66,6 +68,15 @@ export function ApprovalConfirmation({
                 <br />
                 Teach anything Team
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -121,4 +132,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/DemoteFromAdmin.tsx
+++ b/apps/web/src/components/emails/DemoteFromAdmin.tsx
@@ -67,6 +67,15 @@ export function DemoteFromAdmin({
                 <br />
                 Teach anything Team
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -122,4 +131,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/PasswordReset.tsx
+++ b/apps/web/src/components/emails/PasswordReset.tsx
@@ -3,9 +3,10 @@ import * as React from "react";
 interface PasswordResetProps {
   userName: string;
   resetUrl: string;
+  supportEmail: string;
 }
 
-export function PasswordReset({ userName, resetUrl }: PasswordResetProps) {
+export function PasswordReset({ userName, resetUrl, supportEmail }: PasswordResetProps) {
   return (
     <html>
       {/* eslint-disable-next-line @next/next/no-head-element */}
@@ -67,6 +68,15 @@ export function PasswordReset({ userName, resetUrl }: PasswordResetProps) {
                 Best regards,
                 <br />
                 Teach anything Team
+              </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
               </p>
             </td>
           </tr>
@@ -144,4 +154,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/PromoteToAdmin.tsx
+++ b/apps/web/src/components/emails/PromoteToAdmin.tsx
@@ -3,9 +3,10 @@ import * as React from "react";
 interface PromoteToAdminProps {
   userName: string;
   loginUrl: string;
+  supportEmail: string;
 }
 
-export function PromoteToAdmin({ userName, loginUrl }: PromoteToAdminProps) {
+export function PromoteToAdmin({ userName, loginUrl, supportEmail }: PromoteToAdminProps) {
   return (
     <html>
       {/* eslint-disable-next-line @next/next/no-head-element */}
@@ -62,6 +63,15 @@ export function PromoteToAdmin({ userName, loginUrl }: PromoteToAdminProps) {
                 <br />
                 Teach anything Admin Team
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -117,4 +127,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/RejectionNotification.tsx
+++ b/apps/web/src/components/emails/RejectionNotification.tsx
@@ -59,6 +59,15 @@ export function RejectionNotification({
                 <br />
                 Teach anything Team
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -114,4 +123,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/components/emails/UserRegistrationNotification.tsx
+++ b/apps/web/src/components/emails/UserRegistrationNotification.tsx
@@ -5,6 +5,7 @@ interface UserRegistrationNotificationProps {
   userEmail: string;
   registrationDate: string;
   adminUrl: string;
+  supportEmail: string;
 }
 
 export function UserRegistrationNotification({
@@ -12,6 +13,7 @@ export function UserRegistrationNotification({
   userEmail,
   registrationDate,
   adminUrl,
+  supportEmail,
 }: UserRegistrationNotificationProps) {
   return (
     <html>
@@ -60,6 +62,15 @@ export function UserRegistrationNotification({
                 <br />
                 Teach anything
               </p>
+
+              <p style={footer}>
+                This is an automated message. Please do not reply to this email.
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+              </p>
             </td>
           </tr>
         </table>
@@ -107,4 +118,13 @@ const signature = {
   color: "#333333",
   fontSize: "16px",
   lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
 };

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -14,14 +14,11 @@ import { db } from "@teachanything/db";
 import { user } from "@teachanything/db/schema";
 import { eq } from "drizzle-orm";
 
-// Helper to get support email
-function getSupportEmail(): string {
-  if (env.NEXT_PUBLIC_CONTACT_EMAIL) {
-    return env.NEXT_PUBLIC_CONTACT_EMAIL;
-  }
-  const adminEmails = getAdminEmails();
-  return adminEmails[0] || "no admin email found";
-}
+// Support email - computed once at module load
+const supportEmail =
+  env.NEXT_PUBLIC_CONTACT_EMAIL ||
+  getAdminEmails()[0] ||
+  "no admin email found";
 
 const resend = new Resend(env.RESEND_API_KEY);
 
@@ -81,6 +78,7 @@ export async function sendAdminNotificationEmail(params: {
         userEmail: params.email,
         registrationDate: new Date().toLocaleString(),
         adminUrl,
+        supportEmail,
       }),
     });
 
@@ -115,7 +113,6 @@ export async function sendApprovalEmail(params: {
 }) {
   try {
     const loginUrl = `${env.NEXT_PUBLIC_APP_URL}/login`;
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -123,6 +120,7 @@ export async function sendApprovalEmail(params: {
       react: ApprovalConfirmation({
         userName: params.name,
         loginUrl,
+        supportEmail,
       }),
     });
 
@@ -152,8 +150,6 @@ export async function sendRejectionEmail(params: {
   name: string;
 }) {
   try {
-    const supportEmail = getSupportEmail();
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -191,7 +187,6 @@ export async function sendPromoteToAdminEmail(params: {
 }) {
   try {
     const loginUrl = `${env.NEXT_PUBLIC_APP_URL}/admin`;
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -199,6 +194,7 @@ export async function sendPromoteToAdminEmail(params: {
       react: PromoteToAdmin({
         userName: params.name,
         loginUrl,
+        supportEmail,
       }),
     });
 
@@ -228,9 +224,7 @@ export async function sendDemoteFromAdminEmail(params: {
   name: string;
 }) {
   try {
-    const supportEmail = getSupportEmail();
     const loginUrl = `${env.NEXT_PUBLIC_APP_URL}/login`;
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -268,8 +262,6 @@ export async function sendAccountDisabledEmail(params: {
   name: string;
 }) {
   try {
-    const supportEmail = getSupportEmail();
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -307,7 +299,6 @@ export async function sendAccountEnabledEmail(params: {
 }) {
   try {
     const loginUrl = `${env.NEXT_PUBLIC_APP_URL}/login`;
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -315,6 +306,7 @@ export async function sendAccountEnabledEmail(params: {
       react: AccountEnabled({
         userName: params.name,
         loginUrl,
+        supportEmail,
       }),
     });
 
@@ -344,8 +336,6 @@ export async function sendAccountDeletedEmail(params: {
   name: string;
 }) {
   try {
-    const supportEmail = getSupportEmail();
-
     const { data, error } = await resend.emails.send({
       from: `Teach anything. <${env.RESEND_FROM_EMAIL}>`,
       to: params.email,
@@ -390,6 +380,7 @@ export async function sendPasswordResetEmail(params: {
       react: PasswordReset({
         userName: params.name,
         resetUrl: params.resetUrl,
+        supportEmail,
       }),
     });
 


### PR DESCRIPTION
## Summary
- Add a "do not reply" footer to all 9 automated email templates
- Footer includes a link to the support email address for questions or assistance
- Refactor `email.ts` to compute `supportEmail` once at module load instead of per-function

## Changes
- **Email templates updated:**
  - AccountDeleted.tsx
  - AccountDisabled.tsx
  - AccountEnabled.tsx
  - ApprovalConfirmation.tsx
  - DemoteFromAdmin.tsx
  - PasswordReset.tsx
  - PromoteToAdmin.tsx
  - RejectionNotification.tsx
  - UserRegistrationNotification.tsx

- **email.ts:** Simplified by removing redundant `getSupportEmail()` function and computing `supportEmail` once at module load

## Test plan
- [ ] Trigger each email type and verify the footer appears correctly
- [ ] Verify the support email link is clickable and correct
- [ ] Verify existing email functionality is not affected