### PR TITLE
feat(web-sources): improve source management UX

### DIFF
--- a/apps/web/src/__tests__/components/web-sources-utils.test.ts
+++ b/apps/web/src/__tests__/components/web-sources-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getFriendlyError,
+  hasActiveCrawl,
+  normalizeUrl,
+  parsePatternList,
+} from "@/components/chatbot/web-sources/utils";
+
+describe("web source UI utilities", () => {
+  describe("normalizeUrl", () => {
+    it("adds https:// when a protocol is missing", () => {
+      expect(normalizeUrl("example.edu/course")).toBe(
+        "https://example.edu/course",
+      );
+    });
+
+    it("keeps existing http and https protocols", () => {
+      expect(normalizeUrl("http://example.edu")).toBe("http://example.edu");
+      expect(normalizeUrl("https://example.edu")).toBe("https://example.edu");
+    });
+
+    it("trims whitespace before normalizing", () => {
+      expect(normalizeUrl("  example.edu  ")).toBe("https://example.edu");
+    });
+  });
+
+  describe("parsePatternList", () => {
+    it("splits comma-separated patterns and removes empty entries", () => {
+      expect(parsePatternList("/lectures/*, /syllabus, , /readings")).toEqual([
+        "/lectures/*",
+        "/syllabus",
+        "/readings",
+      ]);
+    });
+
+    it("returns an empty array for blank input", () => {
+      expect(parsePatternList("   ")).toEqual([]);
+    });
+  });
+
+  describe("hasActiveCrawl", () => {
+    it("returns true for pending, discovering, or crawling sources", () => {
+      expect(
+        hasActiveCrawl([{ status: "completed" }, { status: "pending" }]),
+      ).toBe(true);
+      expect(hasActiveCrawl([{ status: "discovering" }])).toBe(true);
+      expect(hasActiveCrawl([{ status: "crawling" }])).toBe(true);
+    });
+
+    it("returns false when all sources are inactive", () => {
+      expect(
+        hasActiveCrawl([{ status: "completed" }, { status: "failed" }]),
+      ).toBe(false);
+    });
+  });
+
+  describe("getFriendlyError", () => {
+    it("maps Zod maxPages bounds errors to readable copy", () => {
+      const error = {
+        message: JSON.stringify([
+          {
+            code: "too_big",
+            path: ["maxPages"],
+            maximum: 500,
+          },
+        ]),
+      };
+      expect(getFriendlyError(error)).toBe("Max pages cannot exceed 500");
+    });
+
+    it("maps URL validation errors to readable copy", () => {
+      const error = {
+        message: JSON.stringify([
+          {
+            code: "invalid_format",
+            path: ["rootUrl"],
+            message: "Invalid URL",
+          },
+        ]),
+      };
+      expect(getFriendlyError(error)).toBe("Please enter a valid URL");
+    });
+
+    it("returns plain error messages unchanged", () => {
+      expect(
+        getFriendlyError({ message: "A crawl is already in progress" }),
+      ).toBe("A crawl is already in progress");
+    });
+  });
+});

--- a/apps/web/src/__tests__/lib/crawler-metadata.test.ts
+++ b/apps/web/src/__tests__/lib/crawler-metadata.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getPageDisplayTitle,
+  getSourceDisplayName,
+  getSourceErrorCount,
+  getSourcePageCount,
+} from "@/lib/crawler-metadata";
+
+describe("crawler metadata helpers", () => {
+  describe("getSourceDisplayName", () => {
+    it("uses the trimmed custom source display name", () => {
+      expect(
+        getSourceDisplayName({
+          rootUrl: "https://example.edu",
+          metadata: { displayName: "  Course Site  " },
+        }),
+      ).toBe("Course Site");
+    });
+
+    it("falls back to the root URL when no display name exists", () => {
+      expect(
+        getSourceDisplayName({
+          rootUrl: "https://example.edu",
+          metadata: {},
+        }),
+      ).toBe("https://example.edu");
+    });
+  });
+
+  describe("getSourcePageCount", () => {
+    it("returns the stored page count", () => {
+      expect(getSourcePageCount({ metadata: { pageCount: 12 } })).toBe(12);
+    });
+
+    it("falls back to zero when page count is missing", () => {
+      expect(getSourcePageCount({ metadata: {} })).toBe(0);
+    });
+  });
+
+  describe("getSourceErrorCount", () => {
+    it("returns the stored error count", () => {
+      expect(getSourceErrorCount({ metadata: { errorCount: 3 } })).toBe(3);
+    });
+
+    it("falls back to zero when error count is missing", () => {
+      expect(getSourceErrorCount({ metadata: null })).toBe(0);
+    });
+  });
+
+  describe("getPageDisplayTitle", () => {
+    it("prefers the trimmed custom title over the crawled title", () => {
+      expect(
+        getPageDisplayTitle({
+          title: "Original HTML Title",
+          url: "https://example.edu/plays/winters-tale",
+          metadata: { customTitle: "  Winter's Tale Folger full text  " },
+        }),
+      ).toBe("Winter's Tale Folger full text");
+    });
+
+    it("falls back to the crawled title when no custom title exists", () => {
+      expect(
+        getPageDisplayTitle({
+          title: "Original HTML Title",
+          url: "https://example.edu/plays/winters-tale",
+          metadata: {},
+        }),
+      ).toBe("Original HTML Title");
+    });
+
+    it("falls back to the URL when no title exists", () => {
+      expect(
+        getPageDisplayTitle({
+          title: null,
+          url: "https://example.edu/plays/winters-tale",
+          metadata: {},
+        }),
+      ).toBe("https://example.edu/plays/winters-tale");
+    });
+  });
+});

