### PR TITLE
feat(web): add newsletter signup and sending system

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,7 +30,8 @@ ADMIN_EMAILS=admin@example.com
 # RESEND_API_KEY=re_...
 # RESEND_FROM_EMAIL=noreply@yourdomain.com  # Must be a verified sender domain in Resend (resend.dev addresses cannot send broadcasts)
 # RESEND_WEBHOOK_SECRET=whsec_your_webhook_secret
-# RESEND_AUDIENCE_ID=aud_...  # Required for newsletter feature (subscribe, list, broadcast)
+# RESEND_AUDIENCE_ID=aud_...  # Required for newsletter subscribers (subscribe, list)
+# RESEND_BROADCAST_SEGMENT_ID=seg_...  # Required to send newsletter broadcasts
 
 # Upstash Redis (without this, rate limiting is disabled)
 # UPSTASH_REDIS_REST_URL=https://[region].upstash.io

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,8 +28,9 @@ ADMIN_EMAILS=admin@example.com
 
 # Resend Email (without this, emails are logged to console)
 # RESEND_API_KEY=re_...
-# RESEND_FROM_EMAIL=noreply@yourdomain.com
+# RESEND_FROM_EMAIL=noreply@yourdomain.com  # Must be a verified sender domain in Resend (resend.dev addresses cannot send broadcasts)
 # RESEND_WEBHOOK_SECRET=whsec_your_webhook_secret
+# RESEND_AUDIENCE_ID=aud_...  # Required for newsletter feature (subscribe, list, broadcast)
 
 # Upstash Redis (without this, rate limiting is disabled)
 # UPSTASH_REDIS_REST_URL=https://[region].upstash.io

--- a/apps/web/src/__tests__/components/newsletter-email.test.tsx
+++ b/apps/web/src/__tests__/components/newsletter-email.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ *
+ * Node environment avoids the jsdom "browser" condition on react-dom/server
+ * which would otherwise select server.browser.js and require MessageChannel.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { render as renderEmail } from "@react-email/render";
+import { NewsletterEmail } from "@/components/emails/NewsletterEmail";
+
+const DEFAULT_PROPS = {
+  subject: "Monthly Update",
+  body: "First paragraph.\nSecond paragraph.",
+  supportEmail: "support@example.com",
+} as const;
+
+async function buildHtml(
+  overrides: Partial<Parameters<typeof NewsletterEmail>[0]> = {},
+): Promise<string> {
+  return renderEmail(NewsletterEmail({ ...DEFAULT_PROPS, ...overrides }));
+}
+
+describe("NewsletterEmail", () => {
+  it("includes the Resend personalisation variable {{{contact.first_name|there}}}", async () => {
+    const html = await buildHtml();
+    expect(html).toContain("{{{contact.first_name|there}}}");
+  });
+
+  it("includes the Resend unsubscribe URL variable {{{RESEND_UNSUBSCRIBE_URL}}}", async () => {
+    const html = await buildHtml();
+    expect(html).toContain("{{{RESEND_UNSUBSCRIBE_URL}}}");
+  });
+
+  it("renders the subject inside the email body", async () => {
+    const html = await buildHtml({ subject: "Summer Newsletter" });
+    expect(html).toContain("Summer Newsletter");
+  });
+
+  it("renders each non-empty body line", async () => {
+    const html = await buildHtml();
+    expect(html).toContain("First paragraph.");
+    expect(html).toContain("Second paragraph.");
+  });
+
+  it("renders the support email address and mailto link", async () => {
+    const html = await buildHtml({ supportEmail: "help@school.edu" });
+    expect(html).toContain("help@school.edu");
+    expect(html).toContain("mailto:help@school.edu");
+  });
+
+  it("skips blank body lines (renders br instead of p)", async () => {
+    const html = await buildHtml({ body: "Line one.\n\nLine two." });
+    expect(html).toContain("Line one.");
+    expect(html).toContain("Line two.");
+  });
+});

