### PR TITLE
fix(privacy): update section 16 for self-service account deletion

### DIFF
--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1440,17 +1440,16 @@ export default function PrivacyPolicyPage() {
             from You?
           </h2>
           <p>
-            Based on the applicable laws of your country or state of residence
-            in the US, you may have the right to request access to the personal
-            information we collect from you, details about how we have processed
-            it, correct inaccuracies, or delete your personal information. You
-            may also have the right to withdraw your consent to our processing
-            of your personal information. These rights may be limited in some
+            You can delete your account from your dashboard. Further, based on
+            the applicable laws of your country or state of residence in the US,
+            you may have the right to request access to the personal information
+            we collect from you, details about how we have processed it, correct
+            inaccuracies, or delete your personal information. You may also have
+            the right to withdraw your consent to our processing of your
+            personal information. These rights may be limited in some
             circumstances by applicable law. You can export individual chat
             conversation histories as text or JSON files directly from the
-            chatbot interface. To request a full review, update, or deletion of
-            your personal information, please contact us at{" "}
-            <a href="mailto:admin@teachanything.ai">admin@teachanything.ai</a>.
+            chatbot interface.
           </p>
         </article>
       </main>

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1444,7 +1444,9 @@ export default function PrivacyPolicyPage() {
             the applicable laws of your country or state of residence in the US,
             you may have the right to request access to the personal information
             we collect from you, details about how we have processed it, correct
-            inaccuracies, or delete your personal information. You may also have
+            inaccuracies, or delete your personal information. To make such a
+            request, please use the contact details listed in{" "}
+            <a href="#section-15">Section 15</a>. You may also have
             the right to withdraw your consent to our processing of your
             personal information. These rights may be limited in some
             circumstances by applicable law. You can export individual chat

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1440,7 +1440,7 @@ export default function PrivacyPolicyPage() {
             from You?
           </h2>
           <p>
-            You can delete your account from your dashboard. Further, based on
+            You can delete your account from your dashboard settings. Further, based on
             the applicable laws of your country or state of residence in the US,
             you may have the right to request access to the personal information
             we collect from you, details about how we have processed it, correct

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1440,18 +1440,17 @@ export default function PrivacyPolicyPage() {
             from You?
           </h2>
           <p>
-            You can delete your account from your dashboard settings. Further, based on
-            the applicable laws of your country or state of residence in the US,
-            you may have the right to request access to the personal information
-            we collect from you, details about how we have processed it, correct
-            inaccuracies, or delete your personal information. To make such a
-            request, please use the contact details listed in{" "}
-            <a href="#section-15">Section 15</a>. You may also have
-            the right to withdraw your consent to our processing of your
-            personal information. These rights may be limited in some
-            circumstances by applicable law. You can export individual chat
-            conversation histories as text or JSON files directly from the
-            chatbot interface.
+            You can delete your account from your dashboard settings. Further,
+            based on the applicable laws of your country or state of residence
+            in the US, you may have the right to request access to the personal
+            information we collect from you, details about how we have processed
+            it, correct inaccuracies, or delete your personal information. To
+            make such a request, please use the contact details listed in{" "}
+            <a href="#section-15">Section 15</a>. You may also have the right to
+            withdraw your consent to our processing of your personal
+            information. These rights may be limited in some circumstances by
+            applicable law. You can export individual chat conversation
+            histories as text or JSON files directly from the chatbot interface.
           </p>
         </article>
       </main>


### PR DESCRIPTION
## Summary
- Updates privacy policy section 16 per Professor Joubin's feedback
- Adds "You can delete your account from your dashboard" as the opening sentence
- Removes the old "contact us at admin@teachanything.ai" closing, since users can now self-serve

## Test plan
- [x] Verify privacy policy page renders correctly at `/privacy-policy`
- [x] Confirm section 16 text matches the requested copy