### PR TITLE
fix(layout): use h-dvh instead of h-screen for mobile viewport

### DIFF
--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -49,7 +49,7 @@ export default function AdminLayout({
 
   return (
     <SidebarProvider isOpen={isOpen} setIsOpen={setIsOpen}>
-      <div className="h-screen bg-background flex flex-col overflow-hidden">
+      <div className="h-dvh bg-background flex flex-col overflow-hidden">
         {/* Header - Full Width */}
         <DashboardHeader />
 

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -34,7 +34,7 @@ export default function DashboardLayout({
 
   return (
     <SidebarProvider isOpen={isOpen} setIsOpen={setIsOpen}>
-      <div className="h-screen bg-background flex flex-col overflow-hidden">
+      <div className="h-dvh bg-background flex flex-col overflow-hidden">
         {/* Header - Full Width */}
         <DashboardHeader />
 

--- a/apps/web/src/app/chatbot/layout.tsx
+++ b/apps/web/src/app/chatbot/layout.tsx
@@ -34,7 +34,7 @@ export default function ChatbotLayout({
 
   return (
     <SidebarProvider isOpen={isOpen} setIsOpen={setIsOpen}>
-      <div className="h-screen bg-background flex flex-col overflow-hidden">
+      <div className="h-dvh bg-background flex flex-col overflow-hidden">
         {/* Header - Full Width */}
         <DashboardHeader />
 

--- a/apps/web/src/components/ui/skeletons.tsx
+++ b/apps/web/src/components/ui/skeletons.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
  */
 export function DashboardShellSkeleton() {
   return (
-    <div className="h-screen bg-background flex flex-col overflow-hidden">
+    <div className="h-dvh bg-background flex flex-col overflow-hidden">
       <div className="h-14 border-b border-border bg-card px-4 flex items-center gap-4">
         <Skeleton className="h-8 w-32" />
         <div className="ml-auto flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Replace `h-screen` (100vh) with `h-dvh` (100dvh) in all dashboard layouts and the skeleton shell
- On mobile browsers, `100vh` includes the area behind the browser chrome (address bar), making the container taller than the visible viewport and clipping scroll content at the bottom
- `100dvh` uses the dynamic viewport height that adjusts with browser chrome visibility

## Files changed
- `apps/web/src/app/(dashboard)/layout.tsx`
- `apps/web/src/app/(admin)/layout.tsx`
- `apps/web/src/app/chatbot/layout.tsx`
- `apps/web/src/components/ui/skeletons.tsx`

## Test plan
- [x] Verify all dashboard pages scroll fully on mobile (iOS Safari, Chrome)
- [x] Verify bottom content is no longer clipped behind browser chrome
- [x] Verify desktop layout is unaffected