--- a/apps/web/src/__tests__/components/newsletter-signup.test.tsx
+++ b/apps/web/src/__tests__/components/newsletter-signup.test.tsx
@@ -1,0 +1,175 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// ESM modules — jest.unstable_mockModule (framer-motion ships .mjs)
+// Strip framer-motion-specific props so they don't pollute the real DOM.
+// ---------------------------------------------------------------------------
+const MOTION_PROPS = new Set([
+  "initial",
+  "animate",
+  "exit",
+  "whileInView",
+  "viewport",
+  "transition",
+  "variants",
+  "whileHover",
+  "whileTap",
+]);
+
+function stripMotionProps(
+  props: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !MOTION_PROPS.has(key)),
+  );
+}
+
+jest.unstable_mockModule("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: Record<string, unknown>) =>
+      React.createElement(
+        "div",
+        stripMotionProps(props),
+        children as React.ReactNode,
+      ),
+    p: ({ children, ...props }: Record<string, unknown>) =>
+      React.createElement(
+        "p",
+        stripMotionProps(props),
+        children as React.ReactNode,
+      ),
+  },
+}));
+
+jest.unstable_mockModule("@/lib/trpc", () => ({
+  trpc: {
+    newsletter: {
+      subscribe: {
+        useMutation: jest.fn(),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports after mocks
+// ---------------------------------------------------------------------------
+const trpcMod = await import("@/lib/trpc");
+const mockUseMutation = trpcMod.trpc.newsletter.subscribe
+  .useMutation as jest.Mock;
+
+const { default: NewsletterSignup } =
+  await import("@/components/landing/NewsletterSignup");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function setupMutation({
+  mutate = jest.fn(),
+  isPending = false,
+}: {
+  mutate?: jest.Mock;
+  isPending?: boolean;
+} = {}) {
+  mockUseMutation.mockReturnValue({ mutate, isPending });
+}
+
+function getForm(container: HTMLElement): HTMLFormElement {
+  return container.querySelector("form") as HTMLFormElement;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("NewsletterSignup", () => {
+  beforeEach(() => {
+    setupMutation();
+  });
+
+  it("renders the email input and subscribe button", () => {
+    render(React.createElement(NewsletterSignup));
+
+    expect(screen.getByRole("textbox", { name: /email/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /subscribe/i })).toBeDefined();
+  });
+
+  it("shows a validation error for an invalid email address", () => {
+    const { container } = render(React.createElement(NewsletterSignup));
+
+    fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.submit(getForm(container));
+
+    expect(screen.getByText(/valid email/i)).toBeDefined();
+  });
+
+  it("shows a validation error when the email field is empty", () => {
+    const { container } = render(React.createElement(NewsletterSignup));
+
+    fireEvent.submit(getForm(container));
+
+    expect(screen.getByText(/valid email/i)).toBeDefined();
+  });
+
+  it("calls trpc subscribe.mutate with the trimmed email", () => {
+    const mutate = jest.fn();
+    setupMutation({ mutate });
+
+    const { container } = render(React.createElement(NewsletterSignup));
+
+    fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+      target: { value: "  user@example.com  " },
+    });
+    fireEvent.submit(getForm(container));
+
+    expect(mutate).toHaveBeenCalledWith({ email: "user@example.com" });
+  });
+
+  it("disables the button while a request is pending", () => {
+    setupMutation({ isPending: true });
+
+    render(React.createElement(NewsletterSignup));
+
+    const button = screen.getByRole("button", { name: /subscribing/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows a success message when onSuccess is triggered", () => {
+    let capturedOnSuccess: (() => void) | undefined;
+    mockUseMutation.mockImplementation(
+      ({ onSuccess }: { onSuccess: () => void }) => {
+        capturedOnSuccess = onSuccess;
+        return { mutate: jest.fn(), isPending: false };
+      },
+    );
+
+    render(React.createElement(NewsletterSignup));
+
+    act(() => {
+      capturedOnSuccess!();
+    });
+
+    expect(screen.getByText(/subscribed|thank you/i)).toBeDefined();
+  });
+
+  it("shows an error message when onError is triggered", () => {
+    let capturedOnError: (() => void) | undefined;
+    mockUseMutation.mockImplementation(
+      ({ onError }: { onError: () => void }) => {
+        capturedOnError = onError;
+        return { mutate: jest.fn(), isPending: false };
+      },
+    );
+
+    render(React.createElement(NewsletterSignup));
+
+    act(() => {
+      capturedOnError!();
+    });
+
+    expect(screen.getByText(/failed to subscribe/i)).toBeDefined();
+  });
+});

--- a/apps/web/src/__tests__/components/newsletter-tab.test.tsx
+++ b/apps/web/src/__tests__/components/newsletter-tab.test.tsx
@@ -1,0 +1,155 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { NewsletterContact } from "@/lib/email";
+
+// ---------------------------------------------------------------------------
+// ESM modules — jest.unstable_mockModule (sonner ships .mjs)
+// ---------------------------------------------------------------------------
+jest.unstable_mockModule("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("@/lib/trpc", () => ({
+  trpc: {
+    newsletter: {
+      listSubscribers: {
+        useQuery: jest.fn(),
+      },
+      sendBroadcast: {
+        useMutation: jest.fn(),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports after mocks
+// ---------------------------------------------------------------------------
+const trpcMod = await import("@/lib/trpc");
+const mockUseQuery = trpcMod.trpc.newsletter.listSubscribers
+  .useQuery as jest.Mock;
+const mockUseMutation = trpcMod.trpc.newsletter.sendBroadcast
+  .useMutation as jest.Mock;
+
+const { NewsletterTab } = await import("@/components/admin/tabs/NewsletterTab");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function setupQuery(
+  overrides: {
+    data?: NewsletterContact[];
+    isLoading?: boolean;
+    isError?: boolean;
+  } = {},
+) {
+  mockUseQuery.mockReturnValue({
+    data: overrides.data,
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+  });
+}
+
+function setupMutation() {
+  mockUseMutation.mockReturnValue({ mutate: jest.fn(), isPending: false });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("NewsletterTab", () => {
+  beforeEach(() => {
+    setupQuery();
+    setupMutation();
+  });
+
+  it("renders a loading skeleton while the query is in-flight", () => {
+    setupQuery({ isLoading: true });
+
+    const { container } = render(React.createElement(NewsletterTab));
+
+    // TableSkeleton renders Skeleton divs with animate-pulse
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows the empty-state message when there are no subscribers", () => {
+    setupQuery({ data: [] });
+
+    render(React.createElement(NewsletterTab));
+
+    expect(screen.getByText(/no subscribers yet/i)).toBeDefined();
+  });
+
+  it("renders subscriber rows when data is present", () => {
+    const subscriber: NewsletterContact = {
+      id: "c-1",
+      email: "alice@example.com",
+      firstName: "Alice",
+      lastName: "Smith",
+      createdAt: "2024-01-15T00:00:00.000Z",
+      unsubscribed: false,
+    };
+    setupQuery({ data: [subscriber] });
+
+    render(React.createElement(NewsletterTab));
+
+    expect(screen.getByText("alice@example.com")).toBeDefined();
+    expect(screen.getByText(/alice smith/i)).toBeDefined();
+    // Both the table column header and the badge say "Subscribed"
+    expect(screen.getAllByText("Subscribed").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows Unsubscribed badge for contacts with unsubscribed=true", () => {
+    const subscriber: NewsletterContact = {
+      id: "c-2",
+      email: "bob@example.com",
+      firstName: null,
+      lastName: null,
+      createdAt: "2024-02-01T00:00:00.000Z",
+      unsubscribed: true,
+    };
+    setupQuery({ data: [subscriber] });
+
+    render(React.createElement(NewsletterTab));
+
+    expect(screen.getByText("Unsubscribed")).toBeDefined();
+  });
+
+  it("renders a dash when subscriber has no name", () => {
+    const subscriber: NewsletterContact = {
+      id: "c-3",
+      email: "carol@example.com",
+      firstName: null,
+      lastName: null,
+      createdAt: "2024-03-01T00:00:00.000Z",
+      unsubscribed: false,
+    };
+    setupQuery({ data: [subscriber] });
+
+    render(React.createElement(NewsletterTab));
+
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it("shows an error message when the subscriber query fails", () => {
+    setupQuery({ isError: true });
+
+    render(React.createElement(NewsletterTab));
+
+    expect(screen.getByText(/failed to load/i)).toBeDefined();
+  });
+
+  it("disables the Send Newsletter button when the query errored", () => {
+    setupQuery({ isError: true });
+
+    render(React.createElement(NewsletterTab));
+
+    const button = screen.getByRole("button", { name: /send newsletter/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/lib/email-newsletter-broadcast-env.test.ts
+++ b/apps/web/src/__tests__/lib/email-newsletter-broadcast-env.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ *
+ * Verifies newsletter contact operations use RESEND_AUDIENCE_ID while
+ * broadcasts require a separate RESEND_BROADCAST_SEGMENT_ID.
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+process.env.SKIP_ENV_VALIDATION = "1";
+
+const mockContactsCreate = jest.fn();
+const mockContactsList = jest.fn();
+
+jest.unstable_mockModule("resend", () => ({
+  Resend: jest.fn(() => ({
+    contacts: { create: mockContactsCreate, list: mockContactsList },
+  })),
+}));
+
+jest.unstable_mockModule("@/lib/env", () => ({
+  env: {
+    RESEND_API_KEY: "re_test_key",
+    RESEND_AUDIENCE_ID: "aud-test-123",
+    RESEND_FROM_EMAIL: "newsletter@example.com",
+    NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com",
+    ADMIN_EMAILS: "admin@example.com",
+  },
+  getAdminEmails: jest.fn(() => ["admin@example.com"]),
+  isServiceAvailable: jest.fn(() => false),
+}));
+
+jest.unstable_mockModule("@/lib/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.unstable_mockModule("@/lib/qstash", () => ({
+  publishEmailJob: jest.fn(),
+}));
+
+jest.unstable_mockModule("@teachanything/db", () => ({
+  db: {
+    insert: jest.fn(),
+    update: jest.fn(),
+    select: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("@teachanything/db/schema", () => ({
+  user: {},
+  emailDeliveries: {},
+  emailTypeEnum: { enumValues: [] },
+}));
+
+const {
+  subscribeToNewsletter,
+  listNewsletterSubscribers,
+  sendNewsletterBroadcast,
+} = await import("@/lib/email");
+
+const resendMod = await import("resend");
+const MockResend = resendMod.Resend as jest.Mock;
+
+describe("newsletter broadcast segment env", () => {
+  beforeEach(() => {
+    MockResend.mockImplementation(() => ({
+      contacts: { create: mockContactsCreate, list: mockContactsList },
+    }));
+  });
+
+  it("keeps contact operations on RESEND_AUDIENCE_ID without a segment id", async () => {
+    mockContactsCreate.mockResolvedValueOnce({ data: null, error: null });
+    mockContactsList.mockResolvedValueOnce({ data: { data: [] }, error: null });
+
+    await expect(
+      subscribeToNewsletter({ email: "user@example.com" }),
+    ).resolves.toBeUndefined();
+    await expect(listNewsletterSubscribers()).resolves.toEqual([]);
+
+    expect(mockContactsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ audienceId: "aud-test-123" }),
+    );
+    expect(mockContactsList).toHaveBeenCalledWith({
+      audienceId: "aud-test-123",
+    });
+  });
+
+  it("requires RESEND_BROADCAST_SEGMENT_ID for newsletter broadcasts", async () => {
+    await expect(
+      sendNewsletterBroadcast({ subject: "Sub", body: "Body" }),
+    ).rejects.toThrow("RESEND_BROADCAST_SEGMENT_ID is not configured");
+  });
+});

--- a/apps/web/src/__tests__/lib/email-newsletter-env.test.ts
+++ b/apps/web/src/__tests__/lib/email-newsletter-env.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ *
+ * Verifies the split env-validation paths introduced in email.ts:
+ *   - requireContactEnv  — used by subscribe + list (needs AUDIENCE_ID only)
+ *   - requireBroadcastEnv — used by sendBroadcast  (needs AUDIENCE_ID + FROM_EMAIL)
+ *
+ * This file mocks RESEND_FROM_EMAIL as absent so we can confirm that:
+ *   • subscribeToNewsletter succeeds (does NOT require FROM_EMAIL)
+ *   • listNewsletterSubscribers succeeds (does NOT require FROM_EMAIL)
+ *   • sendNewsletterBroadcast throws "RESEND_FROM_EMAIL is not configured"
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+process.env.SKIP_ENV_VALIDATION = "1";
+
+// ---------------------------------------------------------------------------
+// Module-level mock functions
+// ---------------------------------------------------------------------------
+const mockContactsCreate = jest.fn();
+const mockContactsList = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Mocks — RESEND_FROM_EMAIL intentionally absent
+// ---------------------------------------------------------------------------
+jest.unstable_mockModule("resend", () => ({
+  Resend: jest.fn(() => ({
+    contacts: { create: mockContactsCreate, list: mockContactsList },
+  })),
+}));
+
+jest.unstable_mockModule("@/lib/env", () => ({
+  env: {
+    RESEND_API_KEY: "re_test_key",
+    RESEND_AUDIENCE_ID: "aud-test-123",
+    // RESEND_FROM_EMAIL is intentionally absent to test the split
+    NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com",
+    ADMIN_EMAILS: "admin@example.com",
+  },
+  getAdminEmails: jest.fn(() => ["admin@example.com"]),
+  isServiceAvailable: jest.fn(() => false),
+}));
+
+jest.unstable_mockModule("@/lib/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.unstable_mockModule("@/lib/qstash", () => ({
+  publishEmailJob: jest.fn(),
+}));
+
+jest.unstable_mockModule("@teachanything/db", () => ({
+  db: {
+    insert: jest.fn(),
+    update: jest.fn(),
+    select: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("@teachanything/db/schema", () => ({
+  user: {},
+  emailDeliveries: {},
+  emailTypeEnum: { enumValues: [] },
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports — must come after all unstable_mockModule calls
+// ---------------------------------------------------------------------------
+const {
+  subscribeToNewsletter,
+  listNewsletterSubscribers,
+  sendNewsletterBroadcast,
+} = await import("@/lib/email");
+
+const resendMod = await import("resend");
+const MockResend = resendMod.Resend as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("env validation split — contact-only path (no FROM_EMAIL)", () => {
+  beforeEach(() => {
+    MockResend.mockImplementation(() => ({
+      contacts: { create: mockContactsCreate, list: mockContactsList },
+    }));
+  });
+
+  it("subscribeToNewsletter succeeds when RESEND_FROM_EMAIL is absent", async () => {
+    mockContactsCreate.mockResolvedValueOnce({ data: null, error: null });
+
+    await expect(
+      subscribeToNewsletter({ email: "user@example.com" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockContactsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ audienceId: "aud-test-123" }),
+    );
+  });
+
+  it("listNewsletterSubscribers succeeds when RESEND_FROM_EMAIL is absent", async () => {
+    mockContactsList.mockResolvedValueOnce({ data: { data: [] }, error: null });
+
+    await expect(listNewsletterSubscribers()).resolves.toEqual([]);
+  });
+});
+
+describe("env validation split — broadcast path requires FROM_EMAIL", () => {
+  it("sendNewsletterBroadcast throws when RESEND_FROM_EMAIL is absent", async () => {
+    await expect(
+      sendNewsletterBroadcast({ subject: "Sub", body: "Body" }),
+    ).rejects.toThrow("RESEND_FROM_EMAIL is not configured");
+  });
+});

--- a/apps/web/src/__tests__/lib/email-newsletter-env.test.ts
+++ b/apps/web/src/__tests__/lib/email-newsletter-env.test.ts
@@ -3,7 +3,7 @@
  *
  * Verifies the split env-validation paths introduced in email.ts:
  *   - requireContactEnv  — used by subscribe + list (needs AUDIENCE_ID only)
- *   - requireBroadcastEnv — used by sendBroadcast  (needs AUDIENCE_ID + FROM_EMAIL)
+ *   - requireBroadcastEnv — used by sendBroadcast  (needs SEGMENT_ID + FROM_EMAIL)
  *
  * This file mocks RESEND_FROM_EMAIL as absent so we can confirm that:
  *   • subscribeToNewsletter succeeds (does NOT require FROM_EMAIL)
@@ -34,6 +34,7 @@ jest.unstable_mockModule("@/lib/env", () => ({
   env: {
     RESEND_API_KEY: "re_test_key",
     RESEND_AUDIENCE_ID: "aud-test-123",
+    RESEND_BROADCAST_SEGMENT_ID: "seg-test-456",
     // RESEND_FROM_EMAIL is intentionally absent to test the split
     NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com",
     ADMIN_EMAILS: "admin@example.com",

--- a/apps/web/src/__tests__/lib/email-newsletter.test.ts
+++ b/apps/web/src/__tests__/lib/email-newsletter.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment node
+ *
+ * Node environment avoids jsdom browser-condition resolution on react-dom/server.
+ * We also prevent @teachanything/db from throwing by setting the env vars before
+ * module evaluation, and mock the whole package with jest.unstable_mockModule so
+ * the real postgres connection is never attempted.
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+// Prevent packages/db/src/db.ts from throwing at import time
+process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+process.env.SKIP_ENV_VALIDATION = "1";
+
+// ---------------------------------------------------------------------------
+// Module-level mock functions (captured by reference in factory closures)
+// ---------------------------------------------------------------------------
+const mockContactsCreate = jest.fn();
+const mockContactsList = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Mocks — use jest.unstable_mockModule for ESM-compiled local/monorepo modules
+// ---------------------------------------------------------------------------
+
+jest.unstable_mockModule("resend", () => ({
+  Resend: jest.fn(() => ({
+    contacts: { create: mockContactsCreate, list: mockContactsList },
+  })),
+}));
+
+jest.unstable_mockModule("@/lib/env", () => ({
+  env: {
+    RESEND_API_KEY: "re_test_key",
+    RESEND_AUDIENCE_ID: "aud-test-123",
+    RESEND_FROM_EMAIL: "newsletter@example.com",
+    NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com",
+    ADMIN_EMAILS: "admin@example.com",
+  },
+  getAdminEmails: jest.fn(() => ["admin@example.com"]),
+  isServiceAvailable: jest.fn(() => false),
+}));
+
+jest.unstable_mockModule("@/lib/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.unstable_mockModule("@/lib/qstash", () => ({
+  publishEmailJob: jest.fn(),
+}));
+
+jest.unstable_mockModule("@teachanything/db", () => ({
+  db: {
+    insert: jest.fn(),
+    update: jest.fn(),
+    select: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("@teachanything/db/schema", () => ({
+  user: {},
+  emailDeliveries: {},
+  emailTypeEnum: { enumValues: [] },
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports — must come after all unstable_mockModule calls
+// ---------------------------------------------------------------------------
+
+const {
+  subscribeToNewsletter,
+  listNewsletterSubscribers,
+  sendNewsletterBroadcast,
+} = await import("@/lib/email");
+
+const resendMod = await import("resend");
+const MockResend = resendMod.Resend as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// subscribeToNewsletter
+// ---------------------------------------------------------------------------
+
+describe("subscribeToNewsletter", () => {
+  beforeEach(() => {
+    // resetMocks:true clears implementations between tests; re-establish Resend
+    MockResend.mockImplementation(() => ({
+      contacts: { create: mockContactsCreate, list: mockContactsList },
+    }));
+  });
+
+  it("calls contacts.create with audienceId and email", async () => {
+    mockContactsCreate.mockResolvedValueOnce({ data: null, error: null });
+
+    await subscribeToNewsletter({ email: "user@example.com" });
+
+    expect(mockContactsCreate).toHaveBeenCalledWith({
+      audienceId: "aud-test-123",
+      email: "user@example.com",
+      firstName: undefined,
+      unsubscribed: false,
+    });
+  });
+
+  it("passes optional firstName to contacts.create", async () => {
+    mockContactsCreate.mockResolvedValueOnce({ data: null, error: null });
+
+    await subscribeToNewsletter({
+      email: "user@example.com",
+      firstName: "Alice",
+    });
+
+    expect(mockContactsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "Alice" }),
+    );
+  });
+
+  it("throws when Resend returns an error", async () => {
+    mockContactsCreate.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Contact already exists", name: "conflict_error" },
+    });
+
+    await expect(
+      subscribeToNewsletter({ email: "user@example.com" }),
+    ).rejects.toThrow("Contact already exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listNewsletterSubscribers
+// ---------------------------------------------------------------------------
+
+type RawResendContact = {
+  id: string;
+  email: string;
+  first_name: string | undefined;
+  last_name: string | undefined;
+  created_at: string;
+  unsubscribed: boolean;
+};
+
+describe("listNewsletterSubscribers", () => {
+  beforeEach(() => {
+    MockResend.mockImplementation(() => ({
+      contacts: { create: mockContactsCreate, list: mockContactsList },
+    }));
+  });
+
+  it("maps Resend contact fields to NewsletterContact shape", async () => {
+    const raw: RawResendContact = {
+      id: "contact-1",
+      email: "alice@example.com",
+      first_name: "Alice",
+      last_name: "Smith",
+      created_at: "2024-01-15T00:00:00.000Z",
+      unsubscribed: false,
+    };
+    mockContactsList.mockResolvedValueOnce({
+      data: { data: [raw] },
+      error: null,
+    });
+
+    const result = await listNewsletterSubscribers();
+
+    expect(result).toEqual([
+      {
+        id: "contact-1",
+        email: "alice@example.com",
+        firstName: "Alice",
+        lastName: "Smith",
+        createdAt: "2024-01-15T00:00:00.000Z",
+        unsubscribed: false,
+      },
+    ]);
+  });
+
+  it("maps missing name fields to null", async () => {
+    const raw: RawResendContact = {
+      id: "contact-2",
+      email: "bob@example.com",
+      first_name: undefined,
+      last_name: undefined,
+      created_at: "2024-02-01T00:00:00.000Z",
+      unsubscribed: true,
+    };
+    mockContactsList.mockResolvedValueOnce({
+      data: { data: [raw] },
+      error: null,
+    });
+
+    const result = await listNewsletterSubscribers();
+
+    expect(result[0]!.firstName).toBeNull();
+    expect(result[0]!.lastName).toBeNull();
+  });
+
+  it("returns an empty array when data.data is absent", async () => {
+    mockContactsList.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await listNewsletterSubscribers();
+    expect(result).toEqual([]);
+  });
+
+  it("throws when Resend returns an error", async () => {
+    mockContactsList.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Audience not found", name: "not_found_error" },
+    });
+
+    await expect(listNewsletterSubscribers()).rejects.toThrow(
+      "Audience not found",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendNewsletterBroadcast
+// ---------------------------------------------------------------------------
+
+describe("sendNewsletterBroadcast", () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it("POSTs to the Resend broadcasts endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "broadcast-abc" }),
+    });
+
+    await sendNewsletterBroadcast({
+      subject: "Test Subject",
+      body: "Test body",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.resend.com/broadcasts",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("builds the correct broadcast request body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "broadcast-abc" }),
+    });
+
+    await sendNewsletterBroadcast({
+      subject: "Test Subject",
+      body: "Test body",
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    expect(body.segment_id).toBe("aud-test-123");
+    expect(body.send).toBe(true);
+    expect(body.subject).toBe("Test Subject");
+    expect(typeof body.from).toBe("string");
+    expect(body.from as string).toContain("newsletter@example.com");
+    expect(typeof body.html).toBe("string");
+  });
+
+  it("returns the broadcastId from a successful Resend response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "broadcast-xyz" }),
+    });
+
+    const result = await sendNewsletterBroadcast({
+      subject: "Sub",
+      body: "Body",
+    });
+
+    expect(result).toEqual({ broadcastId: "broadcast-xyz" });
+  });
+
+  it("throws when Resend returns an error payload", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({
+        statusCode: 422,
+        message: "Domain not verified",
+        name: "validation_error",
+      }),
+    });
+
+    await expect(
+      sendNewsletterBroadcast({ subject: "Sub", body: "Body" }),
+    ).rejects.toThrow("Domain not verified");
+  });
+
+  it("throws a network-error message when fetch itself rejects", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Failed to fetch"));
+
+    await expect(
+      sendNewsletterBroadcast({ subject: "Sub", body: "Body" }),
+    ).rejects.toThrow(/network error/i);
+  });
+
+  it("includes the Bearer token in the Authorization header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "broadcast-abc" }),
+    });
+
+    await sendNewsletterBroadcast({ subject: "Sub", body: "Body" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer re_test_key");
+  });
+});

--- a/apps/web/src/__tests__/lib/email-newsletter.test.ts
+++ b/apps/web/src/__tests__/lib/email-newsletter.test.ts
@@ -32,6 +32,7 @@ jest.unstable_mockModule("@/lib/env", () => ({
   env: {
     RESEND_API_KEY: "re_test_key",
     RESEND_AUDIENCE_ID: "aud-test-123",
+    RESEND_BROADCAST_SEGMENT_ID: "seg-test-456",
     RESEND_FROM_EMAIL: "newsletter@example.com",
     NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com",
     ADMIN_EMAILS: "admin@example.com",
@@ -257,7 +258,7 @@ describe("sendNewsletterBroadcast", () => {
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
 
-    expect(body.segment_id).toBe("aud-test-123");
+    expect(body.segment_id).toBe("seg-test-456");
     expect(body.send).toBe(true);
     expect(body.subject).toBe("Test Subject");
     expect(typeof body.from).toBe("string");

--- a/apps/web/src/__tests__/lib/env.test.ts
+++ b/apps/web/src/__tests__/lib/env.test.ts
@@ -35,6 +35,7 @@ const envSchema = z.object({
   RESEND_FROM_EMAIL: z.string().email().optional(),
   RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
   RESEND_AUDIENCE_ID: z.string().min(1).optional(),
+  RESEND_BROADCAST_SEGMENT_ID: z.string().min(1).optional(),
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
   QSTASH_URL: z.string().url().optional(),

--- a/apps/web/src/__tests__/lib/env.test.ts
+++ b/apps/web/src/__tests__/lib/env.test.ts
@@ -34,6 +34,7 @@ const envSchema = z.object({
   RESEND_API_KEY: z.string().min(1).optional(),
   RESEND_FROM_EMAIL: z.string().email().optional(),
   RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
+  RESEND_AUDIENCE_ID: z.string().min(1).optional(),
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
   QSTASH_URL: z.string().url().optional(),
@@ -136,7 +137,7 @@ describe("env schema validation", () => {
 
 describe("env helper logic", () => {
   // Test the pure logic of the helper functions without importing env.ts
-  // (env.ts module-level side effects make it hard to test in jsdom)
+  // ( module-level side effects make it hard to test in jsdom)
 
   it("getApprovedDomains splits and trims correctly", () => {
     const raw = " .edu , .ac.in , .edu.in ";

--- a/apps/web/src/__tests__/lib/env.test.ts
+++ b/apps/web/src/__tests__/lib/env.test.ts
@@ -137,7 +137,6 @@ describe("env schema validation", () => {
 
 describe("env helper logic", () => {
   // Test the pure logic of the helper functions without importing env.ts
-  // ( module-level side effects make it hard to test in jsdom)
 
   it("getApprovedDomains splits and trims correctly", () => {
     const raw = " .edu , .ac.in , .edu.in ";

--- a/apps/web/src/__tests__/server/newsletter-router.test.ts
+++ b/apps/web/src/__tests__/server/newsletter-router.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Newsletter router — input validation tests.
+ *
+ * The router itself delegates to external services (Resend) and relies on the
+ * tRPC middleware for authentication. Instead of spinning up a full tRPC
+ * caller we mirror the Zod schemas from newsletter.ts and verify they accept
+ * and reject the right shapes — the same technique used in env.test.ts.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { z } from "zod";
+
+// Mirror of the subscribe input schema in newsletter.ts
+const subscribeInput = z.object({
+  email: z.string().email(),
+  firstName: z.string().trim().max(100).optional(),
+});
+
+// Mirror of the sendBroadcast input schema in newsletter.ts
+const sendBroadcastInput = z.object({
+  subject: z.string().min(1).max(200),
+  body: z.string().min(1).max(50000),
+});
+
+describe("newsletter router — subscribe input", () => {
+  it("accepts a valid email address", () => {
+    expect(() =>
+      subscribeInput.parse({ email: "user@example.com" }),
+    ).not.toThrow();
+  });
+
+  it("rejects a non-email string", () => {
+    expect(() => subscribeInput.parse({ email: "not-an-email" })).toThrow();
+  });
+
+  it("accepts an optional firstName", () => {
+    const result = subscribeInput.parse({
+      email: "user@example.com",
+      firstName: "Alice",
+    });
+    expect(result.firstName).toBe("Alice");
+  });
+
+  it("trims whitespace from firstName", () => {
+    const result = subscribeInput.parse({
+      email: "user@example.com",
+      firstName: "  Alice  ",
+    });
+    expect(result.firstName).toBe("Alice");
+  });
+
+  it("rejects firstName longer than 100 characters", () => {
+    expect(() =>
+      subscribeInput.parse({
+        email: "user@example.com",
+        firstName: "A".repeat(101),
+      }),
+    ).toThrow();
+  });
+
+  it("accepts firstName at exactly 100 characters", () => {
+    expect(() =>
+      subscribeInput.parse({
+        email: "user@example.com",
+        firstName: "A".repeat(100),
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limit IP extraction (mirrors logic in newsletter.ts subscribe handler)
+// ---------------------------------------------------------------------------
+describe("newsletter router — rate limit IP extraction", () => {
+  it("uses the first address from a comma-separated x-forwarded-for header", () => {
+    const header = "203.0.113.1, 10.0.0.1, 192.168.1.1";
+    const clientIp = header.split(",")[0]?.trim() ?? "unknown";
+    expect(clientIp).toBe("203.0.113.1");
+  });
+
+  it("trims whitespace from the extracted IP", () => {
+    const header = "  203.0.113.5  , 10.0.0.2";
+    const clientIp = header.split(",")[0]?.trim() ?? "unknown";
+    expect(clientIp).toBe("203.0.113.5");
+  });
+
+  it("falls back to 'unknown' when x-forwarded-for is absent", () => {
+    const header: string | undefined = undefined;
+    const clientIp = header?.split(",")[0]?.trim() ?? "unknown";
+    expect(clientIp).toBe("unknown");
+  });
+});
+
+describe("newsletter router — sendBroadcast input", () => {
+  it("accepts valid subject and body", () => {
+    expect(() =>
+      sendBroadcastInput.parse({ subject: "Hello", body: "World" }),
+    ).not.toThrow();
+  });
+
+  it("rejects an empty subject", () => {
+    expect(() =>
+      sendBroadcastInput.parse({ subject: "", body: "Body" }),
+    ).toThrow();
+  });
+
+  it("rejects a subject exceeding 200 characters", () => {
+    expect(() =>
+      sendBroadcastInput.parse({ subject: "S".repeat(201), body: "Body" }),
+    ).toThrow();
+  });
+
+  it("accepts a subject at exactly 200 characters", () => {
+    expect(() =>
+      sendBroadcastInput.parse({ subject: "S".repeat(200), body: "Body" }),
+    ).not.toThrow();
+  });
+
+  it("rejects an empty body", () => {
+    expect(() =>
+      sendBroadcastInput.parse({ subject: "Subject", body: "" }),
+    ).toThrow();
+  });
+
+  it("rejects body exceeding 50000 characters", () => {
+    expect(() =>
+      sendBroadcastInput.parse({
+        subject: "Subject",
+        body: "B".repeat(50001),
+      }),
+    ).toThrow();
+  });
+
+  it("accepts body at exactly 50000 characters", () => {
+    expect(() =>
+      sendBroadcastInput.parse({
+        subject: "Subject",
+        body: "B".repeat(50000),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -7,6 +7,7 @@ import { PendingUsersTab } from "@/components/admin/tabs/PendingUsersTab";
 import { AllChatbotsTab } from "@/components/admin/tabs/AllChatbotsTab";
 import { AllowedDomainsTab } from "@/components/admin/tabs/AllowedDomainsTab";
 import { AllUsersTab } from "@/components/admin/tabs/AllUsersTab";
+import { NewsletterTab } from "@/components/admin/tabs/NewsletterTab";
 import { Shield, Download } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
@@ -149,6 +150,12 @@ export default function AdminPage() {
             >
               Domains
             </TabsTrigger>
+            <TabsTrigger
+              value="newsletter"
+              className="text-xs md:text-sm flex-1 min-w-fit"
+            >
+              Newsletter
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="users" className="mt-6">
@@ -165,6 +172,10 @@ export default function AdminPage() {
 
           <TabsContent value="domains" className="mt-6">
             <AllowedDomainsTab />
+          </TabsContent>
+
+          <TabsContent value="newsletter" className="mt-6">
+            <NewsletterTab />
           </TabsContent>
         </Tabs>
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,6 +8,7 @@ import TechnologySection from "@/components/landing/TechnologySection";
 import ComparisonSection from "@/components/landing/ComparisonSection";
 import InfoSection from "@/components/landing/InfoSection";
 import SupportUsSection from "@/components/landing/SupportUsSection";
+import NewsletterSignup from "@/components/landing/NewsletterSignup";
 import Footer from "@/components/landing/Footer";
 
 export default function HomePage() {
@@ -33,6 +34,8 @@ export default function HomePage() {
       <InfoSection />
       {/* Support Us Section */}
       <SupportUsSection />
+      {/* Newsletter Signup */}
+      <NewsletterSignup />
       {/* Footer */}
       <Footer />
     </div>

--- a/apps/web/src/components/admin/tabs/NewsletterTab.tsx
+++ b/apps/web/src/components/admin/tabs/NewsletterTab.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+import { StatsHeader } from "../components/StatsHeader";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TableSkeleton } from "@/components/ui/skeletons";
+import { Send } from "lucide-react";
+
+export function NewsletterTab() {
+  const [search, setSearch] = useState("");
+  const [sendDialogOpen, setSendDialogOpen] = useState(false);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+
+  const {
+    data: subscribers,
+    isLoading,
+    isError: isSubscribersError,
+  } = trpc.newsletter.listSubscribers.useQuery();
+
+  const sendBroadcast = trpc.newsletter.sendBroadcast.useMutation({
+    onSuccess: () => {
+      toast.success("Newsletter sent successfully");
+      setSendDialogOpen(false);
+      setSubject("");
+      setBody("");
+    },
+    onError: () => {
+      toast.error(
+        "Newsletter could not be sent. Check Resend sender domain configuration.",
+      );
+    },
+  });
+
+  const handleSend = () => {
+    if (!subject.trim()) {
+      toast.error("Subject is required");
+      return;
+    }
+    if (!body.trim()) {
+      toast.error("Body is required");
+      return;
+    }
+    sendBroadcast.mutate({ subject: subject.trim(), body: body.trim() });
+  };
+
+  const filtered = (subscribers ?? []).filter(
+    (s) =>
+      !search ||
+      s.email.toLowerCase().includes(search.toLowerCase()) ||
+      (s.firstName ?? "").toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const activeCount = (subscribers ?? []).filter((s) => !s.unsubscribed).length;
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="pb-4">
+          <StatsHeader
+            title="Newsletter"
+            description="Manage subscribers and send newsletters via Resend"
+            stats={[
+              {
+                value: activeCount,
+                label: "Active subscribers",
+                highlight: true,
+              },
+              {
+                value: (subscribers ?? []).length,
+                label: "Total contacts",
+              },
+            ]}
+          />
+        </CardHeader>
+        <CardContent>
+          {/* Actions toolbar */}
+          <div className="flex flex-col sm:flex-row gap-3 mb-6 justify-between items-start sm:items-center">
+            <Input
+              placeholder="Search subscribers..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="max-w-xs"
+            />
+            <Button
+              onClick={() => setSendDialogOpen(true)}
+              disabled={isSubscribersError}
+              title={
+                isSubscribersError
+                  ? "Subscriber list failed to load"
+                  : undefined
+              }
+            >
+              <Send className="mr-2 h-4 w-4" />
+              Send Newsletter
+            </Button>
+          </div>
+
+          {/* Subscriber table */}
+          {isLoading ? (
+            <TableSkeleton
+              header={
+                <>
+                  <Skeleton className="h-4 w-40 shrink-0" />
+                  <Skeleton className="h-4 w-24 shrink-0 hidden sm:block" />
+                  <Skeleton className="h-4 w-20 shrink-0 hidden md:block" />
+                  <Skeleton className="h-4 w-16 shrink-0 ml-auto" />
+                </>
+              }
+              row={
+                <>
+                  <Skeleton className="h-4 w-48 shrink-0" />
+                  <Skeleton className="h-4 w-24 shrink-0 hidden sm:block" />
+                  <Skeleton className="h-4 w-20 shrink-0 hidden md:block" />
+                  <Skeleton className="h-5 w-20 rounded-full shrink-0 ml-auto" />
+                </>
+              }
+            />
+          ) : filtered.length === 0 ? (
+            <div className="text-center py-10 text-muted-foreground">
+              {search
+                ? "No subscribers match your search."
+                : "No subscribers yet. Share the newsletter signup on your homepage!"}
+            </div>
+          ) : (
+            <div className="border rounded-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead className="hidden sm:table-cell">Name</TableHead>
+                    <TableHead className="hidden md:table-cell">
+                      Subscribed
+                    </TableHead>
+                    <TableHead className="text-right">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((subscriber) => (
+                    <TableRow key={subscriber.id}>
+                      <TableCell className="font-medium">
+                        {subscriber.email}
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell text-muted-foreground">
+                        {subscriber.firstName
+                          ? `${subscriber.firstName}${subscriber.lastName ? " " + subscriber.lastName : ""}`
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
+                        {new Date(subscriber.createdAt).toLocaleDateString(
+                          "en-US",
+                          {
+                            year: "numeric",
+                            month: "short",
+                            day: "numeric",
+                          },
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Badge
+                          variant={
+                            subscriber.unsubscribed ? "secondary" : "default"
+                          }
+                        >
+                          {subscriber.unsubscribed
+                            ? "Unsubscribed"
+                            : "Subscribed"}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Send newsletter dialog */}
+      <Dialog open={sendDialogOpen} onOpenChange={setSendDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Send Newsletter</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="nl-subject">Subject</Label>
+              <Input
+                id="nl-subject"
+                placeholder="Your newsletter subject"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                disabled={sendBroadcast.isPending}
+                maxLength={200}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="nl-body">Body</Label>
+              <Textarea
+                id="nl-body"
+                placeholder="Write your newsletter content here..."
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                disabled={sendBroadcast.isPending}
+                rows={8}
+                className="resize-none"
+              />
+              <p className="text-xs text-muted-foreground">
+                Plain text. Each line becomes a paragraph.
+              </p>
+            </div>
+
+            {/* Preview */}
+            {(subject || body) && (
+              <div className="rounded-md border bg-muted/40 p-4 space-y-2">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                  Preview
+                </p>
+                {subject && <p className="font-semibold text-sm">{subject}</p>}
+                {body && (
+                  <p className="text-sm text-muted-foreground whitespace-pre-wrap line-clamp-4">
+                    {body}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              {subscribers !== undefined ? (
+                <>
+                  This will send to{" "}
+                  <strong>
+                    {activeCount} active subscriber
+                    {activeCount !== 1 ? "s" : ""}
+                  </strong>{" "}
+                  via Resend. Resend handles unsubscribe links automatically.
+                </>
+              ) : (
+                "Subscriber count unavailable. Resend handles unsubscribe links automatically."
+              )}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setSendDialogOpen(false)}
+              disabled={sendBroadcast.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={
+                sendBroadcast.isPending || !subject.trim() || !body.trim()
+              }
+            >
+              {sendBroadcast.isPending ? "Sending..." : "Send"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/admin/tabs/NewsletterTab.tsx
+++ b/apps/web/src/components/admin/tabs/NewsletterTab.tsx
@@ -139,6 +139,10 @@ export function NewsletterTab() {
                 </>
               }
             />
+          ) : isSubscribersError ? (
+            <div className="text-center py-10 text-destructive">
+              Failed to load subscribers. Please refresh and try again.
+            </div>
           ) : filtered.length === 0 ? (
             <div className="text-center py-10 text-muted-foreground">
               {search

--- a/apps/web/src/components/emails/NewsletterEmail.tsx
+++ b/apps/web/src/components/emails/NewsletterEmail.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+
+interface NewsletterEmailProps {
+  subject: string;
+  body: string;
+  supportEmail: string;
+}
+
+export function NewsletterEmail({
+  subject,
+  body,
+  supportEmail,
+}: NewsletterEmailProps) {
+  return (
+    <html>
+      {/* eslint-disable-next-line @next/next/no-head-element */}
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </head>
+      <body style={bodyStyle}>
+        <table
+          role="presentation"
+          style={wrapper}
+          cellPadding="0"
+          cellSpacing="0"
+          border={0}
+        >
+          <tr>
+            <td style={cell}>
+              {/* {{{contact.first_name|there}}} is a Resend personalization
+                  variable replaced per-recipient at send time. */}
+              <p style={text}>Hi {"{{{contact.first_name|there}}}"},</p>
+
+              <h1 style={heading}>{subject}</h1>
+
+              {body.split("\n").map((line, i) =>
+                line.trim() ? (
+                  <p key={i} style={text}>
+                    {line}
+                  </p>
+                ) : (
+                  <br key={i} />
+                ),
+              )}
+
+              <p style={signature}>
+                Best regards,
+                <br />
+                Teach Anything™ Team
+              </p>
+
+              <p style={footer}>
+                For questions or support, contact us at{" "}
+                <a href={`mailto:${supportEmail}`} style={link}>
+                  {supportEmail}
+                </a>
+                .
+                <br />
+                <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style={unsubscribeLink}>
+                  Unsubscribe from this newsletter
+                </a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>
+  );
+}
+
+export default NewsletterEmail;
+
+const bodyStyle = {
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: "16px",
+  lineHeight: "1.6",
+  color: "#333333",
+  backgroundColor: "#ffffff",
+  margin: 0,
+  padding: "20px",
+};
+
+const wrapper = {
+  maxWidth: "600px",
+  margin: "0 auto",
+};
+
+const cell = {
+  padding: "20px 0",
+};
+
+const heading = {
+  margin: "0 0 24px",
+  color: "#111111",
+  fontSize: "24px",
+  fontWeight: "600" as const,
+  lineHeight: "1.3",
+};
+
+const text = {
+  margin: "0 0 16px",
+  color: "#333333",
+  fontSize: "16px",
+  lineHeight: "1.6",
+};
+
+const link = {
+  color: "#0066cc",
+  textDecoration: "underline",
+};
+
+const signature = {
+  margin: "24px 0 0",
+  color: "#333333",
+  fontSize: "16px",
+  lineHeight: "1.6",
+};
+
+const footer = {
+  margin: "24px 0 0",
+  padding: "16px 0 0",
+  borderTop: "1px solid #e9ecef",
+  color: "#666666",
+  fontSize: "12px",
+  lineHeight: "1.5",
+};
+
+const unsubscribeLink = {
+  color: "#666666",
+  textDecoration: "underline",
+};

--- a/apps/web/src/components/landing/NewsletterSignup.tsx
+++ b/apps/web/src/components/landing/NewsletterSignup.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc";
+import { Mail } from "lucide-react";
+
+export default function NewsletterSignup() {
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const subscribe = trpc.newsletter.subscribe.useMutation({
+    onSuccess: () => {
+      setSubmitted(true);
+      setEmail("");
+      setErrorMsg("");
+    },
+    onError: () => {
+      setErrorMsg("Failed to subscribe. Please try again.");
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMsg("");
+    const trimmed = email.trim();
+    if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setErrorMsg("Please enter a valid email address.");
+      return;
+    }
+    subscribe.mutate({ email: trimmed });
+  };
+
+  return (
+    <section className="py-20 px-6 md:px-12 bg-muted/30 border-t border-border">
+      <div className="max-w-2xl mx-auto text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className="flex justify-center mb-4">
+            <span className="inline-flex items-center justify-center rounded-full bg-primary/10 p-3">
+              <Mail className="h-6 w-6 text-primary" />
+            </span>
+          </div>
+
+          <h2 className="text-3xl md:text-4xl font-serif font-light text-foreground mb-3 leading-tight">
+            Stay in the loop
+          </h2>
+          <p className="text-muted-foreground text-base mb-8 leading-[1.8]">
+            Get updates on new features, research, and best practices for
+            AI-powered teaching — straight to your inbox.
+          </p>
+
+          {submitted ? (
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="text-green-600 font-medium"
+            >
+              You&apos;re subscribed! Thank you for joining.
+            </motion.p>
+          ) : (
+            <form
+              onSubmit={handleSubmit}
+              className="flex flex-col sm:flex-row gap-3 justify-center items-start max-w-md mx-auto"
+            >
+              <div className="flex-1 w-full">
+                <Input
+                  type="email"
+                  placeholder="your@email.edu"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={subscribe.isPending}
+                  className="w-full"
+                  aria-label="Email address"
+                />
+                {errorMsg && (
+                  <p className="mt-1.5 text-sm text-destructive text-left">
+                    {errorMsg}
+                  </p>
+                )}
+              </div>
+              <Button
+                type="submit"
+                disabled={subscribe.isPending}
+                className="shrink-0 w-full sm:w-auto"
+              >
+                {subscribe.isPending ? "Subscribing..." : "Subscribe"}
+              </Button>
+            </form>
+          )}
+
+          <p className="text-xs text-muted-foreground mt-4">
+            No spam. Unsubscribe any time.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -1,4 +1,5 @@
 import { render } from "@react-email/render";
+import { Resend } from "resend";
 import { env, getAdminEmails, isServiceAvailable } from "./env";
 import { logInfo, logError } from "./logger";
 import { publishEmailJob } from "./qstash";
@@ -11,6 +12,7 @@ import { AccountDisabled } from "@/components/emails/AccountDisabled";
 import { AccountEnabled } from "@/components/emails/AccountEnabled";
 import { AccountDeleted } from "@/components/emails/AccountDeleted";
 import { PasswordReset } from "@/components/emails/PasswordReset";
+import { NewsletterEmail } from "@/components/emails/NewsletterEmail";
 import { db } from "@teachanything/db";
 import {
   user,
@@ -350,4 +352,194 @@ export async function sendPasswordResetEmail(params: {
       email: params.email,
     });
   }
+}
+
+// =============================================================================
+// Newsletter helpers — use Resend Audiences/Contacts/Broadcasts APIs directly
+// =============================================================================
+
+export interface NewsletterContact {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  createdAt: string;
+  unsubscribed: boolean;
+}
+
+function getResendClient(): Resend {
+  if (!env.RESEND_API_KEY) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+  return new Resend(env.RESEND_API_KEY);
+}
+
+function requireNewsletterEnv(): { audienceId: string; fromEmail: string } {
+  if (!env.RESEND_AUDIENCE_ID) {
+    throw new Error("RESEND_AUDIENCE_ID is not configured");
+  }
+  if (!env.RESEND_FROM_EMAIL) {
+    throw new Error("RESEND_FROM_EMAIL is not configured");
+  }
+  return {
+    audienceId: env.RESEND_AUDIENCE_ID,
+    fromEmail: env.RESEND_FROM_EMAIL,
+  };
+}
+
+export async function subscribeToNewsletter(params: {
+  email: string;
+  firstName?: string;
+}): Promise<void> {
+  const { audienceId } = requireNewsletterEnv();
+  const resend = getResendClient();
+
+  const { error } = await resend.contacts.create({
+    audienceId,
+    email: params.email,
+    firstName: params.firstName,
+    unsubscribed: false,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * List all contacts in the newsletter audience from Resend.
+ */
+export async function listNewsletterSubscribers(): Promise<
+  NewsletterContact[]
+> {
+  const { audienceId } = requireNewsletterEnv();
+  const resend = getResendClient();
+
+  const { data, error } = await resend.contacts.list({ audienceId });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data?.data ?? []).map((c) => ({
+    id: c.id,
+    email: c.email,
+    firstName: c.first_name ?? null,
+    lastName: c.last_name ?? null,
+    createdAt: c.created_at,
+    unsubscribed: c.unsubscribed,
+  }));
+}
+
+interface ResendBroadcastRequest {
+  segment_id: string;
+  from: string;
+  subject: string;
+  name: string;
+  html: string;
+  send: true;
+}
+
+interface ResendBroadcastSuccess {
+  id: string;
+}
+
+interface ResendBroadcastError {
+  statusCode: number;
+  message: string;
+  name: string;
+}
+
+type ResendBroadcastResponse = ResendBroadcastSuccess | ResendBroadcastError;
+
+/**
+ * Create and immediately send a newsletter broadcast via Resend.
+ * The rendered HTML includes {{{RESEND_UNSUBSCRIBE_URL}}} and
+ * {{{contact.first_name|there}}} which Resend substitutes per-recipient.
+ */
+export async function sendNewsletterBroadcast(params: {
+  subject: string;
+  body: string;
+}): Promise<{ broadcastId: string }> {
+  const { audienceId, fromEmail } = requireNewsletterEnv();
+
+  if (!env.RESEND_API_KEY) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+  const apiKey = env.RESEND_API_KEY;
+
+  const html = await render(
+    NewsletterEmail({
+      subject: params.subject,
+      body: params.body,
+      supportEmail:
+        env.NEXT_PUBLIC_CONTACT_EMAIL || getAdminEmails()[0] || fromEmail,
+    }),
+  );
+
+  // Logged on every failure so the terminal always has context
+  const debugCtx = {
+    hasApiKey: true,
+    hasAudienceId: !!env.RESEND_AUDIENCE_ID,
+    fromEmail,
+    subjectLength: params.subject.length,
+    bodyLength: params.body.length,
+    htmlLength: html.length,
+  };
+
+  const requestBody: ResendBroadcastRequest = {
+    segment_id: audienceId,
+    from: `Teach Anything™ <${fromEmail}>`,
+    subject: params.subject,
+    name: params.subject,
+    html,
+    send: true,
+  };
+
+  let res: Response;
+  try {
+    res = await fetch("https://api.resend.com/broadcasts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+  } catch (fetchError) {
+    const message =
+      fetchError instanceof Error ? fetchError.message : "Network error";
+    logError(new Error(message), "Resend broadcasts fetch failed", debugCtx);
+    throw new Error(`Broadcast failed: network error — ${message}`);
+  }
+
+  let payload: ResendBroadcastResponse;
+  try {
+    payload = (await res.json()) as ResendBroadcastResponse;
+  } catch {
+    logError(
+      new Error("Non-JSON response from Resend"),
+      "Resend broadcasts API returned non-JSON",
+      { ...debugCtx, httpStatus: res.status },
+    );
+    throw new Error(
+      `Broadcast failed: unexpected response (HTTP ${res.status})`,
+    );
+  }
+
+  if ("id" in payload) {
+    logInfo("Newsletter broadcast sent", { broadcastId: payload.id });
+    return { broadcastId: payload.id };
+  }
+
+  logError(new Error(payload.message), "Resend broadcasts API failed", {
+    ...debugCtx,
+    httpStatus: res.status,
+    resendErrorName: payload.name,
+    resendErrorMessage: payload.message,
+    resendStatusCode: payload.statusCode,
+  });
+  throw new Error(
+    `Broadcast failed (HTTP ${res.status}): ${payload.name} — ${payload.message}`,
+  );
 }

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -374,24 +374,26 @@ function getResendClient(): Resend {
   return new Resend(env.RESEND_API_KEY);
 }
 
-function requireNewsletterEnv(): { audienceId: string; fromEmail: string } {
+function requireContactEnv(): { audienceId: string } {
   if (!env.RESEND_AUDIENCE_ID) {
     throw new Error("RESEND_AUDIENCE_ID is not configured");
   }
+  return { audienceId: env.RESEND_AUDIENCE_ID };
+}
+
+function requireBroadcastEnv(): { audienceId: string; fromEmail: string } {
+  const { audienceId } = requireContactEnv();
   if (!env.RESEND_FROM_EMAIL) {
     throw new Error("RESEND_FROM_EMAIL is not configured");
   }
-  return {
-    audienceId: env.RESEND_AUDIENCE_ID,
-    fromEmail: env.RESEND_FROM_EMAIL,
-  };
+  return { audienceId, fromEmail: env.RESEND_FROM_EMAIL };
 }
 
 export async function subscribeToNewsletter(params: {
   email: string;
   firstName?: string;
 }): Promise<void> {
-  const { audienceId } = requireNewsletterEnv();
+  const { audienceId } = requireContactEnv();
   const resend = getResendClient();
 
   const { error } = await resend.contacts.create({
@@ -412,7 +414,7 @@ export async function subscribeToNewsletter(params: {
 export async function listNewsletterSubscribers(): Promise<
   NewsletterContact[]
 > {
-  const { audienceId } = requireNewsletterEnv();
+  const { audienceId } = requireContactEnv();
   const resend = getResendClient();
 
   const { data, error } = await resend.contacts.list({ audienceId });
@@ -461,7 +463,7 @@ export async function sendNewsletterBroadcast(params: {
   subject: string;
   body: string;
 }): Promise<{ broadcastId: string }> {
-  const { audienceId, fromEmail } = requireNewsletterEnv();
+  const { audienceId, fromEmail } = requireBroadcastEnv();
 
   if (!env.RESEND_API_KEY) {
     throw new Error("RESEND_API_KEY is not configured");

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -381,12 +381,17 @@ function requireContactEnv(): { audienceId: string } {
   return { audienceId: env.RESEND_AUDIENCE_ID };
 }
 
-function requireBroadcastEnv(): { audienceId: string; fromEmail: string } {
-  const { audienceId } = requireContactEnv();
+function requireBroadcastEnv(): { segmentId: string; fromEmail: string } {
   if (!env.RESEND_FROM_EMAIL) {
     throw new Error("RESEND_FROM_EMAIL is not configured");
   }
-  return { audienceId, fromEmail: env.RESEND_FROM_EMAIL };
+  if (!env.RESEND_BROADCAST_SEGMENT_ID) {
+    throw new Error("RESEND_BROADCAST_SEGMENT_ID is not configured");
+  }
+  return {
+    segmentId: env.RESEND_BROADCAST_SEGMENT_ID,
+    fromEmail: env.RESEND_FROM_EMAIL,
+  };
 }
 
 export async function subscribeToNewsletter(params: {
@@ -463,7 +468,7 @@ export async function sendNewsletterBroadcast(params: {
   subject: string;
   body: string;
 }): Promise<{ broadcastId: string }> {
-  const { audienceId, fromEmail } = requireBroadcastEnv();
+  const { segmentId, fromEmail } = requireBroadcastEnv();
 
   if (!env.RESEND_API_KEY) {
     throw new Error("RESEND_API_KEY is not configured");
@@ -482,7 +487,7 @@ export async function sendNewsletterBroadcast(params: {
   // Logged on every failure so the terminal always has context
   const debugCtx = {
     hasApiKey: true,
-    hasAudienceId: !!env.RESEND_AUDIENCE_ID,
+    hasBroadcastSegmentId: !!env.RESEND_BROADCAST_SEGMENT_ID,
     fromEmail,
     subjectLength: params.subject.length,
     bodyLength: params.body.length,
@@ -490,7 +495,7 @@ export async function sendNewsletterBroadcast(params: {
   };
 
   const requestBody: ResendBroadcastRequest = {
-    segment_id: audienceId,
+    segment_id: segmentId,
     from: `Teach Anything™ <${fromEmail}>`,
     subject: params.subject,
     name: params.subject,

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -28,6 +28,7 @@ const envSchema = z.object({
   RESEND_FROM_EMAIL: z.string().email().optional(),
   RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
   RESEND_AUDIENCE_ID: z.string().min(1).optional(),
+  RESEND_BROADCAST_SEGMENT_ID: z.string().min(1).optional(),
 
   // Upstash Redis (optional — rate limiting disabled without these)
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   RESEND_API_KEY: z.string().min(1).optional(),
   RESEND_FROM_EMAIL: z.string().email().optional(),
   RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
+  RESEND_AUDIENCE_ID: z.string().min(1).optional(),
 
   // Upstash Redis (optional — rate limiting disabled without these)
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -125,6 +125,13 @@ export const conversationSearchRateLimit = createLimiter({
   prefix: "@ratelimit/conversation-search",
 });
 
+// Rate limiter for public newsletter signup
+// 5 signups per hour per IP (anti-spam)
+export const newsletterSignupRateLimit = createLimiter({
+  window: [5, "1 h"],
+  prefix: "@ratelimit/newsletter-signup",
+});
+
 /**
  * Check rate limit and log if exceeded.
  * When limiter is null (Redis not configured), returns success as a noop.

--- a/apps/web/src/server/routers/_app.ts
+++ b/apps/web/src/server/routers/_app.ts
@@ -6,6 +6,7 @@ import { filesRouter } from "./files";
 import { analyticsRouter } from "./analytics";
 import { adminRouter } from "./admin";
 import { crawlerRouter } from "./crawler";
+import { newsletterRouter } from "./newsletter";
 
 export const appRouter = router({
   auth: authRouter,
@@ -15,6 +16,7 @@ export const appRouter = router({
   analytics: analyticsRouter,
   admin: adminRouter,
   crawler: crawlerRouter,
+  newsletter: newsletterRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/server/routers/newsletter.ts
+++ b/apps/web/src/server/routers/newsletter.ts
@@ -7,6 +7,7 @@ import {
   sendNewsletterBroadcast,
 } from "@/lib/email";
 import { logError } from "@/lib/logger";
+import { checkRateLimit, newsletterSignupRateLimit } from "@/lib/rate-limit";
 
 export const newsletterRouter = router({
   /**
@@ -19,7 +20,21 @@ export const newsletterRouter = router({
         firstName: z.string().trim().max(100).optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
+      const clientIp =
+        ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+      const { success } = await checkRateLimit(
+        newsletterSignupRateLimit,
+        clientIp,
+        { action: "newsletter-signup", email: input.email },
+      );
+      if (!success) {
+        throw new TRPCError({
+          code: "TOO_MANY_REQUESTS",
+          message: "Too many signup attempts. Please try again later.",
+        });
+      }
+
       try {
         await subscribeToNewsletter({
           email: input.email,

--- a/apps/web/src/server/routers/newsletter.ts
+++ b/apps/web/src/server/routers/newsletter.ts
@@ -1,0 +1,84 @@
+import { router, publicProcedure, adminProcedure } from "../trpc";
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  subscribeToNewsletter,
+  listNewsletterSubscribers,
+  sendNewsletterBroadcast,
+} from "@/lib/email";
+import { logError } from "@/lib/logger";
+
+export const newsletterRouter = router({
+  /**
+   * Public: subscribe an email address to the newsletter audience.
+   */
+  subscribe: publicProcedure
+    .input(
+      z.object({
+        email: z.string().email(),
+        firstName: z.string().trim().max(100).optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      try {
+        await subscribeToNewsletter({
+          email: input.email,
+          firstName: input.firstName,
+        });
+        return { success: true };
+      } catch (error) {
+        logError(error, "Newsletter subscription failed", {
+          email: input.email,
+        });
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to subscribe. Please try again.",
+        });
+      }
+    }),
+
+  /**
+   * Admin: list all contacts in the newsletter audience.
+   */
+  listSubscribers: adminProcedure.query(async () => {
+    try {
+      return await listNewsletterSubscribers();
+    } catch (error) {
+      logError(error, "Failed to list newsletter subscribers");
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to fetch subscribers.",
+      });
+    }
+  }),
+
+  /**
+   * Admin: create and send a newsletter broadcast via Resend.
+   */
+  sendBroadcast: adminProcedure
+    .input(
+      z.object({
+        subject: z.string().min(1).max(200),
+        body: z.string().min(1).max(50000),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      try {
+        return await sendNewsletterBroadcast({
+          subject: input.subject,
+          body: input.body,
+        });
+      } catch (error) {
+        // sendNewsletterBroadcast already logged the Resend error details.
+        // Log the caught message here so the router path is traceable too.
+        logError(error, "Newsletter sendBroadcast mutation failed", {
+          subjectLength: input.subject.length,
+          bodyLength: input.body.length,
+        });
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to send newsletter. Please try again.",
+        });
+      }
+    }),
+});


### PR DESCRIPTION
Closes #137

## Summary
- Added homepage newsletter signup using Resend Contacts.
- Added newsletter tRPC router for subscribe, subscriber listing, and broadcast sending.
- Added admin Newsletter tab with subscriber list, count, compose dialog, preview, and send action.
- Added React Email newsletter template with Resend unsubscribe and personalization variables.
- Added RESEND_AUDIENCE_ID env validation and .env.example documentation.

## Testing
- npm run check-types
- npm run lint
- npm run test
- Manually verified homepage signup creates a Resend contact.
- Manually verified admin Newsletter tab lists subscribers.
- Broadcast API reaches Resend; actual sending requires RESEND_FROM_EMAIL to use a verified Resend domain.