### PR TITLE
fix(settings): title dropdown persistence and component refactor

### DIFF
--- a/apps/web/src/components/dashboard/settings/InstitutionalSection.tsx
+++ b/apps/web/src/components/dashboard/settings/InstitutionalSection.tsx
@@ -104,9 +104,13 @@ function InstitutionalForm({
   saved: SavedValues;
 }) {
   const [form, setForm] = useState<FormValues>(initial);
+  const utils = trpc.useUtils();
 
   const updateProfile = trpc.auth.updateProfile.useMutation({
-    onSuccess: () => toast.success("Information updated"),
+    onSuccess: () => {
+      toast.success("Information updated");
+      utils.auth.getProfile.invalidate();
+    },
     onError: (error) =>
       toast.error("Failed to update", { description: error.message }),
   });


### PR DESCRIPTION
## Summary
- Fixed title dropdown resetting to "Select title" on page refresh
- Refactored InstitutionalSection with cleaner architecture (parent/child split)
- Replaced useEffect state sync with derived values pattern

## Why
The Radix Select component doesn't work correctly when its initial value is set via useEffect after async data loads. This caused the title dropdown to appear empty even when the user had previously saved a title.

## Changes
- Split `InstitutionalSection` into parent (data fetching) and child (form) components
- Parent waits for data, then passes initial values as props with a `key` to force remount
- Form state initialized directly from props instead of via useEffect
- `hasChanges` is now derived instead of computed in useEffect
- Added `parseTitleForForm` and `resolveTitleFromForm` helper functions
- Restored query invalidation on successful save

## Test Plan
1. Go to Settings > Institutional Information
2. Select a title (e.g., "Professor")
3. Fill in other fields and save
4. Refresh the page
5. Verify the title dropdown shows "Professor" (not "Select title")
6. Make a change and save - verify button disables after save