### PR TITLE
fix(chat): surface stream errors and truncation via fullStream

### DIFF
--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -23,6 +23,7 @@ export default function SharedChatPage() {
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    isThinking,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -79,6 +80,7 @@ export default function SharedChatPage() {
           <ChatInterface
             messages={messages}
             isStreaming={isStreaming}
+            isThinking={isThinking}
             streamingContent={streamingContent}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -35,6 +35,7 @@ export default function ChatbotDetailPage() {
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    isThinking,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -171,6 +172,7 @@ export default function ChatbotDetailPage() {
               <ChatInterface
                 messages={messages}
                 isStreaming={isStreaming}
+                isThinking={isThinking}
                 streamingContent={streamingContent}
                 currentMessage={currentMessage}
                 setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/app/embed/[shareToken]/window/page.tsx
+++ b/apps/web/src/app/embed/[shareToken]/window/page.tsx
@@ -21,6 +21,7 @@ export default function EmbedWindowPage() {
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    isThinking,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -69,6 +70,7 @@ export default function EmbedWindowPage() {
           <ChatInterface
             messages={messages}
             isStreaming={isStreaming}
+            isThinking={isThinking}
             streamingContent={streamingContent}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 interface ChatInterfaceProps {
   messages: MessageType[];
   isStreaming: boolean;
+  isThinking?: boolean;
   streamingContent: string;
   currentMessage: string;
   setCurrentMessage: (message: string) => void;
@@ -33,6 +34,7 @@ interface ChatInterfaceProps {
 export function ChatInterface({
   messages,
   isStreaming,
+  isThinking = false,
   streamingContent,
   currentMessage,
   setCurrentMessage,
@@ -130,7 +132,12 @@ export function ChatInterface({
                     showSources={showSources}
                   />
                 ))}
-                {isStreaming && <StreamingMessage content={streamingContent} />}
+                {isStreaming && (
+                  <StreamingMessage
+                    content={streamingContent}
+                    isThinking={isThinking}
+                  />
+                )}
               </div>
             )}
             <ChatContainerScrollAnchor ref={messagesEndRef} />

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -183,6 +183,12 @@ export function StreamingMessage({
               >
                 {content}
               </MessageContent>
+              {isThinking && (
+                <div className="mt-1.5 md:mt-2 flex items-center gap-2 text-xs text-muted-foreground italic">
+                  <TypingLoader size="sm" className="opacity-60" />
+                  <span>Thinking…</span>
+                </div>
+              )}
             </div>
           </Message>
           <div className="pl-9 md:pl-12">

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -9,7 +9,7 @@ import {
 import { CopyButton } from "@/components/ui/copy-button";
 import { TypingLoader } from "@/components/ui/loader";
 import { Badge } from "@/components/ui/badge";
-import { FileText, StopCircle } from "lucide-react";
+import { FileText, StopCircle, AlertTriangle } from "lucide-react";
 import { useMemo } from "react";
 
 interface ChatMessageProps {
@@ -106,6 +106,16 @@ export function ChatMessage({
               <span>Cancelled</span>
             </div>
           )}
+          {/* Display truncated indicator */}
+          {message.truncated && (
+            <div className="mt-1.5 md:mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500 italic">
+              <AlertTriangle className="h-3 w-3" />
+              <span>
+                Response was cut off at the token limit. Try raising max tokens
+                or asking a shorter question.
+              </span>
+            </div>
+          )}
           {/* Display sources if available and enabled */}
           {showSources && uniqueSources.length > 0 && (
             <div className="mt-2 md:mt-3 flex flex-wrap gap-1.5 md:gap-2">
@@ -146,9 +156,13 @@ export function ChatMessage({
 
 interface StreamingMessageProps {
   content: string;
+  isThinking?: boolean;
 }
 
-export function StreamingMessage({ content }: StreamingMessageProps) {
+export function StreamingMessage({
+  content,
+  isThinking = false,
+}: StreamingMessageProps) {
   const hasContent = content && content.trim().length > 0;
 
   return (
@@ -191,7 +205,14 @@ export function StreamingMessage({ content }: StreamingMessageProps) {
             imageClassName="grayscale"
           />
           <div className="bg-secondary rounded-xl md:rounded-lg px-3 py-2 md:px-4 md:py-3 w-fit shadow-xs border border-border/50">
-            <TypingLoader size="md" className="opacity-60" />
+            {isThinking ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground italic">
+                <TypingLoader size="sm" className="opacity-60" />
+                <span>Thinking…</span>
+              </div>
+            ) : (
+              <TypingLoader size="md" className="opacity-60" />
+            )}
           </div>
         </div>
       )}

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -63,6 +63,7 @@ export function useChat(shareToken: string) {
     currentMessage: state.currentMessage,
     setCurrentMessage: state.setCurrentMessage,
     isStreaming: state.isStreaming,
+    isThinking: state.isThinking,
     streamingContent: state.streamingContent,
     messagesEndRef: state.messagesEndRef,
     chatbot,

--- a/apps/web/src/hooks/useChatState.ts
+++ b/apps/web/src/hooks/useChatState.ts
@@ -2,16 +2,17 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 import type { ChatMessage } from "@/types/database";
 
-type StreamData = {
-  type: string;
-  content?: string;
-  sessionId?: string;
-  sources?: Array<{
-    fileName: string;
-    chunkIndex: number;
-    similarity: number;
-  }>;
+type StreamSource = {
+  fileName: string;
+  chunkIndex: number;
+  similarity: number;
 };
+
+type StreamData =
+  | { type: "metadata"; sessionId?: string; sources?: StreamSource[] }
+  | { type: "text"; content: string }
+  | { type: "thinking" }
+  | { type: "done"; truncated?: boolean; responseTime?: number };
 
 /**
  * Shared hook for managing common chat state, auto-scrolling, and streaming orchestration.
@@ -26,7 +27,11 @@ export function useChatState() {
   const [sessionId, setSessionId] = useState<string>("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState("");
+  const [isThinking, setIsThinking] = useState(false);
   const streamingContentRef = useRef("");
+  // Set when the user cancels mid-stream. Gates handleStreamData so any
+  // chunks that arrive after cancellation don't resurrect the streaming UI.
+  const cancelledRef = useRef(false);
 
   const updateStreamingContent = (
     updater: string | ((prev: string) => string),
@@ -82,8 +87,10 @@ export function useChatState() {
     setCurrentMessage("");
     setSessionId("");
     setIsStreaming(false);
+    setIsThinking(false);
     setStreamingContent("");
     streamingContentRef.current = "";
+    cancelledRef.current = false;
     sourcesRef.current = [];
   };
 
@@ -93,8 +100,10 @@ export function useChatState() {
     const finalContent = streamingContentRef.current;
     const finalSources = [...sourcesRef.current];
 
+    cancelledRef.current = true;
     updateStreamingContent("");
     setIsStreaming(false);
+    setIsThinking(false);
     sourcesRef.current = [];
 
     setMessages((prev) => [
@@ -110,6 +119,10 @@ export function useChatState() {
 
   /** Shared onData handler for tRPC streaming subscriptions. */
   const handleStreamData = (data: StreamData) => {
+    // Drop any events that arrive after the user cancelled -- stopStreaming
+    // already committed the partial message, we don't want duplicates.
+    if (cancelledRef.current) return;
+
     if (data.type === "metadata") {
       if (data.sources) {
         sourcesRef.current = data.sources;
@@ -118,9 +131,17 @@ export function useChatState() {
         setSessionId(data.sessionId);
       }
     } else if (data.type === "text") {
-      updateStreamingContent((prev) => prev + (data.content || ""));
+      // First text chunk ends the thinking phase. React bails on identical
+      // state so we call unconditionally to avoid a stale-closure trap.
+      setIsThinking(false);
+      updateStreamingContent((prev) => prev + data.content);
+    } else if (data.type === "thinking") {
+      // Model is in a reasoning phase. Flip the indicator so the UI doesn't
+      // look frozen during long pauses.
+      setIsThinking(true);
     } else if (data.type === "done") {
       clearStreamingTimeout();
+      setIsThinking(false);
 
       // Guard: if streaming was already stopped (e.g., user cancelled), skip.
       // Uses ref (not state) to avoid stale closure issues in subscription callbacks.
@@ -138,6 +159,7 @@ export function useChatState() {
           role: "assistant",
           content: finalContent,
           sources: finalSources.length > 0 ? finalSources : undefined,
+          truncated: data.truncated || undefined,
         },
       ]);
 
@@ -150,15 +172,36 @@ export function useChatState() {
     clearStreamingTimeout();
     toast.error("Failed to send message. Please try again.");
     setIsStreaming(false);
+    setIsThinking(false);
+
+    // Preserve any partial content already received so the user can see what
+    // the model produced before the stream failed. Prior behavior dropped it.
+    const partialContent = streamingContentRef.current;
+    const finalSources = [...sourcesRef.current];
     updateStreamingContent("");
     sourcesRef.current = [];
+    cancelledRef.current = false;
+
+    if (partialContent) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: partialContent,
+          sources: finalSources.length > 0 ? finalSources : undefined,
+          cancelled: true,
+        },
+      ]);
+    }
   };
 
   /** Start streaming a message. Call from the hook's sendMessage handler. */
   const startStreaming = () => {
     setIsStreaming(true);
+    setIsThinking(false);
     updateStreamingContent("");
     sourcesRef.current = [];
+    cancelledRef.current = false;
     clearStreamingTimeout();
     timeoutRef.current = setTimeout(() => {
       stopStreaming();
@@ -183,6 +226,7 @@ export function useChatState() {
     setCurrentMessage,
     sessionId,
     isStreaming,
+    isThinking,
     streamingContent,
     messagesEndRef,
     // Streaming orchestration

--- a/apps/web/src/hooks/useChatbot.ts
+++ b/apps/web/src/hooks/useChatbot.ts
@@ -60,6 +60,7 @@ export function useChatbot(
     currentMessage: state.currentMessage,
     setCurrentMessage: state.setCurrentMessage,
     isStreaming: state.isStreaming,
+    isThinking: state.isThinking,
     streamingContent: state.streamingContent,
     messagesEndRef: state.messagesEndRef,
     chatbot,

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -1,4 +1,5 @@
 import { router, publicProcedure, protectedProcedure } from "../trpc";
+import type { FinishReason } from "ai";
 import { z } from "zod";
 import {
   chatbots,
@@ -218,6 +219,7 @@ async function* processMessage(params: {
   // Stream response using the same client
   const startTime = Date.now();
   let fullResponse = "";
+  let finishReason: FinishReason | undefined;
 
   const result = await aiClient.streamText({
     model: modelId,
@@ -230,16 +232,56 @@ async function* processMessage(params: {
     maxTokens: maxOutputTokens,
   });
 
-  // Stream the text
-  for await (const chunk of result.textStream) {
-    fullResponse += chunk;
-    yield {
-      type: "text" as const,
-      content: chunk,
-    };
+  // Consume fullStream so we get typed events: text deltas, reasoning deltas,
+  // errors, aborts, and finish reasons. textStream swallows all non-text parts,
+  // which means mid-stream errors look identical to a clean finish on the wire.
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case "text-delta": {
+        fullResponse += part.text;
+        yield {
+          type: "text" as const,
+          content: part.text,
+        };
+        break;
+      }
+      case "reasoning-delta": {
+        // Surface reasoning as a thinking indicator so the UI doesn't look
+        // frozen during long pauses. The reasoning text itself is never sent
+        // to the client -- on public shared chatbots it can restate system
+        // prompts or RAG context.
+        yield { type: "thinking" as const };
+        break;
+      }
+      case "finish": {
+        finishReason = part.finishReason;
+        break;
+      }
+      case "error": {
+        throw new Error(`Stream error: ${String(part.error)}`, {
+          cause: part.error,
+        });
+      }
+      case "abort": {
+        throw new Error("Stream aborted by provider");
+      }
+      default:
+        // Other event types (text-start, text-end, reasoning-start, start,
+        // finish-step, etc.) don't affect what we send to the client.
+        break;
+    }
   }
 
   const responseTime = Date.now() - startTime;
+  const truncated = finishReason === "length";
+
+  if (truncated) {
+    logWarn("Response truncated at maxTokens limit", {
+      chatbotId: chatbot.id,
+      modelId,
+      maxOutputTokens,
+    });
+  }
 
   // Save assistant response
   await database.insert(messages).values({
@@ -272,10 +314,12 @@ async function* processMessage(params: {
     eventType,
   });
 
-  // Send done signal
+  // Send done signal. `truncated` surfaces whether the model hit its output
+  // token limit so the UI can render a warning badge on the message.
   yield {
     type: "done" as const,
     responseTime,
+    truncated,
   };
 }
 

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -235,22 +235,35 @@ async function* processMessage(params: {
   // Consume fullStream so we get typed events: text deltas, reasoning deltas,
   // errors, aborts, and finish reasons. textStream swallows all non-text parts,
   // which means mid-stream errors look identical to a clean finish on the wire.
+  //
+  // Emit at most one `thinking` event per reasoning phase: reasoning-delta
+  // fires for every token and would spam the subscription otherwise.
+  let thinkingEmitted = false;
   for await (const part of result.fullStream) {
     switch (part.type) {
       case "text-delta": {
         fullResponse += part.text;
+        thinkingEmitted = false;
         yield {
           type: "text" as const,
           content: part.text,
         };
         break;
       }
+      case "reasoning-start":
       case "reasoning-delta": {
         // Surface reasoning as a thinking indicator so the UI doesn't look
         // frozen during long pauses. The reasoning text itself is never sent
         // to the client -- on public shared chatbots it can restate system
         // prompts or RAG context.
-        yield { type: "thinking" as const };
+        if (!thinkingEmitted) {
+          yield { type: "thinking" as const };
+          thinkingEmitted = true;
+        }
+        break;
+      }
+      case "reasoning-end": {
+        thinkingEmitted = false;
         break;
       }
       case "finish": {
@@ -266,8 +279,8 @@ async function* processMessage(params: {
         throw new Error("Stream aborted by provider");
       }
       default:
-        // Other event types (text-start, text-end, reasoning-start, start,
-        // finish-step, etc.) don't affect what we send to the client.
+        // Other event types (text-start, text-end, start, finish-step, etc.)
+        // don't affect what we send to the client.
         break;
     }
   }

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -111,6 +111,14 @@ async function* processMessage(params: {
     });
   }
 
+  // Yield the sessionId immediately so the client knows the subscription is
+  // live before we start the expensive RAG embedding + history fetch. Sources
+  // are sent as a second metadata event once RAG completes.
+  yield {
+    type: "metadata" as const,
+    sessionId,
+  };
+
   // Resolve model and get context window for budget allocation
   const modelId = resolveModel(chatbot.model);
   const { contextWindow } = MODEL_REGISTRY[modelId];
@@ -130,32 +138,33 @@ async function* processMessage(params: {
     userMessageTokens,
   });
 
-  // Fetch history (up to 50, trimmed to budget below)
-  const historyMessages = await database
-    .select()
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.id))
-    .orderBy(desc(messages.createdAt))
-    .limit(50);
-
-  historyMessages.reverse();
-
-  // Build RAG context with budget-derived chunk limit
   // Create AI client once and reuse for both RAG embedding and LLM streaming
   const aiClient = createOpenRouterClient(
     env.OPENROUTER_API_KEY,
     env.OPENAI_API_KEY,
   );
 
-  const ragResult = await buildRAGContext({
-    chatbotId: chatbot.id,
-    message,
-    db: database,
-    openrouterApiKey: env.OPENROUTER_API_KEY,
-    openaiApiKey: env.OPENAI_API_KEY,
-    chunkLimit: estimatedChunkLimit,
-    aiClient,
-  });
+  // History fetch and RAG context build are independent -- run in parallel so
+  // we're bounded by the slower of the two (usually RAG) instead of their sum.
+  const [historyMessages, ragResult] = await Promise.all([
+    database
+      .select()
+      .from(messages)
+      .where(eq(messages.conversationId, conversation.id))
+      .orderBy(desc(messages.createdAt))
+      .limit(50),
+    buildRAGContext({
+      chatbotId: chatbot.id,
+      message,
+      db: database,
+      openrouterApiKey: env.OPENROUTER_API_KEY,
+      openaiApiKey: env.OPENAI_API_KEY,
+      chunkLimit: estimatedChunkLimit,
+      aiClient,
+    }),
+  ]);
+
+  historyMessages.reverse();
 
   // Pass 2: allocate budget with actual token counts
   const fileManifestTokens = countTokens(ragResult.fileManifest);
@@ -188,10 +197,10 @@ async function* processMessage(params: {
     logWarn(warning, { chatbotId: chatbot.id, modelId });
   }
 
-  // Send metadata
+  // Send RAG sources now that they're available. The client handles metadata
+  // events idempotently (updates only fields that are present).
   yield {
     type: "metadata" as const,
-    sessionId,
     sources: ragResult.sources,
   };
 
@@ -208,13 +217,26 @@ async function* processMessage(params: {
     ragResult.fileManifest +
     ragResult.contextText;
 
-  // Save user message
-  await database.insert(messages).values({
-    conversationId: conversation.id,
-    role: "user",
-    content: message,
-    metadata: {},
-  });
+  // Kick off the user-message insert alongside the streamText handshake
+  // instead of blocking on it first. We await it before saving the assistant
+  // reply so ordering stays correct if either fails.
+  // The .catch keeps an unhandled rejection from surfacing if the stream
+  // throws before we await; the real error is still logged here.
+  const userMessageInsert = database
+    .insert(messages)
+    .values({
+      conversationId: conversation.id,
+      role: "user",
+      content: message,
+      metadata: {},
+    })
+    .catch((err) => {
+      logError(err, "Failed to insert user message", {
+        chatbotId: chatbot.id,
+        sessionId,
+      });
+      throw err;
+    });
 
   // Stream response using the same client
   const startTime = Date.now();
@@ -301,6 +323,10 @@ async function* processMessage(params: {
       maxOutputTokens,
     });
   }
+
+  // Wait for the user message insert (fired in parallel with streamText) so
+  // subsequent turns see the full conversation and the ordering is correct.
+  await userMessageInsert;
 
   // Save assistant response
   await database.insert(messages).values({

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -262,11 +262,17 @@ async function* processMessage(params: {
         }
         break;
       }
-      case "reasoning-end": {
+      case "reasoning-end":
+      case "text-start":
+      case "text-end":
+      case "finish-step": {
+        // Any phase boundary closes the current reasoning phase so the next
+        // reasoning-start/delta will re-emit the indicator.
         thinkingEmitted = false;
         break;
       }
       case "finish": {
+        thinkingEmitted = false;
         finishReason = part.finishReason;
         break;
       }
@@ -279,8 +285,8 @@ async function* processMessage(params: {
         throw new Error("Stream aborted by provider");
       }
       default:
-        // Other event types (text-start, text-end, start, finish-step, etc.)
-        // don't affect what we send to the client.
+        // Other event types (start, etc.) don't affect what we send to the
+        // client.
         break;
     }
   }

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -1,4 +1,5 @@
 import { initTRPC, TRPCError } from "@trpc/server";
+import { ZodError } from "zod";
 import { auth } from "@/lib/auth";
 import { db } from "@teachanything/db";
 import { logError, logWarn } from "@/lib/logger";
@@ -25,11 +26,16 @@ export type Context = Awaited<ReturnType<typeof createTRPCContext>>;
 const t = initTRPC.context<Context>().create({
   transformer: superjson,
   errorFormatter({ shape, error }) {
+    // Only surface Zod validation errors to the client. Spreading any
+    // `cause.message` leaks provider/internal error details (upstream URLs,
+    // API key fragments, raw response bodies) for every router, not just
+    // validation failures.
     return {
       ...shape,
       data: {
         ...shape.data,
-        zodError: error.cause instanceof Error ? error.cause.message : null,
+        zodError:
+          error.cause instanceof ZodError ? error.cause.flatten() : null,
       },
     };
   },

--- a/apps/web/src/types/database.ts
+++ b/apps/web/src/types/database.ts
@@ -51,6 +51,7 @@ export interface ChatMessage {
     similarity: number;
   }>;
   cancelled?: boolean;
+  truncated?: boolean;
 }
 
 // Message source type


### PR DESCRIPTION
## Summary
- Switch chat streaming from `textStream` to `fullStream` so mid-stream errors, aborts, and finish reasons propagate instead of looking like clean finishes (mirrors tambo's pattern)
- Add a "Thinking…" indicator for reasoning-model pauses; server never forwards reasoning content (would leak system prompt / RAG context on public shared chatbots)
- Show an inline "response was cut off at the token limit" badge when the model hits `maxTokens`
- Preserve partial content on mid-stream errors instead of dropping it
- Tighten tRPC `errorFormatter` to only surface Zod validation errors, not arbitrary `cause.message` strings

## Why
Laiba reported responses cutting off mid-sentence ("Paris is the" then blank) with no indication of why. Root cause: `textStream` flattens all non-text SDK events, so upstream `error` / `abort` parts and length-limit finishes all ended the loop identically to a clean completion. The client committed the partial text as if done, no toast, no retry.

During review we also found the tRPC `errorFormatter` was spreading any `error.cause.message` into the client payload under a misnamed `zodError` field. This leaked provider error details (upstream URLs, API key fragments, raw response bodies) across every router, not just validation failures. Fixed while we were in there.

## Review findings addressed
- **P1 security**: dropped reasoning content from the wire (public shared chatbots could expose system prompts via chain-of-thought)
- **P1 race**: removed stale-closure guard on `isThinking`; `setIsThinking(false)` now unconditional on text deltas
- **P2**: removed duplicate toast + inline badge (kept inline only); added `cancelledRef` to drop chunks that arrive after user cancel; typed `finishReason` with AI SDK's `FinishReason`; wrapped `part.error` in a real `Error` with `cause`
- **P3**: folded `truncated` into the `done` event (removed separate event type and `truncatedRef` bookkeeping); `StreamData` is now a discriminated union; tRPC `errorFormatter` hardened

## Test Plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm run test` (288 passing)
- [ ] Manual: send a chat message with a reasoning-capable model — verify "Thinking…" shows during pauses
- [ ] Manual: set chatbot `maxTokens` to 100, ask a long-answer question — verify amber truncated badge
- [ ] Manual: cancel a stream mid-flight — verify partial message saved, no ghost chunks resurrect it
- [ ] Manual: provoke a mid-stream error (break network) — verify error toast + partial content preserved