--- a/apps/web/src/__tests__/server/crawler-validation.test.ts
+++ b/apps/web/src/__tests__/server/crawler-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  allCrawlSourcesInput,
+  renameCrawledPageInput,
+  renameCrawlSourceInput,
+} from "@/server/routers/crawler/validation";
+
+describe("crawler validation schemas", () => {
+  describe("renameCrawlSourceInput", () => {
+    it("accepts and trims valid source names", () => {
+      const result = renameCrawlSourceInput.parse({
+        crawlSourceId: "00000000-0000-4000-8000-000000000001",
+        name: "  Winter's Tale Folger  ",
+      });
+      expect(result.name).toBe("Winter's Tale Folger");
+    });
+
+    it("rejects empty source names", () => {
+      expect(() =>
+        renameCrawlSourceInput.parse({
+          crawlSourceId: "00000000-0000-4000-8000-000000000001",
+          name: "   ",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("renameCrawledPageInput", () => {
+    it("accepts and trims valid page titles", () => {
+      const result = renameCrawledPageInput.parse({
+        crawledPageId: "00000000-0000-4000-8000-000000000002",
+        title: "  Winter's Tale full text  ",
+      });
+      expect(result.title).toBe("Winter's Tale full text");
+    });
+
+    it("rejects empty page titles", () => {
+      expect(() =>
+        renameCrawledPageInput.parse({
+          crawledPageId: "00000000-0000-4000-8000-000000000002",
+          title: "   ",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("allCrawlSourcesInput", () => {
+    it("defaults pagination parameters", () => {
+      expect(allCrawlSourcesInput.parse({})).toEqual({
+        limit: 20,
+        offset: 0,
+      });
+    });
+
+    it("accepts valid pagination parameters", () => {
+      expect(allCrawlSourcesInput.parse({ limit: 50, offset: 100 })).toEqual({
+        limit: 50,
+        offset: 100,
+      });
+    });
+
+    it("rejects limits above the endpoint cap", () => {
+      expect(() =>
+        allCrawlSourcesInput.parse({ limit: 101, offset: 0 }),
+      ).toThrow();
+    });
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PaginationControls } from "@/components/dashboard/files/PaginationControls";
+import { Bot, ExternalLink, Globe, Plus } from "lucide-react";
+import { keepPreviousData } from "@tanstack/react-query";
+import { useState } from "react";
+import { getSourceDisplayName } from "@/lib/crawler-metadata";
+
+const ITEMS_PER_PAGE = 20;
+
+function getStatusVariant(status: string, enabled: boolean) {
+  if (!enabled) return "secondary" as const;
+  if (status === "failed") return "destructive" as const;
+  return "outline" as const;
+}
+
+export default function WebSourcesPage() {
+  const [page, setPage] = useState(0);
+  const offset = page * ITEMS_PER_PAGE;
+  const { data, isLoading, isFetching } =
+    trpc.crawler.getAllCrawlSources.useQuery(
+      { limit: ITEMS_PER_PAGE, offset },
+      { placeholderData: keepPreviousData },
+    );
+  const { data: chatbotsData, isLoading: chatbotsLoading } =
+    trpc.chatbot.list.useQuery({ limit: 1, offset: 0 });
+
+  const sources = data?.sources ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+  const chatbotCount = chatbotsData?.totalCount ?? 0;
+  const hasSources = sources.length > 0;
+
+  return (
+    <div className="flex-1 p-4 md:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-4xl font-bold text-foreground tracking-tight">
+              Web Sources
+            </h1>
+            <p className="text-muted-foreground mt-2 text-lg">
+              Find websites and single webpages you have added to your chatbots.
+              {data && (
+                <span className="ml-2 font-medium text-foreground">
+                  ({totalCount} {totalCount === 1 ? "source" : "sources"})
+                </span>
+              )}
+            </p>
+          </div>
+          <Button asChild size="lg">
+            <Link href="/dashboard/chatbots">
+              <Plus className="h-4 w-4 mr-2" />
+              Add From a Chatbot
+            </Link>
+          </Button>
+        </div>
+
+        {isLoading || chatbotsLoading ? (
+          <div className="grid gap-4">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={index}
+                className="rounded-lg border border-border/60 p-5 space-y-3"
+              >
+                <Skeleton className="h-5 w-1/2" />
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-8 w-40" />
+              </div>
+            ))}
+          </div>
+        ) : !hasSources ? (
+          <div className="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+            <Globe className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p className="text-lg font-medium text-foreground">
+              No web sources yet
+            </p>
+            <p className="text-sm mt-1 max-w-xl mx-auto">
+              Web sources live inside chatbots. Open a chatbot, choose Web
+              Sources, then add a full website or a single webpage.
+            </p>
+            <Button asChild className="mt-5">
+              <Link href="/dashboard/chatbots">
+                {chatbotCount ? "Open Chatbots" : "Create a Chatbot"}
+              </Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {isFetching && (
+              <p className="text-sm text-muted-foreground">
+                Updating sources...
+              </p>
+            )}
+            <div className="grid gap-4">
+              {sources.map((source) => (
+                <Card
+                  key={source.id}
+                  className="border border-border/60 bg-card shadow-xs"
+                >
+                  <CardContent className="p-5">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0 space-y-2">
+                        <div className="flex min-w-0 items-center gap-3">
+                          <div className="h-10 w-10 rounded-lg bg-primary/10 flex shrink-0 items-center justify-center">
+                            <Globe className="h-5 w-5 text-primary" />
+                          </div>
+                          <div className="min-w-0">
+                            <h2 className="truncate text-lg font-semibold">
+                              {getSourceDisplayName(source)}
+                            </h2>
+                            <a
+                              href={source.rootUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <span className="truncate">{source.rootUrl}</span>
+                              <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                            </a>
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 pl-0 sm:pl-[52px]">
+                          <Badge
+                            variant={getStatusVariant(
+                              source.status,
+                              source.enabled,
+                            )}
+                          >
+                            {source.enabled ? source.status : "disabled"}
+                          </Badge>
+                          <Badge variant="secondary">
+                            {source.pageCount}{" "}
+                            {source.pageCount === 1 ? "page" : "pages"}
+                          </Badge>
+                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                            <Bot className="h-3.5 w-3.5" />
+                            {source.chatbotName}
+                          </span>
+                          {source.lastCrawledAt && (
+                            <span className="text-xs text-muted-foreground">
+                              Last crawled{" "}
+                              {new Date(
+                                source.lastCrawledAt,
+                              ).toLocaleDateString()}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <Button asChild variant="outline" className="shrink-0">
+                        <Link
+                          href={`/chatbot/${source.chatbotId}?tab=web-sources`}
+                        >
+                          Manage Source
+                        </Link>
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+            {totalPages > 1 && (
+              <PaginationControls
+                currentPage={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -198,7 +198,7 @@ export default function ChatbotDetailPage() {
             <TabsTrigger value="chat">Chat</TabsTrigger>
             <TabsTrigger value="files">Files</TabsTrigger>
             <TabsTrigger value="web-sources">Web Sources</TabsTrigger>
-            <TabsTrigger value="conversations">Conversations</TabsTrigger>
+            <TabsTrigger value="conversations">Student Chats</TabsTrigger>
             <TabsTrigger value="settings">Settings</TabsTrigger>
             {chatbot.sharingEnabled && chatbot.shareToken && (
               <TabsTrigger value="embed">Embed</TabsTrigger>

--- a/apps/web/src/components/chatbot/ConversationsTab.tsx
+++ b/apps/web/src/components/chatbot/ConversationsTab.tsx
@@ -116,10 +116,10 @@ export function ConversationsTab({ chatbotId }: ConversationsTabProps) {
         <div>
           <CardTitle className="flex items-center gap-2">
             <MessageSquare className="h-5 w-5" />
-            Conversations
+            Student Chats
           </CardTitle>
           <CardDescription className="mt-1.5">
-            Browse student conversations with your chatbot.
+            Browse your students&apos; chat history with this chatbot.
           </CardDescription>
         </div>
       </CardHeader>
@@ -128,7 +128,7 @@ export function ConversationsTab({ chatbotId }: ConversationsTabProps) {
           <div className="flex-1 relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="Search conversations..."
+              placeholder="Search student chats..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-9"
@@ -228,7 +228,7 @@ function ConversationsResults({
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center text-center">
         <MessageSquare className="h-12 w-12 mb-4 text-red-500 opacity-50" />
         <p className="text-lg font-medium text-red-600">
-          Failed to load conversations
+          Failed to load student chats
         </p>
         <p className="text-sm text-muted-foreground mt-1">
           Please try again in a moment.
@@ -250,10 +250,9 @@ function ConversationsResults({
     return (
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center text-center text-muted-foreground">
         <MessageSquare className="h-12 w-12 mb-4 opacity-50" />
-        <p className="text-lg font-medium">No conversations yet</p>
+        <p className="text-lg font-medium">No student chats yet</p>
         <p className="text-sm mt-1">
-          Conversations will appear here when students start chatting with your
-          bot.
+          Student chats will appear here when students start using this chatbot.
         </p>
       </div>
     );
@@ -386,7 +385,7 @@ function ConversationDetail({
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
-            <CardTitle className="text-lg">Conversation</CardTitle>
+            <CardTitle className="text-lg">Student Chat</CardTitle>
             {data?.conversation && (
               <CardDescription>
                 Started {formatTimestamp(data.conversation.createdAt)} ·

--- a/apps/web/src/components/chatbot/WebSourcesTab.tsx
+++ b/apps/web/src/components/chatbot/WebSourcesTab.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { Globe } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
 import {
   Card,
   CardContent,
@@ -8,185 +11,22 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { CrawlSourceCard } from "./web-sources/CrawlSourceCard";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  AddFullWebSourceDialog,
+  EmptyWebSourcesState,
+  SingleWebpageForm,
+  WebSourcesSkeleton,
+} from "./web-sources/WebSourceForms";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { trpc } from "@/lib/trpc";
-import { toast } from "sonner";
-import {
-  Globe,
-  Plus,
-  RefreshCw,
-  Trash2,
-  Download,
-  ChevronDown,
-  ChevronRight,
-  Link as LinkIcon,
-  Loader2,
-  ExternalLink,
-  AlertCircle,
-  CheckCircle2,
-  Clock,
-  Ban,
-  SkipForward,
-} from "lucide-react";
-import { Progress } from "@/components/ui/progress";
-import { Switch } from "@/components/ui/switch";
-import { Skeleton } from "@/components/ui/skeleton";
+  getFriendlyError,
+  hasActiveCrawl,
+  normalizeUrl,
+  parsePatternList,
+} from "./web-sources/utils";
 
 interface WebSourcesTabProps {
   chatbotId: string;
-}
-
-function getSourceStatusBadge(status: string) {
-  switch (status) {
-    case "completed":
-      return (
-        <Badge className="bg-green-600">
-          <CheckCircle2 className="h-3 w-3 mr-1" />
-          Completed
-        </Badge>
-      );
-    case "crawling":
-      return (
-        <Badge className="bg-blue-600">
-          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-          Crawling
-        </Badge>
-      );
-    case "discovering":
-      return (
-        <Badge className="bg-blue-600">
-          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-          Discovering
-        </Badge>
-      );
-    case "pending":
-      return (
-        <Badge variant="secondary">
-          <Clock className="h-3 w-3 mr-1" />
-          Pending
-        </Badge>
-      );
-    case "failed":
-      return (
-        <Badge variant="destructive">
-          <AlertCircle className="h-3 w-3 mr-1" />
-          Failed
-        </Badge>
-      );
-    default:
-      return <Badge variant="secondary">{status}</Badge>;
-  }
-}
-
-function getPageStatusBadge(status: string) {
-  switch (status) {
-    case "completed":
-      return (
-        <Badge variant="outline" className="text-green-600 border-green-600">
-          <CheckCircle2 className="h-3 w-3 mr-1" />
-          Done
-        </Badge>
-      );
-    case "processing":
-      return (
-        <Badge variant="outline" className="text-blue-600 border-blue-600">
-          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-          Processing
-        </Badge>
-      );
-    case "pending":
-      return (
-        <Badge variant="outline">
-          <Clock className="h-3 w-3 mr-1" />
-          Pending
-        </Badge>
-      );
-    case "failed":
-      return (
-        <Badge variant="outline" className="text-red-600 border-red-600">
-          <AlertCircle className="h-3 w-3 mr-1" />
-          Failed
-        </Badge>
-      );
-    case "blocked":
-      return (
-        <Badge variant="outline" className="text-yellow-600 border-yellow-600">
-          <Ban className="h-3 w-3 mr-1" />
-          Blocked
-        </Badge>
-      );
-    case "skipped":
-      return (
-        <Badge variant="outline" className="text-gray-500 border-gray-500">
-          <SkipForward className="h-3 w-3 mr-1" />
-          Unchanged
-        </Badge>
-      );
-    default:
-      return <Badge variant="outline">{status}</Badge>;
-  }
-}
-
-function getFriendlyError(error: { message: string }): string {
-  try {
-    const parsed = JSON.parse(error.message) as Array<{
-      code?: string;
-      path?: string[];
-      message?: string;
-      maximum?: number;
-      minimum?: number;
-    }>;
-    if (Array.isArray(parsed) && parsed.length > 0) {
-      return parsed
-        .map((e) => {
-          const field = e.path?.join(".") ?? "input";
-          const code = e.code ?? "";
-          if (code === "too_big" && field === "maxPages")
-            return `Max pages cannot exceed ${e.maximum}`;
-          if (code === "too_small" && field === "maxPages")
-            return `Max pages must be at least ${e.minimum}`;
-          if (code === "too_big" && field === "crawlDepth")
-            return `Crawl depth cannot exceed ${e.maximum}`;
-          if (code === "too_small" && field === "crawlDepth")
-            return `Crawl depth must be at least ${e.minimum}`;
-          if (field === "rootUrl" || field === "url")
-            return "Please enter a valid URL";
-          return e.message ?? "Invalid input";
-        })
-        .join(". ");
-    }
-  } catch {
-    // not JSON
-  }
-  return error.message;
 }
 
 export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
@@ -201,14 +41,6 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     new Set(),
   );
 
-  const hasActiveCrawl = (sources: Array<{ status: string }>) =>
-    sources?.some(
-      (s) =>
-        s.status === "pending" ||
-        s.status === "discovering" ||
-        s.status === "crawling",
-    );
-
   const {
     data: sources,
     isLoading: sourcesLoading,
@@ -220,6 +52,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
         hasActiveCrawl(query.state.data ?? []) ? 3000 : false,
     },
   );
+  const utils = trpc.useUtils();
 
   const addCrawlSource = trpc.crawler.addCrawlSource.useMutation({
     onSuccess: () => {
@@ -239,7 +72,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     },
   });
 
-  const addManualUrlMutation = trpc.crawler.addManualUrl.useMutation({
+  const addManualUrl = trpc.crawler.addManualUrl.useMutation({
     onSuccess: () => {
       refetchSources();
       setManualUrl("");
@@ -288,13 +121,20 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     },
   });
 
-  const normalizeUrl = (url: string) => {
-    const trimmed = url.trim();
-    if (trimmed && !trimmed.match(/^https?:\/\//i)) {
-      return `https://${trimmed}`;
-    }
-    return trimmed;
-  };
+  const renameCrawlSource = trpc.crawler.renameCrawlSource.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        refetchSources(),
+        utils.crawler.getAllCrawlSources.invalidate(),
+      ]);
+      toast.success("Web source renamed");
+    },
+    onError: (error) => {
+      toast.error("Failed to rename source", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
 
   const handleAddSource = () => {
     addCrawlSource.mutate({
@@ -302,24 +142,14 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
       rootUrl: normalizeUrl(rootUrl),
       crawlDepth,
       maxPages,
-      includePatterns: includePatterns
-        ? includePatterns
-            .split(",")
-            .map((p) => p.trim())
-            .filter(Boolean)
-        : [],
-      excludePatterns: excludePatterns
-        ? excludePatterns
-            .split(",")
-            .map((p) => p.trim())
-            .filter(Boolean)
-        : [],
+      includePatterns: parsePatternList(includePatterns),
+      excludePatterns: parsePatternList(excludePatterns),
     });
   };
 
   const handleAddManualUrl = () => {
     if (!manualUrl) return;
-    addManualUrlMutation.mutate({ chatbotId, url: normalizeUrl(manualUrl) });
+    addManualUrl.mutate({ chatbotId, url: normalizeUrl(manualUrl) });
   };
 
   const toggleExpanded = (sourceId: string) => {
@@ -348,149 +178,36 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
               knowledge base.
             </CardDescription>
           </div>
-          <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Web Source
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[500px]">
-              <DialogHeader>
-                <DialogTitle>Add Web Source</DialogTitle>
-                <DialogDescription>
-                  Enter a website URL to crawl and add to your chatbot&apos;s
-                  knowledge base.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="rootUrl">Website URL</Label>
-                  <Input
-                    id="rootUrl"
-                    placeholder="https://cs101.university.edu"
-                    value={rootUrl}
-                    onChange={(e) => setRootUrl(e.target.value)}
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="crawlDepth">Crawl Depth</Label>
-                    <Input
-                      id="crawlDepth"
-                      type="number"
-                      min={1}
-                      max={5}
-                      value={crawlDepth}
-                      onChange={(e) =>
-                        setCrawlDepth(parseInt(e.target.value) || 3)
-                      }
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="maxPages">Max Pages</Label>
-                    <Input
-                      id="maxPages"
-                      type="number"
-                      min={1}
-                      max={500}
-                      value={maxPages}
-                      onChange={(e) =>
-                        setMaxPages(parseInt(e.target.value) || 100)
-                      }
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="includePatterns">
-                    Include Patterns (comma-separated)
-                  </Label>
-                  <Input
-                    id="includePatterns"
-                    placeholder="/lectures/*, /syllabus"
-                    value={includePatterns}
-                    onChange={(e) => setIncludePatterns(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="excludePatterns">
-                    Exclude Patterns (comma-separated)
-                  </Label>
-                  <Input
-                    id="excludePatterns"
-                    placeholder="/admin/*, /login"
-                    value={excludePatterns}
-                    onChange={(e) => setExcludePatterns(e.target.value)}
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setAddDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleAddSource}
-                  disabled={!rootUrl || addCrawlSource.isPending}
-                >
-                  {addCrawlSource.isPending && (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  )}
-                  Start Crawl
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <AddFullWebSourceDialog
+            open={addDialogOpen}
+            onOpenChange={setAddDialogOpen}
+            rootUrl={rootUrl}
+            crawlDepth={crawlDepth}
+            maxPages={maxPages}
+            includePatterns={includePatterns}
+            excludePatterns={excludePatterns}
+            onRootUrlChange={setRootUrl}
+            onCrawlDepthChange={setCrawlDepth}
+            onMaxPagesChange={setMaxPages}
+            onIncludePatternsChange={setIncludePatterns}
+            onExcludePatternsChange={setExcludePatterns}
+            onSubmit={handleAddSource}
+            isSubmitting={addCrawlSource.isPending}
+          />
         </div>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="flex gap-2">
-          <div className="flex-1">
-            <Input
-              placeholder="Add a single page URL..."
-              value={manualUrl}
-              onChange={(e) => setManualUrl(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleAddManualUrl()}
-            />
-          </div>
-          <Button
-            variant="outline"
-            onClick={handleAddManualUrl}
-            disabled={!manualUrl || addManualUrlMutation.isPending}
-          >
-            {addManualUrlMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <LinkIcon className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
+        <SingleWebpageForm
+          manualUrl={manualUrl}
+          isSubmitting={addManualUrl.isPending}
+          onManualUrlChange={setManualUrl}
+          onSubmit={handleAddManualUrl}
+        />
 
         {sourcesLoading ? (
-          <div className="space-y-3">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="rounded-lg border p-4">
-                <div className="flex items-center gap-3">
-                  <Skeleton className="h-5 w-5 rounded" />
-                  <div className="flex-1 space-y-2">
-                    <Skeleton className="h-4 w-1/2" />
-                    <Skeleton className="h-3 w-1/3" />
-                  </div>
-                  <Skeleton className="h-8 w-8 rounded" />
-                </div>
-              </div>
-            ))}
-          </div>
+          <WebSourcesSkeleton />
         ) : !sources || sources.length === 0 ? (
-          <div className="text-center py-12 text-muted-foreground">
-            <Globe className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p className="text-lg font-medium">No web sources yet</p>
-            <p className="text-sm mt-1">
-              Add a website URL to crawl or paste a single page URL above.
-            </p>
-          </div>
+          <EmptyWebSourcesState />
         ) : (
           <div className="space-y-3">
             {sources.map((source) => (
@@ -509,450 +226,21 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
                     enabled,
                   })
                 }
+                onRename={(name) =>
+                  renameCrawlSource.mutateAsync({
+                    crawlSourceId: source.id,
+                    name,
+                  })
+                }
                 isRecrawling={recrawl.isPending}
                 isRemoving={removeCrawlSource.isPending}
                 isTogglingEnabled={toggleCrawlSource.isPending}
+                isRenaming={renameCrawlSource.isPending}
               />
             ))}
           </div>
         )}
       </CardContent>
     </Card>
-  );
-}
-
-function computeCrawlProgress(
-  status: string,
-  pageCounts: {
-    pending: number;
-    processing: number;
-    completed: number;
-    failed: number;
-    blocked: number;
-    skipped: number;
-  },
-): { progress: number; label: string } {
-  const { pending, processing, completed, failed, blocked, skipped } =
-    pageCounts;
-  const total = pending + processing + completed + failed + blocked + skipped;
-
-  if (status === "pending") {
-    return { progress: 5, label: "Waiting to start..." };
-  }
-  if (status === "discovering") {
-    return { progress: 15, label: "Discovering pages..." };
-  }
-  if (status === "crawling" && total > 0) {
-    const done = completed + failed + blocked + skipped;
-    return {
-      progress: 20 + Math.round((done / total) * 80),
-      label: `Processing ${done} of ${total} pages...`,
-    };
-  }
-  if (status === "crawling") {
-    return { progress: 20, label: "Processing pages..." };
-  }
-  return { progress: 0, label: "Waiting to start..." };
-}
-
-function CrawlProgress({
-  status,
-  pageCounts,
-}: {
-  status: string;
-  pageCounts: {
-    pending: number;
-    processing: number;
-    completed: number;
-    failed: number;
-    blocked: number;
-    skipped: number;
-  };
-}) {
-  const { progress, label } = computeCrawlProgress(status, pageCounts);
-  return (
-    <div className="px-4 pb-3">
-      <Progress value={progress} className="h-2" />
-      <p className="text-xs text-muted-foreground mt-1">{label}</p>
-    </div>
-  );
-}
-
-function CrawlSourceCard({
-  source,
-  isExpanded,
-  onToggleExpand,
-  onRecrawl,
-  onRemove,
-  onToggleEnabled,
-  isRecrawling,
-  isRemoving,
-  isTogglingEnabled,
-}: {
-  source: {
-    id: string;
-    rootUrl: string;
-    status: string;
-    enabled: boolean;
-    lastCrawledAt: Date | null;
-    metadata: Record<string, unknown> | null;
-    pageCounts: {
-      pending: number;
-      processing: number;
-      completed: number;
-      failed: number;
-      blocked: number;
-      skipped: number;
-    };
-  };
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onRecrawl: () => void;
-  onRemove: () => void;
-  onToggleEnabled: (enabled: boolean) => void;
-  isRecrawling: boolean;
-  isRemoving: boolean;
-  isTogglingEnabled: boolean;
-}) {
-  const isActive =
-    source.status === "pending" ||
-    source.status === "discovering" ||
-    source.status === "crawling";
-  const pageCount =
-    typeof source.metadata?.pageCount === "number"
-      ? source.metadata.pageCount
-      : 0;
-  const errorCount =
-    typeof source.metadata?.errorCount === "number"
-      ? source.metadata.errorCount
-      : 0;
-
-  const utils = trpc.useUtils();
-
-  const handleExport = async () => {
-    try {
-      const data = await utils.crawler.exportJson.fetch({
-        crawlSourceId: source.id,
-      });
-      const blob = new Blob([JSON.stringify(data, null, 2)], {
-        type: "application/json",
-      });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `crawl-${new URL(source.rootUrl).hostname}-${new Date().toISOString().split("T")[0]}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      toast.success("JSON exported");
-    } catch {
-      toast.error("Failed to export JSON");
-    }
-  };
-
-  return (
-    <div
-      className={`rounded-lg border transition-opacity ${source.enabled ? "" : "opacity-60"}`}
-    >
-      <Collapsible open={isExpanded} onOpenChange={onToggleExpand}>
-        <div className="flex items-center justify-between p-4">
-          <CollapsibleTrigger asChild>
-            <button className="flex items-center gap-3 text-left flex-1 min-w-0">
-              {isExpanded ? (
-                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-              ) : (
-                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-              )}
-              <Globe className="h-5 w-5 shrink-0 text-muted-foreground" />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium truncate">{source.rootUrl}</p>
-                <div className="flex items-center gap-2 mt-1">
-                  {source.enabled ? (
-                    getSourceStatusBadge(source.status)
-                  ) : (
-                    <Badge variant="secondary">Disabled</Badge>
-                  )}
-                  {source.status === "completed" && (
-                    <span className="text-xs text-muted-foreground">
-                      {pageCount} page{pageCount !== 1 ? "s" : ""} crawled
-                      {errorCount > 0 &&
-                        `, ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
-                    </span>
-                  )}
-                  {source.lastCrawledAt && (
-                    <span className="text-xs text-muted-foreground">
-                      Last:{" "}
-                      {new Date(source.lastCrawledAt).toLocaleDateString()}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </button>
-          </CollapsibleTrigger>
-          <div className="flex items-center gap-2 ml-2">
-            <div
-              className="flex items-center"
-              title={
-                source.enabled
-                  ? "Disable this source (keeps data, excludes from chat context)"
-                  : "Enable this source"
-              }
-            >
-              <Switch
-                checked={source.enabled}
-                onCheckedChange={onToggleEnabled}
-                disabled={isTogglingEnabled}
-                aria-label="Toggle source"
-              />
-            </div>
-            {source.status === "completed" && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleExport}
-                  title="Download JSON"
-                >
-                  <Download className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onRecrawl}
-                  disabled={isRecrawling}
-                  title="Re-crawl"
-                >
-                  <RefreshCw
-                    className={`h-4 w-4 ${isRecrawling ? "animate-spin" : ""}`}
-                  />
-                </Button>
-              </>
-            )}
-            {source.status === "failed" && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onRecrawl}
-                disabled={isRecrawling}
-                title="Retry"
-              >
-                <RefreshCw
-                  className={`h-4 w-4 ${isRecrawling ? "animate-spin" : ""}`}
-                />
-              </Button>
-            )}
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  disabled={isRemoving || isActive}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Remove Web Source</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will remove the crawl source, all {pageCount} crawled
-                    page{pageCount !== 1 ? "s" : ""}, and their embeddings. This
-                    action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={onRemove}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  >
-                    Remove
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
-        </div>
-
-        {isActive && (
-          <CrawlProgress
-            status={source.status}
-            pageCounts={source.pageCounts}
-          />
-        )}
-
-        <CollapsibleContent>
-          <CrawledPagesList crawlSourceId={source.id} isExpanded={isExpanded} />
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
-  );
-}
-
-function CrawledPagesList({
-  crawlSourceId,
-  isExpanded,
-}: {
-  crawlSourceId: string;
-  isExpanded: boolean;
-}) {
-  const [offset, setOffset] = useState(0);
-  const limit = 10;
-  const utils = trpc.useUtils();
-
-  const { data, isLoading } = trpc.crawler.getCrawledPages.useQuery(
-    {
-      crawlSourceId,
-      limit,
-      offset,
-    },
-    { enabled: isExpanded, staleTime: 30_000 },
-  );
-
-  const removeCrawledPage = trpc.crawler.removeCrawledPage.useMutation({
-    onSuccess: async () => {
-      await Promise.all([
-        utils.crawler.getCrawledPages.invalidate({ crawlSourceId }),
-        utils.crawler.getCrawlSources.invalidate(),
-      ]);
-      toast.success("Page removed");
-    },
-    onError: (error) => {
-      toast.error("Failed to remove page", {
-        description: getFriendlyError(error),
-      });
-    },
-  });
-
-  if (isLoading || !data) {
-    return (
-      <div className="border-t">
-        <div className="divide-y">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="flex items-center justify-between px-4 py-2.5"
-            >
-              <div className="min-w-0 flex-1 mr-3 space-y-1.5">
-                <Skeleton className="h-4 w-2/3" />
-                <Skeleton className="h-3 w-1/2" />
-              </div>
-              <Skeleton className="h-5 w-16" />
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (data.pages.length === 0) {
-    return (
-      <div className="px-4 pb-4 text-sm text-muted-foreground">
-        No pages crawled yet.
-      </div>
-    );
-  }
-
-  return (
-    <div className="border-t">
-      <div className="divide-y">
-        {data.pages.map(
-          (page: {
-            id: string;
-            title: string | null;
-            url: string;
-            status: string;
-            metadata: Record<string, unknown> | null;
-          }) => (
-            <div
-              key={page.id}
-              className="flex items-center justify-between px-4 py-2.5"
-            >
-              <div className="min-w-0 flex-1 mr-3">
-                <p className="text-sm truncate">{page.title || page.url}</p>
-                <div className="flex items-center gap-2 mt-0.5">
-                  <a
-                    href={page.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs text-muted-foreground hover:text-foreground truncate flex items-center gap-1"
-                  >
-                    {page.url}
-                    <ExternalLink className="h-3 w-3 shrink-0" />
-                  </a>
-                  {typeof page.metadata?.wordCount === "number" && (
-                    <span className="text-xs text-muted-foreground shrink-0">
-                      {page.metadata.wordCount.toLocaleString()} words
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                {getPageStatusBadge(page.status)}
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      disabled={removeCrawledPage.isPending}
-                      title="Remove page"
-                    >
-                      <Trash2 className="h-3.5 w-3.5 text-destructive" />
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Remove page</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Remove &quot;{page.title || page.url}&quot; from this
-                        chatbot&apos;s knowledge? This deletes the page and its
-                        embeddings. This action cannot be undone.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={() =>
-                          removeCrawledPage.mutate({ crawledPageId: page.id })
-                        }
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                      >
-                        Remove
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </div>
-            </div>
-          ),
-        )}
-      </div>
-      {data.totalCount > limit && (
-        <div className="flex items-center justify-between px-4 py-2 border-t bg-muted/50">
-          <span className="text-xs text-muted-foreground">
-            Showing {offset + 1}-{Math.min(offset + limit, data.totalCount)} of{" "}
-            {data.totalCount}
-          </span>
-          <div className="flex gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setOffset(Math.max(0, offset - limit))}
-              disabled={offset === 0}
-            >
-              Previous
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setOffset(offset + limit)}
-              disabled={offset + limit >= data.totalCount}
-            >
-              Next
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
   );
 }

--- a/apps/web/src/components/chatbot/web-sources/CrawlProgress.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawlProgress.tsx
@@ -1,0 +1,53 @@
+import { Progress } from "@/components/ui/progress";
+
+interface PageCounts {
+  pending: number;
+  processing: number;
+  completed: number;
+  failed: number;
+  blocked: number;
+  skipped: number;
+}
+
+function computeCrawlProgress(
+  status: string,
+  pageCounts: PageCounts,
+): { progress: number; label: string } {
+  const { pending, processing, completed, failed, blocked, skipped } =
+    pageCounts;
+  const total = pending + processing + completed + failed + blocked + skipped;
+
+  if (status === "pending") {
+    return { progress: 5, label: "Waiting to start..." };
+  }
+  if (status === "discovering") {
+    return { progress: 15, label: "Discovering pages..." };
+  }
+  if (status === "crawling" && total > 0) {
+    const done = completed + failed + blocked + skipped;
+    return {
+      progress: 20 + Math.round((done / total) * 80),
+      label: `Processing ${done} of ${total} pages...`,
+    };
+  }
+  if (status === "crawling") {
+    return { progress: 20, label: "Processing pages..." };
+  }
+  return { progress: 0, label: "Waiting to start..." };
+}
+
+export function CrawlProgress({
+  status,
+  pageCounts,
+}: {
+  status: string;
+  pageCounts: PageCounts;
+}) {
+  const { progress, label } = computeCrawlProgress(status, pageCounts);
+  return (
+    <div className="px-4 pb-3">
+      <Progress value={progress} className="h-2" />
+      <p className="text-xs text-muted-foreground mt-1">{label}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import {
+  Download,
+  ChevronDown,
+  ChevronRight,
+  Globe,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { trpc, type RouterOutputs } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EditableName } from "@/components/ui/editable-name";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  getSourceDisplayName,
+  getSourceErrorCount,
+  getSourcePageCount,
+} from "@/lib/crawler-metadata";
+import { CrawlProgress } from "./CrawlProgress";
+import { CrawledPagesList } from "./CrawledPagesList";
+import { SourceStatusBadge } from "./status-badges";
+
+type CrawlSource = RouterOutputs["crawler"]["getCrawlSources"][number];
+
+export function CrawlSourceCard({
+  source,
+  isExpanded,
+  onToggleExpand,
+  onRecrawl,
+  onRemove,
+  onToggleEnabled,
+  onRename,
+  isRecrawling,
+  isRemoving,
+  isTogglingEnabled,
+  isRenaming,
+}: {
+  source: CrawlSource;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onRecrawl: () => void;
+  onRemove: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onRename: (name: string) => Promise<unknown>;
+  isRecrawling: boolean;
+  isRemoving: boolean;
+  isTogglingEnabled: boolean;
+  isRenaming: boolean;
+}) {
+  const isActive =
+    source.status === "pending" ||
+    source.status === "discovering" ||
+    source.status === "crawling";
+  const pageCount = getSourcePageCount(source);
+  const errorCount = getSourceErrorCount(source);
+  const utils = trpc.useUtils();
+
+  const handleExport = async () => {
+    try {
+      const data = await utils.crawler.exportJson.fetch({
+        crawlSourceId: source.id,
+      });
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `crawl-${new URL(source.rootUrl).hostname}-${new Date().toISOString().split("T")[0]}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success("JSON exported");
+    } catch {
+      toast.error("Failed to export JSON");
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-lg border transition-opacity ${source.enabled ? "" : "opacity-60"}`}
+    >
+      <Collapsible open={isExpanded} onOpenChange={onToggleExpand}>
+        <div className="flex items-center justify-between p-4">
+          <div className="flex items-center gap-3 text-left flex-1 min-w-0">
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                aria-label={isExpanded ? "Collapse source" : "Expand source"}
+              >
+                {isExpanded ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+              </Button>
+            </CollapsibleTrigger>
+            <Globe className="h-5 w-5 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <EditableName
+                value={getSourceDisplayName(source)}
+                fallback={source.rootUrl}
+                ariaLabel="Rename web source"
+                isSaving={isRenaming}
+                onSave={onRename}
+                className="text-sm font-medium"
+              />
+              <div className="flex items-center gap-2 mt-1">
+                {source.enabled ? (
+                  <SourceStatusBadge status={source.status} />
+                ) : (
+                  <Badge variant="secondary">Disabled</Badge>
+                )}
+                {source.status === "completed" && (
+                  <span className="text-xs text-muted-foreground">
+                    {pageCount} page{pageCount !== 1 ? "s" : ""} crawled
+                    {errorCount > 0 &&
+                      `, ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
+                  </span>
+                )}
+                {source.lastCrawledAt && (
+                  <span className="text-xs text-muted-foreground">
+                    Last: {new Date(source.lastCrawledAt).toLocaleDateString()}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 ml-2">
+            <div
+              className="flex items-center"
+              title={
+                source.enabled
+                  ? "Disable this source (keeps data, excludes from chat context)"
+                  : "Enable this source"
+              }
+            >
+              <Switch
+                checked={source.enabled}
+                onCheckedChange={onToggleEnabled}
+                disabled={isTogglingEnabled}
+                aria-label="Toggle source"
+              />
+            </div>
+            <CrawlSourceActions
+              source={source}
+              pageCount={pageCount}
+              isActive={isActive}
+              isRecrawling={isRecrawling}
+              isRemoving={isRemoving}
+              onExport={handleExport}
+              onRecrawl={onRecrawl}
+              onRemove={onRemove}
+            />
+          </div>
+        </div>
+
+        {isActive && (
+          <CrawlProgress
+            status={source.status}
+            pageCounts={source.pageCounts}
+          />
+        )}
+
+        <CollapsibleContent>
+          <CrawledPagesList crawlSourceId={source.id} isExpanded={isExpanded} />
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}
+
+function CrawlSourceActions({
+  source,
+  pageCount,
+  isActive,
+  isRecrawling,
+  isRemoving,
+  onExport,
+  onRecrawl,
+  onRemove,
+}: {
+  source: CrawlSource;
+  pageCount: number;
+  isActive: boolean;
+  isRecrawling: boolean;
+  isRemoving: boolean;
+  onExport: () => void;
+  onRecrawl: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <>
+      {source.status === "completed" && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onExport}
+            title="Download JSON"
+          >
+            <Download className="h-4 w-4" />
+          </Button>
+          <RecrawlButton onRecrawl={onRecrawl} isRecrawling={isRecrawling} />
+        </>
+      )}
+      {source.status === "failed" && (
+        <RecrawlButton
+          onRecrawl={onRecrawl}
+          isRecrawling={isRecrawling}
+          title="Retry"
+        />
+      )}
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="ghost" size="icon" disabled={isRemoving || isActive}>
+            <Trash2 className="h-4 w-4 text-destructive" />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Web Source</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the crawl source, all {pageCount} crawled page
+              {pageCount !== 1 ? "s" : ""}, and their embeddings. This action
+              cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onRemove}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function RecrawlButton({
+  onRecrawl,
+  isRecrawling,
+  title = "Re-crawl",
+}: {
+  onRecrawl: () => void;
+  isRecrawling: boolean;
+  title?: string;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onRecrawl}
+      disabled={isRecrawling}
+      title={title}
+    >
+      <RefreshCw className={`h-4 w-4 ${isRecrawling ? "animate-spin" : ""}`} />
+    </Button>
+  );
+}

--- a/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  Download,
-  ChevronDown,
-  ChevronRight,
-  Globe,
-  RefreshCw,
-  Trash2,
-} from "lucide-react";
+import { Download, ChevronDown, Globe, RefreshCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc, type RouterOutputs } from "@/lib/trpc";
 import { Badge } from "@/components/ui/badge";
@@ -72,6 +65,7 @@ export function CrawlSourceCard({
     source.status === "crawling";
   const pageCount = getSourcePageCount(source);
   const errorCount = getSourceErrorCount(source);
+  const pageLabel = `${pageCount} page${pageCount !== 1 ? "s" : ""}`;
   const utils = trpc.useUtils();
 
   const handleExport = async () => {
@@ -101,21 +95,6 @@ export function CrawlSourceCard({
       <Collapsible open={isExpanded} onOpenChange={onToggleExpand}>
         <div className="flex items-center justify-between p-4">
           <div className="flex items-center gap-3 text-left flex-1 min-w-0">
-            <CollapsibleTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0"
-                aria-label={isExpanded ? "Collapse source" : "Expand source"}
-              >
-                {isExpanded ? (
-                  <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                )}
-              </Button>
-            </CollapsibleTrigger>
             <Globe className="h-5 w-5 shrink-0 text-muted-foreground" />
             <div className="min-w-0 flex-1">
               <EditableName
@@ -126,7 +105,7 @@ export function CrawlSourceCard({
                 onSave={onRename}
                 className="text-sm font-medium"
               />
-              <div className="flex items-center gap-2 mt-1">
+              <div className="flex flex-wrap items-center gap-2 mt-1">
                 {source.enabled ? (
                   <SourceStatusBadge status={source.status} />
                 ) : (
@@ -134,9 +113,9 @@ export function CrawlSourceCard({
                 )}
                 {source.status === "completed" && (
                   <span className="text-xs text-muted-foreground">
-                    {pageCount} page{pageCount !== 1 ? "s" : ""} crawled
-                    {errorCount > 0 &&
-                      `, ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
+                    {errorCount > 0
+                      ? `${errorCount} error${errorCount !== 1 ? "s" : ""}`
+                      : "Crawl complete"}
                   </span>
                 )}
                 {source.lastCrawledAt && (
@@ -144,6 +123,26 @@ export function CrawlSourceCard({
                     Last: {new Date(source.lastCrawledAt).toLocaleDateString()}
                   </span>
                 )}
+                <CollapsibleTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+                    aria-label={
+                      isExpanded
+                        ? `Hide crawled pages for ${getSourceDisplayName(source)}`
+                        : `Show ${pageLabel} for ${getSourceDisplayName(source)}`
+                    }
+                  >
+                    {isExpanded ? "Hide pages" : `Show ${pageLabel}`}
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 transition-transform ${
+                        isExpanded ? "rotate-180" : ""
+                      }`}
+                    />
+                  </Button>
+                </CollapsibleTrigger>
               </div>
             </div>
           </div>

--- a/apps/web/src/components/chatbot/web-sources/CrawledPagesList.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawledPagesList.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { ExternalLink, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { trpc, type RouterOutputs } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EditableName } from "@/components/ui/editable-name";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { getPageDisplayTitle } from "@/lib/crawler-metadata";
+import { getFriendlyError } from "./utils";
+import { PageStatusBadge } from "./status-badges";
+
+type CrawledPage = RouterOutputs["crawler"]["getCrawledPages"]["pages"][number];
+
+export function CrawledPagesList({
+  crawlSourceId,
+  isExpanded,
+}: {
+  crawlSourceId: string;
+  isExpanded: boolean;
+}) {
+  const [offset, setOffset] = useState(0);
+  const limit = 10;
+  const utils = trpc.useUtils();
+
+  const { data, isLoading } = trpc.crawler.getCrawledPages.useQuery(
+    {
+      crawlSourceId,
+      limit,
+      offset,
+    },
+    { enabled: isExpanded, staleTime: 30_000 },
+  );
+
+  const removeCrawledPage = trpc.crawler.removeCrawledPage.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.crawler.getCrawledPages.invalidate({ crawlSourceId }),
+        utils.crawler.getCrawlSources.invalidate(),
+      ]);
+      toast.success("Page removed");
+    },
+    onError: (error) => {
+      toast.error("Failed to remove page", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
+
+  const renameCrawledPage = trpc.crawler.renameCrawledPage.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.crawler.getCrawledPages.invalidate({ crawlSourceId }),
+        utils.crawler.getCrawlSources.invalidate(),
+        utils.crawler.getAllCrawlSources.invalidate(),
+        utils.files.list.invalidate(),
+        utils.files.listForChatbot.invalidate(),
+      ]);
+      toast.success("Page renamed");
+    },
+    onError: (error) => {
+      toast.error("Failed to rename page", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
+
+  if (isLoading || !data) {
+    return <CrawledPagesSkeleton />;
+  }
+
+  if (data.pages.length === 0) {
+    return (
+      <div className="px-4 pb-4 text-sm text-muted-foreground">
+        No pages crawled yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t">
+      <div className="divide-y">
+        {data.pages.map((page) => (
+          <CrawledPageRow
+            key={page.id}
+            page={page}
+            isRemoving={removeCrawledPage.isPending}
+            isRenaming={renameCrawledPage.isPending}
+            onRemove={() =>
+              removeCrawledPage.mutate({ crawledPageId: page.id })
+            }
+            onRename={(title) =>
+              renameCrawledPage.mutateAsync({
+                crawledPageId: page.id,
+                title,
+              })
+            }
+          />
+        ))}
+      </div>
+      {data.totalCount > limit && (
+        <div className="flex items-center justify-between px-4 py-2 border-t bg-muted/50">
+          <span className="text-xs text-muted-foreground">
+            Showing {offset + 1}-{Math.min(offset + limit, data.totalCount)} of{" "}
+            {data.totalCount}
+          </span>
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+              disabled={offset === 0}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setOffset(offset + limit)}
+              disabled={offset + limit >= data.totalCount}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CrawledPagesSkeleton() {
+  return (
+    <div className="border-t">
+      <div className="divide-y">
+        {[0, 1, 2].map((index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between px-4 py-2.5"
+          >
+            <div className="min-w-0 flex-1 mr-3 space-y-1.5">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+            <Skeleton className="h-5 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CrawledPageRow({
+  page,
+  isRemoving,
+  isRenaming,
+  onRemove,
+  onRename,
+}: {
+  page: CrawledPage;
+  isRemoving: boolean;
+  isRenaming: boolean;
+  onRemove: () => void;
+  onRename: (title: string) => Promise<unknown>;
+}) {
+  const displayTitle = getPageDisplayTitle(page);
+  return (
+    <div className="flex items-center justify-between px-4 py-2.5">
+      <div className="min-w-0 flex-1 mr-3">
+        <EditableName
+          value={displayTitle}
+          fallback={page.url}
+          ariaLabel="Rename crawled page"
+          isSaving={isRenaming}
+          onSave={onRename}
+          className="text-sm"
+        />
+        <div className="flex items-center gap-2 mt-0.5">
+          <a
+            href={page.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-muted-foreground hover:text-foreground truncate flex items-center gap-1"
+          >
+            {page.url}
+            <ExternalLink className="h-3 w-3 shrink-0" />
+          </a>
+          {typeof page.metadata?.wordCount === "number" && (
+            <span className="text-xs text-muted-foreground shrink-0">
+              {page.metadata.wordCount.toLocaleString()} words
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <PageStatusBadge status={page.status} />
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              disabled={isRemoving}
+              title="Remove page"
+            >
+              <Trash2 className="h-3.5 w-3.5 text-destructive" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove page</AlertDialogTitle>
+              <AlertDialogDescription>
+                Remove &quot;{displayTitle}&quot; from this chatbot&apos;s
+                knowledge? This deletes the page and its embeddings. This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={onRemove}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Remove
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chatbot/web-sources/CrawledPagesList.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawledPagesList.tsx
@@ -34,20 +34,17 @@ export function CrawledPagesList({
   const [offset, setOffset] = useState(0);
   const limit = 10;
   const utils = trpc.useUtils();
+  const pageQueryInput = { crawlSourceId, limit, offset };
 
   const { data, isLoading } = trpc.crawler.getCrawledPages.useQuery(
-    {
-      crawlSourceId,
-      limit,
-      offset,
-    },
+    pageQueryInput,
     { enabled: isExpanded, staleTime: 30_000 },
   );
 
   const removeCrawledPage = trpc.crawler.removeCrawledPage.useMutation({
     onSuccess: async () => {
       await Promise.all([
-        utils.crawler.getCrawledPages.invalidate({ crawlSourceId }),
+        utils.crawler.getCrawledPages.invalidate(pageQueryInput),
         utils.crawler.getCrawlSources.invalidate(),
       ]);
       toast.success("Page removed");
@@ -62,7 +59,7 @@ export function CrawledPagesList({
   const renameCrawledPage = trpc.crawler.renameCrawledPage.useMutation({
     onSuccess: async () => {
       await Promise.all([
-        utils.crawler.getCrawledPages.invalidate({ crawlSourceId }),
+        utils.crawler.getCrawledPages.invalidate(pageQueryInput),
         utils.crawler.getCrawlSources.invalidate(),
         utils.crawler.getAllCrawlSources.invalidate(),
         utils.files.list.invalidate(),

--- a/apps/web/src/components/chatbot/web-sources/WebSourceForms.tsx
+++ b/apps/web/src/components/chatbot/web-sources/WebSourceForms.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { Globe, Link as LinkIcon, Loader2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function AddFullWebSourceDialog({
+  open,
+  onOpenChange,
+  rootUrl,
+  crawlDepth,
+  maxPages,
+  includePatterns,
+  excludePatterns,
+  onRootUrlChange,
+  onCrawlDepthChange,
+  onMaxPagesChange,
+  onIncludePatternsChange,
+  onExcludePatternsChange,
+  onSubmit,
+  isSubmitting,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rootUrl: string;
+  crawlDepth: number;
+  maxPages: number;
+  includePatterns: string;
+  excludePatterns: string;
+  onRootUrlChange: (value: string) => void;
+  onCrawlDepthChange: (value: number) => void;
+  onMaxPagesChange: (value: number) => void;
+  onIncludePatternsChange: (value: string) => void;
+  onExcludePatternsChange: (value: string) => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Full Web Source
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Add Full Web Source</DialogTitle>
+          <DialogDescription>
+            Enter a starting URL. The crawler follows links from that page
+            within the limits you set.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="rootUrl">Website URL</Label>
+            <Input
+              id="rootUrl"
+              placeholder="https://cs101.university.edu"
+              value={rootUrl}
+              onChange={(event) => onRootUrlChange(event.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="crawlDepth">Crawl Depth</Label>
+              <Input
+                id="crawlDepth"
+                type="number"
+                min={1}
+                max={5}
+                value={crawlDepth}
+                onChange={(event) =>
+                  onCrawlDepthChange(parseInt(event.target.value) || 3)
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="maxPages">Max Pages</Label>
+              <Input
+                id="maxPages"
+                type="number"
+                min={1}
+                max={500}
+                value={maxPages}
+                onChange={(event) =>
+                  onMaxPagesChange(parseInt(event.target.value) || 100)
+                }
+              />
+            </div>
+          </div>
+          <PatternInput
+            id="includePatterns"
+            label="Include URL patterns"
+            value={includePatterns}
+            placeholder="/lectures/*, /syllabus"
+            helpText="Optional. Only crawl matching paths, such as /lectures/*. The * means any characters."
+            onChange={onIncludePatternsChange}
+          />
+          <PatternInput
+            id="excludePatterns"
+            label="Exclude URL patterns"
+            value={excludePatterns}
+            placeholder="/admin/*, /login"
+            helpText="Optional. Skip matching paths, such as /login or /admin/*."
+            onChange={onExcludePatternsChange}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} disabled={!rootUrl || isSubmitting}>
+            {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Start Crawl
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function SingleWebpageForm({
+  manualUrl,
+  isSubmitting,
+  onManualUrlChange,
+  onSubmit,
+}: {
+  manualUrl: string;
+  isSubmitting: boolean;
+  onManualUrlChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row">
+      <div className="flex-1">
+        <Input
+          placeholder="Add a single page URL..."
+          value={manualUrl}
+          onChange={(event) => onManualUrlChange(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && onSubmit()}
+        />
+      </div>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              onClick={onSubmit}
+              disabled={!manualUrl || isSubmitting}
+              className="sm:w-auto"
+            >
+              {isSubmitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <LinkIcon className="h-4 w-4" />
+              )}
+              Add Single Webpage
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Adds only this page. It will not follow links.
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+export function WebSourcesSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[0, 1, 2].map((index) => (
+        <div key={index} className="rounded-lg border p-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-5 w-5 rounded" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+            <Skeleton className="h-8 w-8 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function EmptyWebSourcesState() {
+  return (
+    <div className="text-center py-12 text-muted-foreground">
+      <Globe className="h-12 w-12 mx-auto mb-4 opacity-50" />
+      <p className="text-lg font-medium">No web sources yet</p>
+      <p className="text-sm mt-1">
+        Add a website URL to crawl or paste a single page URL above.
+      </p>
+    </div>
+  );
+}
+
+function PatternInput({
+  id,
+  label,
+  value,
+  placeholder,
+  helpText,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  helpText: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      <p className="text-xs text-muted-foreground">{helpText}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/chatbot/web-sources/status-badges.tsx
+++ b/apps/web/src/components/chatbot/web-sources/status-badges.tsx
@@ -1,0 +1,100 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertCircle,
+  Ban,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  SkipForward,
+} from "lucide-react";
+
+export function SourceStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return (
+        <Badge className="bg-green-600">
+          <CheckCircle2 className="h-3 w-3 mr-1" />
+          Completed
+        </Badge>
+      );
+    case "crawling":
+      return (
+        <Badge className="bg-blue-600">
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+          Crawling
+        </Badge>
+      );
+    case "discovering":
+      return (
+        <Badge className="bg-blue-600">
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+          Discovering
+        </Badge>
+      );
+    case "pending":
+      return (
+        <Badge variant="secondary">
+          <Clock className="h-3 w-3 mr-1" />
+          Pending
+        </Badge>
+      );
+    case "failed":
+      return (
+        <Badge variant="destructive">
+          <AlertCircle className="h-3 w-3 mr-1" />
+          Failed
+        </Badge>
+      );
+    default:
+      return <Badge variant="secondary">{status}</Badge>;
+  }
+}
+
+export function PageStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return (
+        <Badge variant="outline" className="text-green-600 border-green-600">
+          <CheckCircle2 className="h-3 w-3 mr-1" />
+          Done
+        </Badge>
+      );
+    case "processing":
+      return (
+        <Badge variant="outline" className="text-blue-600 border-blue-600">
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+          Processing
+        </Badge>
+      );
+    case "pending":
+      return (
+        <Badge variant="outline">
+          <Clock className="h-3 w-3 mr-1" />
+          Pending
+        </Badge>
+      );
+    case "failed":
+      return (
+        <Badge variant="outline" className="text-red-600 border-red-600">
+          <AlertCircle className="h-3 w-3 mr-1" />
+          Failed
+        </Badge>
+      );
+    case "blocked":
+      return (
+        <Badge variant="outline" className="text-yellow-600 border-yellow-600">
+          <Ban className="h-3 w-3 mr-1" />
+          Blocked
+        </Badge>
+      );
+    case "skipped":
+      return (
+        <Badge variant="outline" className="text-gray-500 border-gray-500">
+          <SkipForward className="h-3 w-3 mr-1" />
+          Unchanged
+        </Badge>
+      );
+    default:
+      return <Badge variant="outline">{status}</Badge>;
+  }
+}

--- a/apps/web/src/components/chatbot/web-sources/utils.ts
+++ b/apps/web/src/components/chatbot/web-sources/utils.ts
@@ -1,0 +1,70 @@
+export function normalizeUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed && !trimmed.match(/^https?:\/\//i)) {
+    return `https://${trimmed}`;
+  }
+  return trimmed;
+}
+
+export function parsePatternList(value: string): string[] {
+  return value
+    ? value
+        .split(",")
+        .map((pattern) => pattern.trim())
+        .filter(Boolean)
+    : [];
+}
+
+export function hasActiveCrawl(sources: Array<{ status: string }>): boolean {
+  return sources.some(
+    (source) =>
+      source.status === "pending" ||
+      source.status === "discovering" ||
+      source.status === "crawling",
+  );
+}
+
+export function getFriendlyError(error: { message: string }): string {
+  try {
+    const parsed = JSON.parse(error.message) as Array<{
+      code?: string;
+      path?: string[];
+      message?: string;
+      maximum?: number;
+      minimum?: number;
+    }>;
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return parsed.map(getFriendlyZodIssue).join(". ");
+    }
+  } catch {
+    // tRPC returns plain messages for non-Zod errors.
+  }
+  return error.message;
+}
+
+function getFriendlyZodIssue(issue: {
+  code?: string;
+  path?: string[];
+  message?: string;
+  maximum?: number;
+  minimum?: number;
+}): string {
+  const field = issue.path?.join(".") ?? "input";
+  const code = issue.code ?? "";
+  if (code === "too_big" && field === "maxPages") {
+    return `Max pages cannot exceed ${issue.maximum}`;
+  }
+  if (code === "too_small" && field === "maxPages") {
+    return `Max pages must be at least ${issue.minimum}`;
+  }
+  if (code === "too_big" && field === "crawlDepth") {
+    return `Crawl depth cannot exceed ${issue.maximum}`;
+  }
+  if (code === "too_small" && field === "crawlDepth") {
+    return `Crawl depth must be at least ${issue.minimum}`;
+  }
+  if (field === "rootUrl" || field === "url") {
+    return "Please enter a valid URL";
+  }
+  return issue.message ?? "Invalid input";
+}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Shield,
   ScrollText,
+  Globe,
 } from "lucide-react";
 
 const navigation = [
@@ -28,6 +29,11 @@ const navigation = [
     name: "Files",
     href: "/dashboard/files",
     icon: FileText,
+  },
+  {
+    name: "Web Sources",
+    href: "/dashboard/web-sources",
+    icon: Globe,
   },
   {
     name: "Settings",

--- a/apps/web/src/components/ui/editable-name.tsx
+++ b/apps/web/src/components/ui/editable-name.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Loader2, Pencil, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface EditableNameProps {
+  value: string;
+  fallback: string;
+  ariaLabel: string;
+  isSaving: boolean;
+  onSave: (value: string) => Promise<unknown>;
+  className?: string;
+}
+
+export function EditableName({
+  value,
+  fallback,
+  ariaLabel,
+  isSaving,
+  onSave,
+  className,
+}: EditableNameProps) {
+  const displayValue = value.trim() || fallback;
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(displayValue);
+
+  const startEditing = () => {
+    setDraft(displayValue);
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setDraft(displayValue);
+    setIsEditing(false);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextValue = draft.trim();
+    if (!nextValue) return;
+    if (nextValue === displayValue) {
+      setIsEditing(false);
+      return;
+    }
+    await onSave(nextValue);
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <form className="flex min-w-0 items-center gap-1" onSubmit={handleSubmit}>
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          aria-label={ariaLabel}
+          maxLength={200}
+          className="h-8 min-w-0 text-sm"
+          autoFocus
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              cancelEditing();
+            }
+          }}
+        />
+        <Button
+          type="submit"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          disabled={isSaving || !draft.trim()}
+          aria-label="Save name"
+        >
+          {isSaving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="h-4 w-4" />
+          )}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={cancelEditing}
+          disabled={isSaving}
+          aria-label="Cancel rename"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <div className="group/name flex min-w-0 items-center gap-1">
+      <p className={`min-w-0 truncate ${className ?? ""}`}>{displayValue}</p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0 opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100"
+        onClick={startEditing}
+        aria-label={ariaLabel}
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/editable-name.tsx
+++ b/apps/web/src/components/ui/editable-name.tsx
@@ -44,8 +44,12 @@ export function EditableName({
       setIsEditing(false);
       return;
     }
-    await onSave(nextValue);
-    setIsEditing(false);
+    try {
+      await onSave(nextValue);
+      setIsEditing(false);
+    } catch {
+      // Parent mutations show the error toast. Keep the field open for retry.
+    }
   };
 
   if (isEditing) {

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -20,6 +20,10 @@ import {
 import { env } from "./env";
 import { publishQStashJob } from "./qstash";
 import { logInfo, logError } from "./logger";
+import {
+  mergeCrawledPageMetadata,
+  mergeCrawlSourceMetadata,
+} from "./crawler-metadata-sql";
 
 /**
  * Dispatch a crawl job: runs inline in development, publishes to QStash in production.
@@ -119,7 +123,7 @@ export async function processCrawlDiscovery(params: {
         .update(crawlSources)
         .set({
           status: "failed",
-          metadata: {
+          metadata: mergeCrawlSourceMetadata({
             pageCount: 0,
             errorCount: 1,
             errors: [
@@ -129,7 +133,7 @@ export async function processCrawlDiscovery(params: {
                   "No pages could be scraped. The site may require JavaScript to render content.",
               },
             ],
-          },
+          }),
           updatedAt: new Date(),
         })
         .where(eq(crawlSources.id, crawlSourceId));
@@ -210,12 +214,12 @@ export async function processCrawlDiscovery(params: {
         .update(crawlSources)
         .set({
           status: "crawling",
-          metadata: {
+          metadata: mergeCrawlSourceMetadata({
             pageCount: records.length,
             errorCount: 0,
             errors: [],
             robotsText,
-          },
+          }),
           updatedAt: new Date(),
         })
         .where(eq(crawlSources.id, crawlSourceId));
@@ -256,9 +260,9 @@ export async function processCrawlDiscovery(params: {
       .update(crawlSources)
       .set({
         status: "failed",
-        metadata: {
+        metadata: mergeCrawlSourceMetadata({
           errors: [{ url: "discovery", error: getFriendlyErrorMessage(error) }],
-        },
+        }),
         updatedAt: new Date(),
       })
       .where(eq(crawlSources.id, crawlSourceId));
@@ -309,7 +313,9 @@ export async function processCrawlPage(params: {
         .update(crawledPages)
         .set({
           status: "blocked",
-          metadata: { error: "URL targets a private or disallowed address" },
+          metadata: mergeCrawledPageMetadata({
+            error: "URL targets a private or disallowed address",
+          }),
           updatedAt: new Date(),
         })
         .where(eq(crawledPages.id, crawledPageId));
@@ -326,7 +332,9 @@ export async function processCrawlPage(params: {
         .update(crawledPages)
         .set({
           status: "blocked",
-          metadata: { error: "Blocked by robots.txt" },
+          metadata: mergeCrawledPageMetadata({
+            error: "Blocked by robots.txt",
+          }),
           updatedAt: new Date(),
         })
         .where(eq(crawledPages.id, crawledPageId));
@@ -345,7 +353,9 @@ export async function processCrawlPage(params: {
         .update(crawledPages)
         .set({
           status: "failed",
-          metadata: { error: "Failed to fetch or extract content" },
+          metadata: mergeCrawledPageMetadata({
+            error: "Failed to fetch or extract content",
+          }),
           updatedAt: new Date(),
         })
         .where(eq(crawledPages.id, crawledPageId));
@@ -371,13 +381,22 @@ export async function processCrawlPage(params: {
     );
 
     await db.transaction(async (tx) => {
+      const [currentPage] = await tx
+        .select({
+          metadata: crawledPages.metadata,
+        })
+        .from(crawledPages)
+        .where(eq(crawledPages.id, crawledPageId))
+        .limit(1);
+      const customTitle = currentPage?.metadata?.customTitle?.trim();
+      const displayTitle = customTitle || pageContent.title || page.url;
       let userFileId = page.userFileId;
       if (!userFileId) {
         const [file] = await tx
           .insert(userFiles)
           .values({
             userId: chatbot.userId,
-            fileName: pageContent.title || page.url,
+            fileName: displayTitle,
             fileType: "text/html",
             fileSize: Buffer.byteLength(pageContent.content, "utf-8"),
             storagePath: page.url,
@@ -404,7 +423,7 @@ export async function processCrawlPage(params: {
         await tx
           .update(userFiles)
           .set({
-            fileName: pageContent.title || page.url,
+            fileName: displayTitle,
             fileSize: Buffer.byteLength(pageContent.content, "utf-8"),
             processingStatus: "processing",
           })
@@ -436,9 +455,26 @@ export async function processCrawlPage(params: {
         await tx.insert(fileChunks).values(chunkRecords);
       }
 
+      const [updatedPage] = await tx
+        .update(crawledPages)
+        .set({
+          status: "completed",
+          title: sql<string>`COALESCE(${crawledPages.metadata}->>'customTitle', ${pageContent.title}, ${page.url})`,
+          contentHash: pageContent.contentHash,
+          metadata: mergeCrawledPageMetadata({
+            statusCode: pageContent.statusCode,
+            contentType: pageContent.contentType,
+            wordCount: pageContent.wordCount,
+          }),
+          updatedAt: new Date(),
+        })
+        .where(eq(crawledPages.id, crawledPageId))
+        .returning({ title: crawledPages.title });
+
       await tx
         .update(userFiles)
         .set({
+          fileName: updatedPage?.title ?? displayTitle,
           processingStatus: "completed",
           metadata: {
             chunkCount: chunks.length,
@@ -446,21 +482,6 @@ export async function processCrawlPage(params: {
           },
         })
         .where(eq(userFiles.id, userFileId));
-
-      await tx
-        .update(crawledPages)
-        .set({
-          status: "completed",
-          title: pageContent.title,
-          contentHash: pageContent.contentHash,
-          metadata: {
-            statusCode: pageContent.statusCode,
-            contentType: pageContent.contentType,
-            wordCount: pageContent.wordCount,
-          },
-          updatedAt: new Date(),
-        })
-        .where(eq(crawledPages.id, crawledPageId));
     });
 
     logInfo("Crawled page processed", {
@@ -488,9 +509,9 @@ export async function processCrawlPage(params: {
       .update(crawledPages)
       .set({
         status: "failed",
-        metadata: {
+        metadata: mergeCrawledPageMetadata({
           error: getFriendlyErrorMessage(error),
-        },
+        }),
         updatedAt: new Date(),
       })
       .where(eq(crawledPages.id, crawledPageId));
@@ -528,7 +549,7 @@ export async function finalizeCrawlSource(
     UPDATE crawl_sources
     SET status = 'completed',
         last_crawled_at = NOW(),
-        metadata = ${JSON.stringify({ pageCount: completedCount, errorCount: failedCount })}::jsonb,
+        metadata = COALESCE(metadata, '{}'::jsonb) || ${JSON.stringify({ pageCount: completedCount, errorCount: failedCount })}::jsonb,
         updated_at = NOW()
     WHERE id = ${crawlSourceId}
       AND status = 'crawling'

--- a/apps/web/src/lib/crawler-metadata-sql.ts
+++ b/apps/web/src/lib/crawler-metadata-sql.ts
@@ -1,0 +1,15 @@
+import { sql } from "drizzle-orm";
+import {
+  crawledPages,
+  crawlSources,
+  type CrawledPageMetadata,
+  type CrawlSourceMetadata,
+} from "@teachanything/db/schema";
+
+export function mergeCrawlSourceMetadata(metadata: CrawlSourceMetadata) {
+  return sql`COALESCE(${crawlSources.metadata}, '{}'::jsonb) || ${JSON.stringify(metadata)}::jsonb`;
+}
+
+export function mergeCrawledPageMetadata(metadata: CrawledPageMetadata) {
+  return sql`COALESCE(${crawledPages.metadata}, '{}'::jsonb) || ${JSON.stringify(metadata)}::jsonb`;
+}

--- a/apps/web/src/lib/crawler-metadata.ts
+++ b/apps/web/src/lib/crawler-metadata.ts
@@ -1,0 +1,37 @@
+import type {
+  CrawledPageMetadata,
+  CrawlSourceMetadata,
+} from "@teachanything/db/schema";
+
+export type { CrawledPageMetadata, CrawlSourceMetadata };
+
+export function getSourceDisplayName(source: {
+  rootUrl: string;
+  metadata: CrawlSourceMetadata | null;
+}): string {
+  return source.metadata?.displayName?.trim() || source.rootUrl;
+}
+
+export function getSourcePageCount(source: {
+  metadata: CrawlSourceMetadata | null;
+}): number {
+  return typeof source.metadata?.pageCount === "number"
+    ? source.metadata.pageCount
+    : 0;
+}
+
+export function getSourceErrorCount(source: {
+  metadata: CrawlSourceMetadata | null;
+}): number {
+  return typeof source.metadata?.errorCount === "number"
+    ? source.metadata.errorCount
+    : 0;
+}
+
+export function getPageDisplayTitle(page: {
+  title: string | null;
+  url: string;
+  metadata?: CrawledPageMetadata | null;
+}): string {
+  return page.metadata?.customTitle?.trim() || page.title || page.url;
+}

--- a/apps/web/src/server/routers/crawler/index.ts
+++ b/apps/web/src/server/routers/crawler/index.ts
@@ -8,12 +8,18 @@ import { removeCrawledPageProcedure } from "./procedures/remove-crawled-page";
 import { recrawlProcedure } from "./procedures/recrawl";
 import { exportJsonProcedure } from "./procedures/export-json";
 import { toggleCrawlSourceProcedure } from "./procedures/toggle-crawl-source";
+import { renameCrawlSourceProcedure } from "./procedures/rename-crawl-source";
+import { renameCrawledPageProcedure } from "./procedures/rename-crawled-page";
+import { getAllCrawlSourcesProcedure } from "./procedures/get-all-crawl-sources";
 
 export const crawlerRouter = router({
   addCrawlSource: addCrawlSourceProcedure,
   addManualUrl: addManualUrlProcedure,
+  getAllCrawlSources: getAllCrawlSourcesProcedure,
   getCrawlSources: getCrawlSourcesProcedure,
   getCrawledPages: getCrawledPagesProcedure,
+  renameCrawlSource: renameCrawlSourceProcedure,
+  renameCrawledPage: renameCrawledPageProcedure,
   removeCrawlSource: removeCrawlSourceProcedure,
   removeCrawledPage: removeCrawledPageProcedure,
   recrawl: recrawlProcedure,

--- a/apps/web/src/server/routers/crawler/procedures/export-json.ts
+++ b/apps/web/src/server/routers/crawler/procedures/export-json.ts
@@ -4,6 +4,10 @@ import { TRPCError } from "@trpc/server";
 import { crawledPages, fileChunks } from "@teachanything/db/schema";
 import { crawlSourceIdInput } from "../validation";
 import { assertOwnedCrawlSource } from "../helpers";
+import {
+  getPageDisplayTitle,
+  getSourceDisplayName,
+} from "@/lib/crawler-metadata";
 
 const MAX_EXPORT_PAGES = 200;
 const MAX_EXPORT_CHUNKS = 5000;
@@ -77,11 +81,17 @@ export const exportJsonProcedure = protectedProcedure
       const wordCount =
         (p.metadata as { wordCount?: number } | null)?.wordCount ??
         content.split(/\s+/).filter(Boolean).length;
-      return { url: p.url, title: p.title, content, wordCount };
+      return {
+        url: p.url,
+        title: getPageDisplayTitle(p),
+        content,
+        wordCount,
+      };
     });
 
     return {
       source: source.rootUrl,
+      sourceName: getSourceDisplayName(source),
       crawledAt: source.lastCrawledAt,
       pageCount: pages.length,
       pages,

--- a/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
@@ -1,0 +1,58 @@
+import { protectedProcedure } from "@/server/trpc";
+import { eq, inArray, sql, desc } from "drizzle-orm";
+import { chatbots, crawlSources, crawledPages } from "@teachanything/db/schema";
+import { allCrawlSourcesInput } from "../validation";
+
+export const getAllCrawlSourcesProcedure = protectedProcedure
+  .input(allCrawlSourcesInput)
+  .query(async ({ ctx, input }) => {
+    const [totalCountResult] = await ctx.db
+      .select({ count: sql<number>`count(*)` })
+      .from(crawlSources)
+      .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
+      .where(eq(chatbots.userId, ctx.session.user.id));
+    const totalCount = Number(totalCountResult?.count ?? 0);
+
+    const sources = await ctx.db
+      .select({
+        id: crawlSources.id,
+        chatbotId: crawlSources.chatbotId,
+        chatbotName: chatbots.name,
+        rootUrl: crawlSources.rootUrl,
+        status: crawlSources.status,
+        enabled: crawlSources.enabled,
+        lastCrawledAt: crawlSources.lastCrawledAt,
+        metadata: crawlSources.metadata,
+        createdAt: crawlSources.createdAt,
+      })
+      .from(crawlSources)
+      .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
+      .where(eq(chatbots.userId, ctx.session.user.id))
+      .orderBy(desc(crawlSources.createdAt), desc(crawlSources.id))
+      .limit(input.limit)
+      .offset(input.offset);
+
+    if (sources.length === 0) return { sources: [], totalCount };
+
+    const sourceIds = sources.map((source) => source.id);
+    const pageCounts = await ctx.db
+      .select({
+        crawlSourceId: crawledPages.crawlSourceId,
+        count: sql<number>`count(*)`,
+      })
+      .from(crawledPages)
+      .where(inArray(crawledPages.crawlSourceId, sourceIds))
+      .groupBy(crawledPages.crawlSourceId);
+
+    const countMap = new Map(
+      pageCounts.map((row) => [row.crawlSourceId, Number(row.count)]),
+    );
+
+    return {
+      sources: sources.map((source) => ({
+        ...source,
+        pageCount: countMap.get(source.id) ?? 0,
+      })),
+      totalCount,
+    };
+  });

--- a/apps/web/src/server/routers/crawler/procedures/recrawl.ts
+++ b/apps/web/src/server/routers/crawler/procedures/recrawl.ts
@@ -1,5 +1,5 @@
 import { protectedProcedure } from "@/server/trpc";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { crawlSources } from "@teachanything/db/schema";
 import { dispatchCrawlJob, processCrawlDiscovery } from "@/lib/crawl-processor";
@@ -41,7 +41,7 @@ export const recrawlProcedure = protectedProcedure
       .update(crawlSources)
       .set({
         status: "pending",
-        metadata: {},
+        metadata: sql`jsonb_strip_nulls(jsonb_build_object('displayName', ${crawlSources.metadata}->>'displayName'))`,
         updatedAt: new Date(),
       })
       .where(eq(crawlSources.id, input.crawlSourceId))

--- a/apps/web/src/server/routers/crawler/procedures/rename-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/rename-crawl-source.ts
@@ -1,0 +1,23 @@
+import { protectedProcedure } from "@/server/trpc";
+import { eq } from "drizzle-orm";
+import { crawlSources } from "@teachanything/db/schema";
+import { renameCrawlSourceInput } from "../validation";
+import { assertOwnedCrawlSource } from "../helpers";
+import { mergeCrawlSourceMetadata } from "@/lib/crawler-metadata-sql";
+
+export const renameCrawlSourceProcedure = protectedProcedure
+  .input(renameCrawlSourceInput)
+  .mutation(async ({ ctx, input }) => {
+    await assertOwnedCrawlSource(ctx, input.crawlSourceId);
+
+    const [updated] = await ctx.db
+      .update(crawlSources)
+      .set({
+        metadata: mergeCrawlSourceMetadata({ displayName: input.name.trim() }),
+        updatedAt: new Date(),
+      })
+      .where(eq(crawlSources.id, input.crawlSourceId))
+      .returning();
+
+    return updated;
+  });

--- a/apps/web/src/server/routers/crawler/procedures/rename-crawled-page.ts
+++ b/apps/web/src/server/routers/crawler/procedures/rename-crawled-page.ts
@@ -1,0 +1,33 @@
+import { protectedProcedure } from "@/server/trpc";
+import { eq } from "drizzle-orm";
+import { crawledPages, userFiles } from "@teachanything/db/schema";
+import { renameCrawledPageInput } from "../validation";
+import { assertOwnedCrawledPage } from "../helpers";
+import { mergeCrawledPageMetadata } from "@/lib/crawler-metadata-sql";
+
+export const renameCrawledPageProcedure = protectedProcedure
+  .input(renameCrawledPageInput)
+  .mutation(async ({ ctx, input }) => {
+    const { page } = await assertOwnedCrawledPage(ctx, input.crawledPageId);
+    const title = input.title.trim();
+
+    await ctx.db.transaction(async (tx) => {
+      await tx
+        .update(crawledPages)
+        .set({
+          title,
+          metadata: mergeCrawledPageMetadata({ customTitle: title }),
+          updatedAt: new Date(),
+        })
+        .where(eq(crawledPages.id, input.crawledPageId));
+
+      if (page.userFileId) {
+        await tx
+          .update(userFiles)
+          .set({ fileName: title })
+          .where(eq(userFiles.id, page.userFileId));
+      }
+    });
+
+    return { id: input.crawledPageId, title };
+  });

--- a/apps/web/src/server/routers/crawler/validation.ts
+++ b/apps/web/src/server/routers/crawler/validation.ts
@@ -34,12 +34,27 @@ export const crawlSourceIdInput = z.object({
   crawlSourceId: z.string().uuid(),
 });
 
+export const renameCrawlSourceInput = z.object({
+  crawlSourceId: z.string().uuid(),
+  name: z.string().trim().min(1).max(200),
+});
+
 export const crawledPageIdInput = z.object({
   crawledPageId: z.string().uuid(),
+});
+
+export const renameCrawledPageInput = z.object({
+  crawledPageId: z.string().uuid(),
+  title: z.string().trim().min(1).max(200),
 });
 
 export const crawledPagesInput = z.object({
   crawlSourceId: z.string().uuid(),
   limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const allCrawlSourcesInput = z.object({
+  limit: z.number().int().min(1).max(100).default(20),
   offset: z.number().int().min(0).default(0),
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -67,6 +67,22 @@ export const crawledPageStatusEnum = pgEnum("crawled_page_status", [
   "skipped",
 ]);
 
+export interface CrawlSourceMetadata {
+  displayName?: string;
+  pageCount?: number;
+  errorCount?: number;
+  errors?: Array<{ url: string; error: string }>;
+  robotsText?: string;
+}
+
+export interface CrawledPageMetadata {
+  customTitle?: string;
+  statusCode?: number;
+  contentType?: string;
+  wordCount?: number;
+  error?: string;
+}
+
 // Better Auth: Users table
 // Note: Better Auth uses nanoid for IDs, not UUIDs
 export const user = pgTable("user", {
@@ -393,14 +409,7 @@ export const crawlSources = pgTable(
     includePatterns: jsonb("include_patterns").$type<string[]>().default([]),
     excludePatterns: jsonb("exclude_patterns").$type<string[]>().default([]),
     lastCrawledAt: timestamp("last_crawled_at"),
-    metadata: jsonb("metadata")
-      .$type<{
-        pageCount?: number;
-        errorCount?: number;
-        errors?: Array<{ url: string; error: string }>;
-        robotsText?: string;
-      }>()
-      .default({}),
+    metadata: jsonb("metadata").$type<CrawlSourceMetadata>().default({}),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -422,14 +431,7 @@ export const crawledPages = pgTable(
     contentHash: text("content_hash"),
     depth: integer("depth").default(0).notNull(),
     status: crawledPageStatusEnum("status").default("pending").notNull(),
-    metadata: jsonb("metadata")
-      .$type<{
-        statusCode?: number;
-        contentType?: string;
-        wordCount?: number;
-        error?: string;
-      }>()
-      .default({}),
+    metadata: jsonb("metadata").$type<CrawledPageMetadata>().default({}),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },


### PR DESCRIPTION
## Summary

- Clarifies Web Sources actions with explicit full-site vs single-page controls and plain-language include/exclude pattern help.
- Adds a top-level dashboard Web Sources page with paginated source listing and links back to each chatbot's source management tab.
- Adds inline rename support for crawl sources and crawled pages, preserving custom names through processing, recrawls, exports, and generated file names.
- Renames the chatbot Conversations tab and related UI copy to Student Chats.
- Refactors the Web Sources UI into smaller source/page/form/status components plus shared crawler metadata utilities.

## Why

Professor users were confused by the previous crawler controls and could not discover web sources unless they were already inside a chatbot. Long crawled page titles were also hard to use, and the chat-history label did not clearly communicate that it shows students' chats.

## Validation

- npm run check-types
- npm run lint
- npm run test
