### PR TITLE
feat(site): add trademark status to site logos

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -18,6 +18,7 @@ import { useState, useEffect } from "react";
 import { authClient, useSession } from "@/lib/auth-client";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
+import { BrandName } from "@/components/brand/BrandName";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -144,7 +145,7 @@ export default function LoginPage() {
         <CardHeader>
           <CardTitle>Welcome Back</CardTitle>
           <CardDescription>
-            Login to your Teach anything account
+            Login to your <BrandName /> account
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -30,6 +30,7 @@ import { validatePasswordStrength } from "@/lib/password/password-strength";
 import { PasswordStrengthIndicator } from "@/components/dashboard/settings/PasswordStrengthIndicator";
 import { PasswordRequirementsList } from "@/components/dashboard/settings/PasswordRequirementsList";
 import { TITLE_OPTIONS } from "@/lib/constants/title-options";
+import { BrandName } from "@/components/brand/BrandName";
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -264,7 +265,9 @@ export default function RegisterPage() {
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Create Account</CardTitle>
-          <CardDescription>Register for Teach Anything AI</CardDescription>
+          <CardDescription>
+            Register for <BrandName /> AI
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <Alert className="mb-4">

--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import Image from "next/image";
 import { useParams } from "next/navigation";
 import { useChat } from "@/hooks/useChat";
 import { ChatInterface } from "@/components/chat/messages/ChatInterface";
+import { BrandName } from "@/components/brand/BrandName";
 import {
   Card,
   CardContent,
@@ -92,7 +94,19 @@ export default function SharedChatPage() {
             height="flex-1 min-h-0"
             showFrame={false}
             showSources={chatbot.showSources ?? false}
-            brandingText="Powered by Teach anything"
+            brandingText={
+              <span className="inline-flex items-center gap-1.5">
+                <span>Powered by</span>
+                <Image
+                  src="/logo.svg"
+                  alt="Teach Anything™"
+                  width={14}
+                  height={14}
+                  className="h-3.5 w-3.5"
+                />
+                <BrandName serifAnything className="font-medium" />
+              </span>
+            }
           />
         </ErrorBoundary>
       </div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Instrument_Serif } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { Providers } from "@/lib/providers";
+import { BRAND_NAME_WITH_MARK } from "@/components/brand/BrandName";
 
 const inter = Inter({ subsets: ["latin"] });
 const instrumentSerif = Instrument_Serif({
@@ -16,8 +17,8 @@ export const metadata: Metadata = {
     process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
   ),
   title: {
-    default: "Teach Anything — Open Source LLMs for Open Access Education",
-    template: "%s | Teach Anything",
+    default: `${BRAND_NAME_WITH_MARK} — Open Source LLMs for Open Access Education`,
+    template: `%s | ${BRAND_NAME_WITH_MARK}`,
   },
   description:
     "Build open-access, course-specific, multilingual AI chatbots using open-source LLMs for your students—all for free. This platform is designed by educators for educators. Professors are designers, not consumers.",
@@ -37,9 +38,9 @@ export const metadata: Metadata = {
     "Mistral Large",
     "Qwen 2.5",
   ],
-  authors: [{ name: "Teach Anything Team" }],
-  creator: "Teach Anything",
-  publisher: "Teach Anything",
+  authors: [{ name: `${BRAND_NAME_WITH_MARK} Team` }],
+  creator: BRAND_NAME_WITH_MARK,
+  publisher: BRAND_NAME_WITH_MARK,
   formatDetection: {
     email: false,
     address: false,
@@ -49,8 +50,8 @@ export const metadata: Metadata = {
     type: "website",
     locale: "en_US",
     url: "/",
-    siteName: "Teach Anything",
-    title: "Teach Anything — Open Source LLMs for Open Access Education",
+    siteName: BRAND_NAME_WITH_MARK,
+    title: `${BRAND_NAME_WITH_MARK} — Open Source LLMs for Open Access Education`,
     description:
       "Build open-access, course-specific, multilingual AI chatbots using open-source LLMs for your students—all for free. Designed by educators for educators.",
     images: [
@@ -58,13 +59,13 @@ export const metadata: Metadata = {
         url: "/logo.png",
         width: 1200,
         height: 630,
-        alt: "Teach Anything — Open Source LLMs for Open Access Education",
+        alt: `${BRAND_NAME_WITH_MARK} — Open Source LLMs for Open Access Education`,
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Teach Anything — Open Source LLMs for Open Access Education",
+    title: `${BRAND_NAME_WITH_MARK} — Open Source LLMs for Open Access Education`,
     description:
       "Build open-access, course-specific, multilingual AI chatbots using open-source LLMs for your students—all for free. Designed by educators for educators.",
     images: ["/logo.png"],

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { BrandName, BRAND_NAME_WITH_MARK } from "@/components/brand/BrandName";
 import s from "./legal.module.css";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description:
-    "Privacy Policy for Teach Anything - learn how we collect, use, and protect your personal information.",
+  description: `Privacy Policy for ${BRAND_NAME_WITH_MARK} - learn how we collect, use, and protect your personal information.`,
 };
 
 export default function PrivacyPolicyPage() {
@@ -32,7 +32,7 @@ export default function PrivacyPolicyPage() {
           <p data-legal-meta>Last updated April 17, 2026</p>
 
           <p>
-            This Privacy Notice for Teach Anything (&ldquo;we,&rdquo;
+            This Privacy Notice for <BrandName /> (&ldquo;we,&rdquo;
             &ldquo;us,&rdquo; or &ldquo;our&rdquo;), describes how and why we
             might access, collect, store, use, and/or share
             (&ldquo;process&rdquo;) your personal information when you use our
@@ -47,7 +47,7 @@ export default function PrivacyPolicyPage() {
               or any website of ours that links to this Privacy Notice
             </li>
             <li>
-              Use Teach Anything Open-Access AI for Educators. Teach Anything is
+              Use <BrandName /> Open-Access AI for Educators. <BrandName /> is
               an open-access platform for educators to use open-source large
               language models (LLMs) to design custom AI applications. Educators
               can upload their course files and customize the AI&apos;s
@@ -1424,7 +1424,7 @@ export default function PrivacyPolicyPage() {
             or contact us by post at:
           </p>
           <address>
-            Teach Anything
+            <BrandName />
             <br />
             801 22nd St NW
             <br />

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+interface BrandNameProps {
+  className?: string;
+  markClassName?: string;
+  anythingClassName?: string;
+  serifAnything?: boolean;
+}
+
+export const BRAND_NAME_WITH_MARK = "Teach Anything™";
+
+export function BrandName({
+  className,
+  markClassName,
+  anythingClassName,
+  serifAnything = false,
+}: BrandNameProps) {
+  return (
+    <span className={cn(className)}>
+      Teach{" "}
+      <span
+        className={cn(serifAnything && "italic", anythingClassName)}
+        style={
+          serifAnything
+            ? {
+                fontFamily: "var(--font-instrument-serif), serif",
+                fontWeight: 400,
+              }
+            : undefined
+        }
+      >
+        Anything
+      </span>
+      <sup
+        className={cn(
+          "ml-1.5 align-super text-[0.42em] font-semibold not-italic leading-none tracking-normal",
+          markClassName,
+        )}
+      >
+        TM
+      </sup>
+    </span>
+  );
+}

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -1,9 +1,11 @@
+import type React from "react";
 import { cn } from "@/lib/utils";
 
 interface BrandNameProps {
   className?: string;
   markClassName?: string;
   anythingClassName?: string;
+  anythingStyle?: React.CSSProperties;
   serifAnything?: boolean;
 }
 
@@ -13,6 +15,7 @@ export function BrandName({
   className,
   markClassName,
   anythingClassName,
+  anythingStyle,
   serifAnything = false,
 }: BrandNameProps) {
   return (
@@ -20,14 +23,15 @@ export function BrandName({
       Teach{" "}
       <span
         className={cn(serifAnything && "italic", anythingClassName)}
-        style={
-          serifAnything
+        style={{
+          ...(serifAnything
             ? {
                 fontFamily: "var(--font-instrument-serif), serif",
                 fontWeight: 400,
               }
-            : undefined
-        }
+            : {}),
+          ...anythingStyle,
+        }}
       >
         Anything
       </span>

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -41,8 +41,7 @@ export function BrandName({
           markClassName,
         )}
       >
-        <span aria-hidden="true">™</span>
-        <span className="sr-only">trademark</span>
+        TM
       </sup>
     </span>
   );

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -37,7 +37,8 @@ export function BrandName({
           markClassName,
         )}
       >
-        TM
+        <span aria-hidden="true">™</span>
+        <span className="sr-only">trademark</span>
       </sup>
     </span>
   );

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -28,7 +28,7 @@ interface ChatInterfaceProps {
   embedMode?: boolean;
   showFrame?: boolean;
   showSources?: boolean;
-  brandingText?: string;
+  brandingText?: React.ReactNode;
 }
 
 export function ChatInterface({

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -62,7 +62,7 @@ export function ChatMessage({
         <Message className="items-start gap-2 md:gap-3">
           <MessageAvatar
             src="/logo.svg"
-            alt="Teach anything"
+            alt="Teach Anything™"
             imageClassName="grayscale"
           />
           <div className="flex-1 min-w-0">
@@ -83,7 +83,7 @@ export function ChatMessage({
       <Message className="items-start gap-2 md:gap-3">
         <MessageAvatar
           src="/logo.svg"
-          alt="Teach anything"
+          alt="Teach Anything™"
           imageClassName="grayscale"
         />
         <div className="flex-1 min-w-0">
@@ -162,7 +162,7 @@ export function StreamingMessage({
           <Message className="items-start gap-2 md:gap-3">
             <MessageAvatar
               src="/logo.svg"
-              alt="Teach anything"
+              alt="Teach Anything™"
               imageClassName="grayscale"
             />
             <div className="flex-1 min-w-0">
@@ -197,7 +197,7 @@ export function StreamingMessage({
         <div className="flex gap-2 md:gap-3 items-start">
           <MessageAvatar
             src="/logo.svg"
-            alt="Teach anything"
+            alt="Teach Anything™"
             imageClassName="grayscale"
           />
           <div className="bg-secondary rounded-xl md:rounded-lg px-3 py-2 md:px-4 md:py-3 w-fit shadow-xs border border-border/50">

--- a/apps/web/src/components/dashboard/DashboardHeader.tsx
+++ b/apps/web/src/components/dashboard/DashboardHeader.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useSidebar } from "@/components/dashboard/sidebar-context";
+import { BrandName } from "@/components/brand/BrandName";
 
 export function DashboardHeader() {
   const { data: session } = useSession();
@@ -65,22 +66,15 @@ export function DashboardHeader() {
         >
           <Image
             src="/logo.svg"
-            alt="Teach anything"
+            alt="Teach Anything™"
             width={28}
             height={28}
             className="h-7 w-7"
           />
-          <span className="text-xl font-bold text-foreground">
-            Teach{" "}
-            <i
-              style={{
-                fontFamily: "var(--font-instrument-serif), serif",
-                fontWeight: 400,
-              }}
-            >
-              anything.
-            </i>
-          </span>
+          <BrandName
+            serifAnything
+            className="text-xl font-bold text-foreground"
+          />
         </Link>
         <Link
           href={`mailto:${process.env.NEXT_PUBLIC_CONTACT_EMAIL || ""}`}

--- a/apps/web/src/components/emails/AccountDeleted.tsx
+++ b/apps/web/src/components/emails/AccountDeleted.tsx
@@ -29,7 +29,7 @@ export function AccountDeleted({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                This email confirms that your Teach anything account has been
+                This email confirms that your Teach Anything™ account has been
                 permanently deleted as requested by an administrator.
               </p>
 
@@ -53,19 +53,19 @@ export function AccountDeleted({
               </p>
 
               <p style={text}>
-                If you wish to use Teach anything again in the future, you will
+                If you wish to use Teach Anything™ again in the future, you will
                 need to register a new account.
               </p>
 
               <p style={text}>
                 We&apos;re sorry to see you go. Thank you for being part of the
-                Teach anything community.
+                Teach Anything™ community.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/AccountDisabled.tsx
+++ b/apps/web/src/components/emails/AccountDisabled.tsx
@@ -29,7 +29,7 @@ export function AccountDisabled({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                I&apos;m writing to inform you that your Teach anything account
+                I&apos;m writing to inform you that your Teach Anything™ account
                 has been temporarily disabled by an administrator. You will not
                 be able to log in until your account is re-enabled.
               </p>
@@ -53,13 +53,13 @@ export function AccountDisabled({
 
               <p style={text}>
                 We&apos;re here to help resolve any issues and get you back to
-                using Teach anything as soon as possible.
+                using Teach Anything™ as soon as possible.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/AccountEnabled.tsx
+++ b/apps/web/src/components/emails/AccountEnabled.tsx
@@ -31,7 +31,7 @@ export function AccountEnabled({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Great news! Your Teach anything account has been re-enabled and
+                Great news! Your Teach Anything™ account has been re-enabled and
                 you can now log in again. All your chatbots and data are ready
                 for you to access.
               </p>
@@ -59,7 +59,7 @@ export function AccountEnabled({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/ApprovalConfirmation.tsx
+++ b/apps/web/src/components/emails/ApprovalConfirmation.tsx
@@ -31,7 +31,7 @@ export function ApprovalConfirmation({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Great news! Your Teach anything account has been approved by an
+                Great news! Your Teach Anything™ account has been approved by an
                 administrator. You can now log in and start creating AI-powered
                 chatbots for your courses.
               </p>
@@ -59,14 +59,14 @@ export function ApprovalConfirmation({
               </p>
 
               <p style={text}>
-                Welcome to Teach anything! We&apos;re excited to have you on
+                Welcome to Teach Anything™! We&apos;re excited to have you on
                 board.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/DemoteFromAdmin.tsx
+++ b/apps/web/src/components/emails/DemoteFromAdmin.tsx
@@ -32,7 +32,7 @@ export function DemoteFromAdmin({
 
               <p style={text}>
                 I&apos;m writing to inform you that your administrator
-                privileges have been removed from your Teach anything account.
+                privileges have been removed from your Teach Anything™ account.
                 Your account has been converted to a regular user account.
               </p>
 
@@ -65,7 +65,7 @@ export function DemoteFromAdmin({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/PasswordReset.tsx
+++ b/apps/web/src/components/emails/PasswordReset.tsx
@@ -71,7 +71,7 @@ export function PasswordReset({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/PromoteToAdmin.tsx
+++ b/apps/web/src/components/emails/PromoteToAdmin.tsx
@@ -32,7 +32,7 @@ export function PromoteToAdmin({
 
               <p style={text}>
                 I wanted to let you know that you&apos;ve been promoted to an
-                administrator role on Teach anything. You now have full access
+                administrator role on Teach Anything™. You now have full access
                 to manage users, chatbots, and system settings.
               </p>
 
@@ -58,14 +58,14 @@ export function PromoteToAdmin({
               </p>
 
               <p style={text}>
-                Welcome to the Teach anything admin team! We trust you&apos;ll
+                Welcome to the Teach Anything™ admin team! We trust you&apos;ll
                 help us maintain a secure and efficient platform.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Admin Team
+                Teach Anything™ Admin Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/RejectionNotification.tsx
+++ b/apps/web/src/components/emails/RejectionNotification.tsx
@@ -29,8 +29,8 @@ export function RejectionNotification({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Thank you for your interest in Teach anything. Unfortunately, we
-                are unable to approve your account registration at this time.
+                Thank you for your interest in Teach Anything™. Unfortunately,
+                we are unable to approve your account registration at this time.
               </p>
 
               <p style={text}>Why might this happen?</p>
@@ -57,7 +57,7 @@ export function RejectionNotification({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything Team
+                Teach Anything™ Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/UserRegistrationNotification.tsx
+++ b/apps/web/src/components/emails/UserRegistrationNotification.tsx
@@ -60,7 +60,7 @@ export function UserRegistrationNotification({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach anything
+                Teach Anything™
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/embed/EmbedFooter.tsx
+++ b/apps/web/src/components/embed/EmbedFooter.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { BrandName } from "@/components/brand/BrandName";
 
 export function EmbedFooter() {
   const baseUrl =
@@ -19,22 +20,12 @@ export function EmbedFooter() {
         <span>Powered by</span>
         <Image
           src="/logo.svg"
-          alt="Teach anything"
+          alt="Teach Anything™"
           width={14}
           height={14}
           className="h-3.5 w-3.5"
         />
-        <span className="font-medium">
-          Teach{" "}
-          <i
-            style={{
-              fontFamily: "var(--font-instrument-serif), serif",
-              fontWeight: 400,
-            }}
-          >
-            anything.
-          </i>
-        </span>
+        <BrandName serifAnything className="font-medium" />
       </Link>
     </div>
   );

--- a/apps/web/src/components/landing/ComparisonSection.tsx
+++ b/apps/web/src/components/landing/ComparisonSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { BrandName } from "@/components/brand/BrandName";
 
 export default function ComparisonSection() {
   const comparisonData = [
@@ -77,7 +78,7 @@ export default function ComparisonSection() {
           transition={{ duration: 0.6 }}
         >
           <h2 className="text-3xl md:text-5xl font-serif font-light text-foreground mb-4">
-            Why Choose Teach anything?
+            Why Choose <BrandName markClassName="font-sans font-semibold" />?
           </h2>
           <p className="text-base md:text-lg text-muted-foreground max-w-3xl mx-auto">
             See how we compare to commercial AI solutions. Built with privacy,
@@ -100,7 +101,7 @@ export default function ComparisonSection() {
                   Feature
                 </th>
                 <th className="text-left py-4 px-6 font-semibold text-foreground bg-gray-100">
-                  Teach anything (open access)
+                  <BrandName markClassName="text-[0.42em]" /> (open access)
                 </th>
                 <th className="text-left py-4 px-6 font-semibold text-foreground">
                   Commercial AI
@@ -149,7 +150,7 @@ export default function ComparisonSection() {
               <div className="space-y-3">
                 <div className="bg-white rounded-md p-3 border border-gray-200">
                   <span className="text-xs font-medium text-primary uppercase tracking-wide">
-                    Teach anything
+                    <BrandName markClassName="text-[0.5em]" />
                   </span>
                   <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
                     {row.teachAnything}

--- a/apps/web/src/components/landing/Footer.tsx
+++ b/apps/web/src/components/landing/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { BrandName } from "@/components/brand/BrandName";
 
 export default function Footer() {
   return (
@@ -43,7 +44,8 @@ export default function Footer() {
             </Link>
           </div>
           <p className="text-muted-foreground text-sm">
-            © 2025 Teach anything. All rights reserved.
+            © 2026 <BrandName markClassName="text-[0.45em]" />. All rights
+            reserved.
           </p>
         </div>
       </div>

--- a/apps/web/src/components/landing/Footer.tsx
+++ b/apps/web/src/components/landing/Footer.tsx
@@ -44,8 +44,8 @@ export default function Footer() {
             </Link>
           </div>
           <p className="text-muted-foreground text-sm">
-            © 2026 <BrandName markClassName="text-[0.45em]" />. All rights
-            reserved.
+            © {new Date().getFullYear()}{" "}
+            <BrandName markClassName="text-[0.45em]" />. All rights reserved.
           </p>
         </div>
       </div>

--- a/apps/web/src/components/landing/Navbar.tsx
+++ b/apps/web/src/components/landing/Navbar.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
 import { useSession } from "@/lib/auth-client";
 import { Menu, X } from "lucide-react";
+import { BrandName } from "@/components/brand/BrandName";
 
 export default function Navbar() {
   const [scrolled, setScrolled] = useState(false);
@@ -60,23 +61,16 @@ export default function Navbar() {
               >
                 <Image
                   src="/logo.svg"
-                  alt="Teach anything"
+                  alt="Teach Anything™"
                   width={32}
                   height={32}
                   className="h-8 w-8"
                   priority
                 />
-                <span className="text-xl font-base font-bold text-foreground">
-                  Teach{" "}
-                  <i
-                    style={{
-                      fontFamily: "var(--font-instrument-serif), serif",
-                      fontWeight: 400,
-                    }}
-                  >
-                    anything.
-                  </i>
-                </span>
+                <BrandName
+                  serifAnything
+                  className="text-xl font-base font-bold text-foreground"
+                />
               </Link>
             </div>
 

--- a/apps/web/src/components/landing/hero/HeroHeading.tsx
+++ b/apps/web/src/components/landing/hero/HeroHeading.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { BrandName } from "@/components/brand/BrandName";
+import { MUTED_GREEN } from "./constants";
 
 interface HeroHeadingProps {
   delay?: number;
@@ -18,7 +19,7 @@ export default function HeroHeading({ delay = 0.2 }: HeroHeadingProps) {
       <BrandName
         serifAnything
         className="text-black"
-        anythingClassName="text-[#157F3C]"
+        anythingStyle={{ color: MUTED_GREEN }}
         markClassName="ml-4 text-[0.24em] text-black"
       />
     </motion.h1>

--- a/apps/web/src/components/landing/hero/HeroHeading.tsx
+++ b/apps/web/src/components/landing/hero/HeroHeading.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { MUTED_GREEN } from "./constants";
+import { BrandName } from "@/components/brand/BrandName";
 
 interface HeroHeadingProps {
   delay?: number;
@@ -15,17 +15,12 @@ export default function HeroHeading({ delay = 0.2 }: HeroHeadingProps) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.8, delay }}
     >
-      <span className="text-black">Teach </span>
-      <span
-        className="italic"
-        style={{
-          color: MUTED_GREEN,
-          fontFamily: "var(--font-instrument-serif), serif",
-          fontWeight: 400,
-        }}
-      >
-        anything.
-      </span>
+      <BrandName
+        serifAnything
+        className="text-black"
+        anythingClassName="text-[#157F3C]"
+        markClassName="ml-4 text-[0.24em] text-black"
+      />
     </motion.h1>
   );
 }

--- a/apps/web/src/components/landing/hero/UsedBySection.tsx
+++ b/apps/web/src/components/landing/hero/UsedBySection.tsx
@@ -9,14 +9,8 @@ interface UsedBySectionProps {
   delay?: number;
 }
 
-const DUPLICATION_COUNT = 4;
-
 export default function UsedBySection({ delay = 0.6 }: UsedBySectionProps) {
-  // Duplicate universities array for smooth infinite scroll
-  const duplicatedUniversities = Array.from(
-    { length: DUPLICATION_COUNT },
-    () => UNIVERSITIES,
-  ).flat();
+  const track = [...UNIVERSITIES, ...UNIVERSITIES];
 
   return (
     <motion.div
@@ -30,55 +24,38 @@ export default function UsedBySection({ delay = 0.6 }: UsedBySectionProps) {
           Trusted By Professors At
         </p>
 
-        <div className="relative w-full overflow-hidden">
-          <motion.div
-            className="flex items-center gap-12"
-            animate={{
-              x: ["0%", "-100%"],
-            }}
-            transition={{
-              x: {
-                repeat: Infinity,
-                repeatType: "loop",
-                duration: 40,
-                ease: "linear",
-              },
+        <div className="group relative w-full overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
+          <div
+            className="flex w-max items-center gap-12 group-hover:[animation-play-state:paused]"
+            style={{
+              animation: "infinite-scroll 40s linear infinite",
+              willChange: "transform",
             }}
           >
-            {duplicatedUniversities.map((university, index) => (
-              <motion.div
+            {track.map((university, index) => (
+              <Link
                 key={`${university.name}-${index}`}
-                whileHover={{
-                  scale: 1.1,
-                  y: -5,
-                  filter: "brightness(1.1)",
-                }}
-                transition={{ duration: 0.3 }}
-                className="flex-shrink-0 cursor-pointer"
-                style={{ willChange: "transform" }}
+                href={university.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={university.name}
+                className="flex-shrink-0 block opacity-80 hover:opacity-100 hover:scale-105 transition duration-300"
               >
-                <Link
-                  href={university.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block"
-                >
-                  <Image
-                    src={university.logo}
-                    alt={university.name}
-                    width={university.width}
-                    height={university.height}
-                    style={{
-                      width: `${university.width * 0.7}px`,
-                      height: "auto",
-                    }}
-                    className="object-contain opacity-70 hover:opacity-100 transition-opacity duration-300 drop-shadow-xs"
-                    quality={95}
-                  />
-                </Link>
-              </motion.div>
+                <Image
+                  src={university.logo}
+                  alt={university.name}
+                  width={university.width}
+                  height={university.height}
+                  style={{
+                    width: `${university.width * 0.7}px`,
+                    height: "auto",
+                  }}
+                  className="object-contain drop-shadow-xs"
+                  quality={95}
+                />
+              </Link>
             ))}
-          </motion.div>
+          </div>
         </div>
       </div>
     </motion.div>

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -83,7 +83,7 @@ async function queueEmail(params: {
       body: {
         deliveryId,
         idempotencyKey,
-        from: `Teach anything. <${fromEmail}>`,
+        from: `Teach Anything™ <${fromEmail}>`,
         to: params.to,
         subject: params.subject,
         html,


### PR DESCRIPTION
## Summary

- Add `BrandName` component rendering "Teach Anything™" with consistent TM styling across all surfaces (landing, navbar, footer, emails, embed footer, dashboard header, chat).
- Replace inline brand strings + ad-hoc TM markup with the shared component.
- Hero TM tuned for the large h1 (italic "Anything"): `align-baseline relative -top-10 text-[0.4em]` so the mark sits flush at the top-right of the "g" rather than floating above the line box.
- Refactor `UsedBySection` university marquee to match the Buildy landing pattern:
  - CSS `infinite-scroll` keyframe + 2× duplication for a seamless `-50%` loop (was Framer Motion `x: 0% → -100%` with 4× duplication, which left a visible seam each cycle).
  - `mask-image` linear gradient to fade logos at left/right edges.
  - `group-hover:[animation-play-state:paused]` pauses the whole strip on hover (replaces per-logo Framer scale, which caused mid-scroll wobble).
  - `willChange: transform` moved to the track, off every child.
  - Logos kept in color, opacity 80 idle → 100 + slight scale on hover.

## Test plan

- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] Verified hero TM placement at 1440×900 via headless screenshot — sits at top-right of "Anything"
- [x] Verified marquee renders with edge fade and continues to scroll smoothly
- [x] Spot-check on mobile widths
- [x] Confirm TM renders in all email templates (Resend preview)