### PR TITLE
feat(files): Add OCR support for image uploads and scanned PDFs

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,9 +3,13 @@ const nextConfig = {
   images: {
     qualities: [75, 90, 95, 100],
   },
-  // Externalize pdf-parse to avoid bundling issues
-  // pdf-parse uses Node.js-specific modules that can't be bundled by webpack
-  serverExternalPackages: ["pdf-parse"],
+  // Externalize server-only extraction packages with native/WASM/runtime assets.
+  serverExternalPackages: [
+    "@napi-rs/canvas",
+    "pdf-parse",
+    "pdfjs-dist",
+    "tesseract.js",
+  ],
   output: "standalone",
 };
 

--- a/apps/web/src/__tests__/lib/upload-file-types.test.ts
+++ b/apps/web/src/__tests__/lib/upload-file-types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import { inferSupportedFileType } from "@/lib/upload-file-types";
+
+describe("inferSupportedFileType", () => {
+  it("uses the declared MIME type when it is already supported", () => {
+    expect(inferSupportedFileType("notes.pdf", "application/pdf")).toBe(
+      "application/pdf",
+    );
+  });
+
+  it("infers supported image MIME types from extensions when browser MIME is missing", () => {
+    expect(inferSupportedFileType("whiteboard.JPG", "")).toBe("image/jpeg");
+    expect(inferSupportedFileType("scan.tif", "")).toBe("image/tiff");
+  });
+
+  it("infers supported text MIME types from extensions when browser MIME is generic", () => {
+    expect(inferSupportedFileType("data.csv", "application/octet-stream")).toBe(
+      "text/csv",
+    );
+  });
+
+  it("uses extension-specific text MIME types when browsers report text/plain", () => {
+    expect(inferSupportedFileType("notes.md", "text/plain")).toBe(
+      "text/markdown",
+    );
+    expect(inferSupportedFileType("data.csv", "text/plain")).toBe("text/csv");
+  });
+
+  it("does not hide a supported MIME type that conflicts with the extension", () => {
+    expect(inferSupportedFileType("photo.jpg", "image/png")).toBe("image/png");
+  });
+
+  it("leaves unsupported extensions unchanged for validation to reject", () => {
+    expect(inferSupportedFileType("animation.gif", "image/gif")).toBe(
+      "image/gif",
+    );
+  });
+});

--- a/apps/web/src/__tests__/server/files-validation.test.ts
+++ b/apps/web/src/__tests__/server/files-validation.test.ts
@@ -45,14 +45,18 @@ describe("SUPPORTED_FILE_TYPES", () => {
     expect(SUPPORTED_FILE_TYPES).toContain(
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     );
+    expect(SUPPORTED_FILE_TYPES).toContain("image/jpeg");
+    expect(SUPPORTED_FILE_TYPES).toContain("image/png");
+    expect(SUPPORTED_FILE_TYPES).toContain("image/webp");
+    expect(SUPPORTED_FILE_TYPES).toContain("image/tiff");
     expect(SUPPORTED_FILE_TYPES).toContain("text/plain");
     expect(SUPPORTED_FILE_TYPES).toContain("text/markdown");
     expect(SUPPORTED_FILE_TYPES).toContain("application/json");
     expect(SUPPORTED_FILE_TYPES).toContain("text/csv");
   });
 
-  it("has exactly 8 supported types", () => {
-    expect(SUPPORTED_FILE_TYPES).toHaveLength(8);
+  it("has exactly 12 supported types", () => {
+    expect(SUPPORTED_FILE_TYPES).toHaveLength(12);
   });
 });
 
@@ -87,6 +91,15 @@ describe("EXTENSION_MIME_MAP", () => {
   it("maps csv to text/csv", () => {
     expect(EXTENSION_MIME_MAP["csv"]).toEqual(["text/csv"]);
   });
+
+  it("maps supported image extensions to image MIME types", () => {
+    expect(EXTENSION_MIME_MAP["jpg"]).toEqual(["image/jpeg"]);
+    expect(EXTENSION_MIME_MAP["jpeg"]).toEqual(["image/jpeg"]);
+    expect(EXTENSION_MIME_MAP["png"]).toEqual(["image/png"]);
+    expect(EXTENSION_MIME_MAP["webp"]).toEqual(["image/webp"]);
+    expect(EXTENSION_MIME_MAP["tiff"]).toEqual(["image/tiff"]);
+    expect(EXTENSION_MIME_MAP["tif"]).toEqual(["image/tiff"]);
+  });
 });
 
 describe("FILE_TYPE_DISPLAY_NAMES", () => {
@@ -102,6 +115,10 @@ describe("FILE_TYPE_DISPLAY_NAMES", () => {
     expect(FILE_TYPE_DISPLAY_NAMES["text/markdown"]).toBe("Markdown");
     expect(FILE_TYPE_DISPLAY_NAMES["application/json"]).toBe("JSON");
     expect(FILE_TYPE_DISPLAY_NAMES["text/csv"]).toBe("CSV");
+    expect(FILE_TYPE_DISPLAY_NAMES["image/jpeg"]).toBe("JPEG image");
+    expect(FILE_TYPE_DISPLAY_NAMES["image/png"]).toBe("PNG image");
+    expect(FILE_TYPE_DISPLAY_NAMES["image/webp"]).toBe("WEBP image");
+    expect(FILE_TYPE_DISPLAY_NAMES["image/tiff"]).toBe("TIFF image");
   });
 });
 
@@ -298,6 +315,12 @@ describe("validateFileSize", () => {
       const maxBytes = 50 * 1024 * 1024 - 1;
       expect(() => validateFileSize(maxBytes)).not.toThrow();
     });
+
+    it("accepts an OCR image at exactly the OCR size limit", () => {
+      expect(() =>
+        validateFileSize(25 * 1024 * 1024, "image/png"),
+      ).not.toThrow();
+    });
   });
 
   describe("invalid file sizes", () => {
@@ -337,6 +360,20 @@ describe("validateFileSize", () => {
         expect(trpcError.message).toContain("60.00MB");
       }
     });
+
+    it("rejects images exceeding the OCR size limit before upload", () => {
+      expectTRPCError(
+        () => validateFileSize(25 * 1024 * 1024 + 1, "image/jpeg"),
+        "BAD_REQUEST",
+        "OCR processing limit",
+      );
+    });
+
+    it("does not apply the OCR size limit to non-image files", () => {
+      expect(() =>
+        validateFileSize(30 * 1024 * 1024, "application/pdf"),
+      ).not.toThrow();
+    });
   });
 });
 
@@ -373,12 +410,19 @@ describe("validateFileType", () => {
     it("accepts text/csv", () => {
       expect(() => validateFileType("text/csv")).not.toThrow();
     });
+
+    it("accepts supported image MIME types", () => {
+      expect(() => validateFileType("image/jpeg")).not.toThrow();
+      expect(() => validateFileType("image/png")).not.toThrow();
+      expect(() => validateFileType("image/webp")).not.toThrow();
+      expect(() => validateFileType("image/tiff")).not.toThrow();
+    });
   });
 
   describe("unsupported types", () => {
-    it("rejects image/png", () => {
+    it("rejects unsupported image formats gracefully", () => {
       expectTRPCError(
-        () => validateFileType("image/png"),
+        () => validateFileType("image/gif"),
         "BAD_REQUEST",
         "Unsupported file type",
       );
@@ -418,18 +462,18 @@ describe("validateFileType", () => {
 
     it("includes display name for known unsupported types in error", () => {
       try {
-        validateFileType("image/png");
+        validateFileType("image/gif");
         throw new Error("Expected to throw");
       } catch (error) {
         const trpcError = error as TRPCError;
-        // image/png is not in FILE_TYPE_DISPLAY_NAMES, so the raw type is used
-        expect(trpcError.message).toContain("image/png");
+        // image/gif is not in FILE_TYPE_DISPLAY_NAMES, so the raw type is used
+        expect(trpcError.message).toContain("image/gif");
       }
     });
 
     it("lists supported types in error message", () => {
       try {
-        validateFileType("image/png");
+        validateFileType("image/gif");
         throw new Error("Expected to throw");
       } catch (error) {
         const trpcError = error as TRPCError;
@@ -439,6 +483,7 @@ describe("validateFileType", () => {
         expect(trpcError.message).toContain("Markdown");
         expect(trpcError.message).toContain("JSON");
         expect(trpcError.message).toContain("CSV");
+        expect(trpcError.message).toContain("Images");
       }
     });
   });
@@ -494,6 +539,27 @@ describe("validateExtensionMatchesMimeType", () => {
     it("accepts .csv with text/csv", () => {
       expect(() =>
         validateExtensionMatchesMimeType("data.csv", "text/csv"),
+      ).not.toThrow();
+    });
+
+    it("accepts supported image extensions with matching MIME types", () => {
+      expect(() =>
+        validateExtensionMatchesMimeType("photo.jpg", "image/jpeg"),
+      ).not.toThrow();
+      expect(() =>
+        validateExtensionMatchesMimeType("photo.jpeg", "image/jpeg"),
+      ).not.toThrow();
+      expect(() =>
+        validateExtensionMatchesMimeType("diagram.png", "image/png"),
+      ).not.toThrow();
+      expect(() =>
+        validateExtensionMatchesMimeType("scan.webp", "image/webp"),
+      ).not.toThrow();
+      expect(() =>
+        validateExtensionMatchesMimeType("scan.tiff", "image/tiff"),
+      ).not.toThrow();
+      expect(() =>
+        validateExtensionMatchesMimeType("scan.tif", "image/tiff"),
       ).not.toThrow();
     });
   });
@@ -553,6 +619,14 @@ describe("validateExtensionMatchesMimeType", () => {
       );
     });
 
+    it("rejects supported image extensions with mismatched MIME types", () => {
+      expectTRPCError(
+        () => validateExtensionMatchesMimeType("photo.png", "image/jpeg"),
+        "BAD_REQUEST",
+        "does not match",
+      );
+    });
+
     it("includes extension and display name in error message", () => {
       try {
         validateExtensionMatchesMimeType("document.pdf", "text/plain");
@@ -566,18 +640,22 @@ describe("validateExtensionMatchesMimeType", () => {
   });
 
   describe("unknown extensions", () => {
-    it("does not throw for unknown extension with any MIME type", () => {
-      // Unknown extension means validMimeTypes is undefined, so the check is skipped
-      expect(() =>
-        validateExtensionMatchesMimeType("document.xyz", "application/pdf"),
-      ).not.toThrow();
+    it("rejects unknown extensions", () => {
+      expectTRPCError(
+        () =>
+          validateExtensionMatchesMimeType("document.xyz", "application/pdf"),
+        "BAD_REQUEST",
+        "not supported",
+      );
     });
 
-    it("does not throw for file without extension", () => {
-      // lastIndexOf(".") + 1 gets the full filename as "extension", which is unknown
-      expect(() =>
-        validateExtensionMatchesMimeType("noextension", "application/pdf"),
-      ).not.toThrow();
+    it("rejects files without extensions", () => {
+      expectTRPCError(
+        () =>
+          validateExtensionMatchesMimeType("noextension", "application/pdf"),
+        "BAD_REQUEST",
+        "not supported",
+      );
     });
   });
 

--- a/apps/web/src/components/dashboard/files/FileStatusBadge.tsx
+++ b/apps/web/src/components/dashboard/files/FileStatusBadge.tsx
@@ -20,6 +20,8 @@ interface ProcessingProgress {
   percentage: number;
   currentChunk?: number;
   totalChunks?: number;
+  currentPage?: number;
+  totalPages?: number;
   startedAt?: string;
   lastUpdatedAt?: string;
 }
@@ -173,6 +175,11 @@ export function FileStatusBadge({
               Chunk {progress.currentChunk || 0} of {progress.totalChunks}
             </p>
           )}
+          {progress.totalPages && (
+            <p className="text-xs">
+              Page {progress.currentPage || 0} of {progress.totalPages}
+            </p>
+          )}
           <p className="text-xs">Progress: {progress.percentage.toFixed(0)}%</p>
         </div>
       );
@@ -235,6 +242,13 @@ export function FileStatusBadge({
                   progress.totalChunks > 0 && (
                     <span className="text-[10px] text-muted-foreground tabular-nums whitespace-nowrap">
                       {progress.currentChunk || 0}/{progress.totalChunks}
+                    </span>
+                  )}
+                {progress.stage === "extracting" &&
+                  progress.totalPages &&
+                  progress.totalPages > 0 && (
+                    <span className="text-[10px] text-muted-foreground tabular-nums whitespace-nowrap">
+                      Page {progress.currentPage || 0}/{progress.totalPages}
                     </span>
                   )}
                 <span className="text-xs font-medium text-foreground tabular-nums min-w-[35px] text-right">

--- a/apps/web/src/components/dashboard/files/FileTable.tsx
+++ b/apps/web/src/components/dashboard/files/FileTable.tsx
@@ -50,6 +50,8 @@ type BaseFile = {
       percentage: number;
       currentChunk?: number;
       totalChunks?: number;
+      currentPage?: number;
+      totalPages?: number;
       startedAt?: string;
       lastUpdatedAt?: string;
     };

--- a/apps/web/src/components/dashboard/files/UploadFileDialog.tsx
+++ b/apps/web/src/components/dashboard/files/UploadFileDialog.tsx
@@ -18,6 +18,11 @@ import { cn } from "@/lib/utils";
 import {
   MAX_FILE_SIZE,
   ALLOWED_FILE_TYPES,
+  FILE_INPUT_ACCEPT,
+  OCR_MAX_IMAGE_SIZE_BYTES,
+  OCR_MAX_IMAGE_SIZE_MB,
+  inferSupportedFileType,
+  isOCRImageFileType,
   validateFileName,
   formatFileSize,
   getFileTypeDisplayName,
@@ -86,13 +91,21 @@ export function UploadFileDialog({
       }
 
       // Validate file type
+      const fileType = inferSupportedFileType(file.name, file.type);
       if (
         !ALLOWED_FILE_TYPES.includes(
-          file.type as (typeof ALLOWED_FILE_TYPES)[number],
+          fileType as (typeof ALLOWED_FILE_TYPES)[number],
         )
       ) {
-        const displayName = getFileTypeDisplayName(file.type);
-        return `File type "${displayName}" is not supported. Please upload PDF, Word (.doc, .docx), PowerPoint (.pptx), Text, Markdown, JSON, or CSV files.`;
+        const displayName = getFileTypeDisplayName(fileType || file.type);
+        return `File type "${displayName}" is not supported. Please upload a supported file type.`;
+      }
+
+      if (
+        isOCRImageFileType(fileType) &&
+        file.size > OCR_MAX_IMAGE_SIZE_BYTES
+      ) {
+        return `Image file size exceeds the ${OCR_MAX_IMAGE_SIZE_MB}MB OCR processing limit. Please compress the image or upload a smaller file.`;
       }
 
       // Check for duplicate file name
@@ -337,7 +350,7 @@ export function UploadFileDialog({
               type="file"
               ref={fileInputRef}
               onChange={handleInputChange}
-              accept=".pdf,.doc,.docx,.pptx,.txt,.md,.json,.csv"
+              accept={FILE_INPUT_ACCEPT}
               multiple
               className="hidden"
             />

--- a/apps/web/src/components/dashboard/files/file-constants.ts
+++ b/apps/web/src/components/dashboard/files/file-constants.ts
@@ -1,3 +1,8 @@
+import {
+  ALLOWED_EXTENSIONS,
+  FILE_TYPE_DISPLAY_NAMES,
+} from "@/lib/upload-file-types";
+
 // Get max file size from environment variable (client-accessible via NEXT_PUBLIC_ prefix)
 // Falls back to 50MB if not set
 const getMaxFileSizeMB = (): number => {
@@ -7,42 +12,16 @@ const getMaxFileSizeMB = (): number => {
 
 export const MAX_FILE_SIZE = getMaxFileSizeMB() * 1024 * 1024;
 export const MAX_FILE_NAME_LENGTH = 255;
-export const ALLOWED_FILE_TYPES = [
-  "application/pdf",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "application/msword",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "text/plain",
-  "text/markdown",
-  "application/json",
-  "text/csv",
-] as const;
-
-export const ALLOWED_EXTENSIONS = [
-  ".pdf",
-  ".doc",
-  ".docx",
-  ".pptx",
-  ".txt",
-  ".md",
-  ".markdown",
-  ".json",
-  ".csv",
-] as const;
-
-// User-friendly file type names for error messages
-export const FILE_TYPE_DISPLAY_NAMES: Record<string, string> = {
-  "application/pdf": "PDF",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    "Word (.docx)",
-  "application/msword": "Word (.doc)",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-    "PPTX",
-  "text/plain": "Text",
-  "text/markdown": "Markdown",
-  "application/json": "JSON",
-  "text/csv": "CSV",
-};
+export {
+  ALLOWED_FILE_TYPES,
+  ALLOWED_EXTENSIONS,
+  FILE_INPUT_ACCEPT,
+  FILE_TYPE_DISPLAY_NAMES,
+  OCR_MAX_IMAGE_SIZE_BYTES,
+  OCR_MAX_IMAGE_SIZE_MB,
+  inferSupportedFileType,
+  isOCRImageFileType,
+} from "@/lib/upload-file-types";
 
 // Helper to get user-friendly file type name
 export const getFileTypeDisplayName = (mimeType: string): string => {

--- a/apps/web/src/lib/direct-upload.ts
+++ b/apps/web/src/lib/direct-upload.ts
@@ -5,6 +5,7 @@
  */
 
 import { trpc } from "@/lib/trpc";
+import { inferSupportedFileType } from "@/lib/upload-file-types";
 
 export interface UploadProgress {
   loaded: number;
@@ -29,10 +30,12 @@ export function useDirectUpload() {
     file: File,
     onProgress?: (progress: UploadProgress) => void,
   ): Promise<DirectUploadResult> => {
+    const fileType = inferSupportedFileType(file.name, file.type);
+
     // Step 1: Get signed upload URL
     const uploadUrlData = await createUploadUrl.mutateAsync({
       fileName: file.name,
-      fileType: file.type,
+      fileType,
       fileSize: file.size,
     });
 
@@ -80,7 +83,7 @@ export function useDirectUpload() {
       });
 
       xhr.open("PUT", uploadUrl);
-      xhr.setRequestHeader("Content-Type", file.type);
+      xhr.setRequestHeader("Content-Type", fileType);
       xhr.send(file);
     });
 
@@ -88,7 +91,7 @@ export function useDirectUpload() {
     const result = await finalizeUpload.mutateAsync({
       fileId,
       fileName: file.name,
-      fileType: file.type,
+      fileType,
       fileSize: file.size,
       storagePath,
     });

--- a/apps/web/src/lib/file-processor.ts
+++ b/apps/web/src/lib/file-processor.ts
@@ -8,7 +8,19 @@ import { EMBEDDING_MODEL } from "@teachanything/ai/models";
 import { env } from "./env";
 import { logInfo, logError } from "./logger";
 
-const EXTRACTION_TIMEOUT_MS = 60_000;
+const EXTRACTION_TIMEOUT_MS = 30 * 60_000;
+
+/**
+ * Processing batch sizes - tuned for performance and rate limiting
+ */
+const PROCESSING_CONFIG = {
+  /** Chunks per embedding batch (50 to avoid OpenRouter rate limits) */
+  EMBEDDING_BATCH_SIZE: 50,
+  /** Chunk records per database insert batch (500 for efficient bulk insert) */
+  DB_INSERT_BATCH_SIZE: 500,
+} as const;
+
+type FileMetadata = NonNullable<typeof userFiles.$inferSelect.metadata>;
 
 /**
  * Sanitize error messages before storing in metadata visible to users.
@@ -16,27 +28,27 @@ const EXTRACTION_TIMEOUT_MS = 60_000;
  */
 function sanitizeProcessingError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
+  const errorName = error instanceof Error ? error.name : "";
   if (msg.includes("timed out")) return "File processing timed out";
   if (msg.includes("Unsupported file type")) return msg;
   if (msg.includes("no readable text")) return msg;
+  if (msg.includes("Invalid image format")) return "Invalid image format";
+  if (msg.includes("Image exceeds OCR size limit"))
+    return "Image exceeds OCR size limit";
+  if (msg.includes("Image dimensions exceed"))
+    return "Image dimensions exceed maximum limit";
+  if (msg.includes("too many pages for OCR")) return msg;
+  if (msg.includes("too large to render for OCR")) return msg;
   if (msg.includes("Invalid PDF")) return "Invalid PDF format";
   if (msg.includes("embedding") && msg.includes("dimension"))
     return "Embedding dimension mismatch";
+  if (
+    msg.includes("Extraction aborted") ||
+    msg.includes("timed out") ||
+    errorName === "AbortError"
+  )
+    return "File processing timed out";
   return "File processing failed due to an internal error";
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout>;
-  const timeout = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error(message)), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() =>
-    clearTimeout(timeoutId),
-  );
 }
 
 /**
@@ -48,46 +60,64 @@ async function updateProgress(
   percentage: number,
   currentChunk?: number,
   totalChunks?: number,
+  currentPage?: number,
+  totalPages?: number,
 ) {
-  const now = new Date().toISOString();
+  try {
+    const now = new Date().toISOString();
 
-  // Get current file to preserve existing metadata
-  const [currentFile] = await db
-    .select()
-    .from(userFiles)
-    .where(eq(userFiles.id, fileId))
-    .limit(1);
+    const [currentFile] = await db
+      .select()
+      .from(userFiles)
+      .where(eq(userFiles.id, fileId))
+      .limit(1);
 
-  const existingMetadata = currentFile?.metadata || {};
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { error: _prevError, ...cleanMetadata } = existingMetadata;
-  const startedAt = existingMetadata?.processingProgress?.startedAt || now;
+    const existingMetadata: FileMetadata = currentFile?.metadata || {};
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { error: _prevError, ...cleanMetadata } = existingMetadata;
+    const startedAt = existingMetadata?.processingProgress?.startedAt || now;
 
-  await db
-    .update(userFiles)
-    .set({
-      processingStatus: "processing",
-      metadata: {
-        ...cleanMetadata,
-        processingProgress: {
-          stage,
-          percentage: Math.min(100, Math.max(0, percentage)),
-          currentChunk,
-          totalChunks,
-          startedAt,
-          lastUpdatedAt: now,
+    await db
+      .update(userFiles)
+      .set({
+        processingStatus: "processing",
+        metadata: {
+          ...cleanMetadata,
+          processingProgress: {
+            stage,
+            percentage: Math.min(100, Math.max(0, percentage)),
+            currentChunk,
+            totalChunks,
+            currentPage,
+            totalPages,
+            startedAt,
+            lastUpdatedAt: now,
+          },
         },
-      },
-    })
-    .where(eq(userFiles.id, fileId));
+      })
+      .where(
+        and(
+          eq(userFiles.id, fileId),
+          eq(userFiles.processingStatus, "processing"),
+        ),
+      );
 
-  logInfo(`File processing progress: ${stage} ${percentage}%`, {
-    fileId,
-    stage,
-    percentage,
-    currentChunk,
-    totalChunks,
-  });
+    logInfo(`File processing progress: ${stage} ${percentage}%`, {
+      fileId,
+      stage,
+      percentage,
+      currentChunk,
+      totalChunks,
+      currentPage,
+      totalPages,
+    });
+  } catch (err) {
+    logError(err, "Failed to update processing progress (non-fatal)", {
+      fileId,
+      stage,
+      percentage,
+    });
+  }
 }
 
 /**
@@ -98,10 +128,32 @@ export async function processFile(params: {
   fileId: string;
 }): Promise<{ success: boolean; chunkCount: number }> {
   const { fileId } = params;
+  const ragService = createRAGService();
 
   try {
     const startTime = new Date().toISOString();
     logInfo("File processing started", { fileId });
+
+    const [initialFile] = await db
+      .select()
+      .from(userFiles)
+      .where(eq(userFiles.id, fileId))
+      .limit(1);
+
+    if (!initialFile) {
+      // File was deleted while job was queued - exit gracefully
+      logInfo("File not found (likely deleted), skipping processing", {
+        fileId,
+      });
+      return {
+        success: false,
+        chunkCount: 0,
+      };
+    }
+
+    const initialMetadata: FileMetadata = initialFile.metadata ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { error: _initialError, ...cleanInitialMetadata } = initialMetadata;
 
     // Atomic status guard: only proceed if not already processing (per D-04, D-05)
     const guardResult = await db
@@ -109,6 +161,7 @@ export async function processFile(params: {
       .set({
         processingStatus: "processing",
         metadata: {
+          ...cleanInitialMetadata,
           processingProgress: {
             stage: "downloading",
             percentage: 0,
@@ -203,12 +256,43 @@ export async function processFile(params: {
 
     // Stage 2: Extract text content (10-30%)
     await updateProgress(fileId, "extracting", 10);
-    const ragService = createRAGService();
-    const content = await withTimeout(
-      ragService.extractContent(buffer, file.fileType),
-      EXTRACTION_TIMEOUT_MS,
-      `File extraction timed out after ${EXTRACTION_TIMEOUT_MS / 1000}s`,
-    );
+    let isExtractionActive = true;
+
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      abortController.abort(
+        new Error(
+          `File extraction timed out after ${EXTRACTION_TIMEOUT_MS / 1000}s`,
+        ),
+      );
+    }, EXTRACTION_TIMEOUT_MS);
+
+    let content: string;
+    try {
+      content = await ragService.extractContent(
+        buffer,
+        file.fileType,
+        async (progress) => {
+          if (!isExtractionActive) return;
+          if (progress.stage !== "ocr-page") return;
+
+          const extractionPercentage = 10 + progress.percentage * 0.2;
+          await updateProgress(
+            fileId,
+            "extracting",
+            extractionPercentage,
+            undefined,
+            undefined,
+            progress.currentPage,
+            progress.totalPages,
+          );
+        },
+        abortController.signal,
+      );
+    } finally {
+      clearTimeout(timeoutId);
+      isExtractionActive = false;
+    }
     await updateProgress(fileId, "extracting", 30);
 
     // Stage 3: Chunk text (30-40%)
@@ -228,10 +312,16 @@ export async function processFile(params: {
     const embeddings: number[][] = [];
     const embeddingProgressStart = 40;
     const embeddingProgressRange = 50; // 40% to 90%
-    const BATCH_SIZE = 50; // Process 50 chunks at a time (reduced to avoid rate limits)
 
-    for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
-      const batchEnd = Math.min(i + BATCH_SIZE, chunks.length);
+    for (
+      let i = 0;
+      i < chunks.length;
+      i += PROCESSING_CONFIG.EMBEDDING_BATCH_SIZE
+    ) {
+      const batchEnd = Math.min(
+        i + PROCESSING_CONFIG.EMBEDDING_BATCH_SIZE,
+        chunks.length,
+      );
       const batch = chunks.slice(i, batchEnd);
 
       // Validate batch
@@ -274,12 +364,15 @@ export async function processFile(params: {
         chunks.length,
       );
 
-      logInfo(`Batch ${Math.floor(i / BATCH_SIZE) + 1} completed`, {
-        fileId,
-        processed: batchEnd,
-        total: chunks.length,
-        percentage: progress.toFixed(1),
-      });
+      logInfo(
+        `Batch ${Math.floor(i / PROCESSING_CONFIG.EMBEDDING_BATCH_SIZE) + 1} completed`,
+        {
+          fileId,
+          processed: batchEnd,
+          total: chunks.length,
+          percentage: progress.toFixed(1),
+        },
+      );
     }
 
     // Stage 5: Store chunks with embeddings in database (90-100%)
@@ -300,7 +393,18 @@ export async function processFile(params: {
       }),
     );
 
-    await db.insert(fileChunks).values(chunkRecords).onConflictDoNothing();
+    for (
+      let i = 0;
+      i < chunkRecords.length;
+      i += PROCESSING_CONFIG.DB_INSERT_BATCH_SIZE
+    ) {
+      await db
+        .insert(fileChunks)
+        .values(
+          chunkRecords.slice(i, i + PROCESSING_CONFIG.DB_INSERT_BATCH_SIZE),
+        )
+        .onConflictDoNothing();
+    }
     await updateProgress(fileId, "storing", 95, chunks.length, chunks.length);
 
     // Update file status to completed
@@ -352,11 +456,18 @@ export async function processFile(params: {
     // Mark file as failed -- wrapped in try/catch so status update failure
     // doesn't mask the original processing error
     try {
+      const [currentFile] = await db
+        .select()
+        .from(userFiles)
+        .where(eq(userFiles.id, fileId))
+        .limit(1);
+
       await db
         .update(userFiles)
         .set({
           processingStatus: "failed",
           metadata: {
+            ...(currentFile?.metadata ?? {}),
             error: sanitizeProcessingError(error),
           },
         })
@@ -372,5 +483,7 @@ export async function processFile(params: {
     }
 
     throw error;
+  } finally {
+    ragService.cleanup();
   }
 }

--- a/apps/web/src/lib/upload-file-types.ts
+++ b/apps/web/src/lib/upload-file-types.ts
@@ -1,0 +1,120 @@
+export const ALLOWED_FILE_TYPES = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/tiff",
+  "text/plain",
+  "text/markdown",
+  "application/json",
+  "text/csv",
+] as const;
+
+export type AllowedFileType = (typeof ALLOWED_FILE_TYPES)[number];
+
+export const ALLOWED_EXTENSIONS = [
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".pptx",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".tiff",
+  ".tif",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".json",
+  ".csv",
+] as const;
+
+export const FILE_INPUT_ACCEPT = ALLOWED_EXTENSIONS.join(",");
+
+export const OCR_MAX_IMAGE_SIZE_MB = 25;
+export const OCR_MAX_IMAGE_SIZE_BYTES = OCR_MAX_IMAGE_SIZE_MB * 1024 * 1024;
+
+export const OCR_IMAGE_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/tiff",
+] as const;
+
+export const EXTENSION_TO_FILE_TYPE: Record<string, AllowedFileType> = {
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".pptx":
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".tiff": "image/tiff",
+  ".tif": "image/tiff",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
+  ".json": "application/json",
+  ".csv": "text/csv",
+};
+
+export const FILE_TYPE_DISPLAY_NAMES: Record<string, string> = {
+  "application/pdf": "PDF",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "Word (.docx)",
+  "application/msword": "Word (.doc)",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "PPTX",
+  "image/jpeg": "JPEG image",
+  "image/png": "PNG image",
+  "image/webp": "WEBP image",
+  "image/tiff": "TIFF image",
+  "text/plain": "Text",
+  "text/markdown": "Markdown",
+  "application/json": "JSON",
+  "text/csv": "CSV",
+};
+
+export function getFileExtension(fileName: string): string | null {
+  const lastDot = fileName.lastIndexOf(".");
+  if (lastDot <= 0 || lastDot === fileName.length - 1) {
+    return null;
+  }
+  return fileName.slice(lastDot).toLowerCase();
+}
+
+export function inferSupportedFileType(
+  fileName: string,
+  declaredType: string,
+): string {
+  const extension = getFileExtension(fileName);
+  const extensionType = extension ? EXTENSION_TO_FILE_TYPE[extension] : null;
+
+  if (
+    extensionType &&
+    (!declaredType ||
+      declaredType === "application/octet-stream" ||
+      (declaredType === "text/plain" && extensionType !== "text/plain"))
+  ) {
+    return extensionType;
+  }
+
+  if (ALLOWED_FILE_TYPES.includes(declaredType as AllowedFileType)) {
+    return declaredType;
+  }
+
+  return extensionType ?? declaredType;
+}
+
+export function isOCRImageFileType(fileType: string): boolean {
+  return OCR_IMAGE_FILE_TYPES.includes(
+    fileType as (typeof OCR_IMAGE_FILE_TYPES)[number],
+  );
+}

--- a/apps/web/src/server/routers/files/procedures/create-upload-url.ts
+++ b/apps/web/src/server/routers/files/procedures/create-upload-url.ts
@@ -53,8 +53,8 @@ export const createUploadUrlProcedure = protectedProcedure
 
     // Validate file input
     validateFileName(input.fileName);
-    validateFileSize(input.fileSize);
     validateFileType(input.fileType);
+    validateFileSize(input.fileSize, input.fileType);
     validateExtensionMatchesMimeType(input.fileName, input.fileType);
 
     // Check for duplicate file name early (before generating signed URL)

--- a/apps/web/src/server/routers/files/procedures/finalize-upload.ts
+++ b/apps/web/src/server/routers/files/procedures/finalize-upload.ts
@@ -14,6 +14,12 @@ import { publishQStashJob } from "@/lib/qstash";
 import { env } from "@/lib/env";
 import { logInfo, logError } from "@/lib/logger";
 import { processFile } from "@/lib/file-processor";
+import {
+  validateFileName,
+  validateFileSize,
+  validateFileType,
+  validateExtensionMatchesMimeType,
+} from "../validation";
 
 /**
  * Finalize upload after client has uploaded to storage.
@@ -47,6 +53,11 @@ export const finalizeUploadProcedure = protectedProcedure
     }
 
     try {
+      validateFileName(input.fileName);
+      validateFileType(input.fileType);
+      validateFileSize(input.fileSize, input.fileType);
+      validateExtensionMatchesMimeType(input.fileName, input.fileType);
+
       // Validate storage path matches expected pattern: {userId}/{fileId}
       const expectedPath = `${ctx.session.user.id}/${input.fileId}`;
       if (input.storagePath !== expectedPath) {

--- a/apps/web/src/server/routers/files/validation.ts
+++ b/apps/web/src/server/routers/files/validation.ts
@@ -1,54 +1,33 @@
 import { TRPCError } from "@trpc/server";
 import { env } from "@/lib/env";
+import {
+  ALLOWED_FILE_TYPES,
+  EXTENSION_TO_FILE_TYPE,
+  FILE_TYPE_DISPLAY_NAMES,
+  OCR_MAX_IMAGE_SIZE_MB,
+  OCR_MAX_IMAGE_SIZE_BYTES,
+  isOCRImageFileType,
+} from "@/lib/upload-file-types";
 
 /**
  * Supported MIME types for file uploads
  */
-export const SUPPORTED_FILE_TYPES = [
-  "application/pdf",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "application/msword",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "text/plain",
-  "text/markdown",
-  "application/json",
-  "text/csv",
-] as const;
+export const SUPPORTED_FILE_TYPES = ALLOWED_FILE_TYPES;
 
 /**
  * File extension to MIME type mapping
  */
-export const EXTENSION_MIME_MAP: Record<string, string[]> = {
-  pdf: ["application/pdf"],
-  doc: ["application/msword"],
-  docx: [
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  ],
-  pptx: [
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  ],
-  txt: ["text/plain"],
-  md: ["text/markdown"],
-  markdown: ["text/markdown"],
-  json: ["application/json"],
-  csv: ["text/csv"],
-} as const;
+export const EXTENSION_MIME_MAP: Record<string, string[]> = Object.fromEntries(
+  Object.entries(EXTENSION_TO_FILE_TYPE).map(([extension, mimeType]) => [
+    extension.slice(1),
+    [mimeType],
+  ]),
+);
 
 /**
  * User-friendly file type names for error messages
  */
-export const FILE_TYPE_DISPLAY_NAMES: Record<string, string> = {
-  "application/pdf": "PDF",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    "Word (.docx)",
-  "application/msword": "Word (.doc)",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-    "PPTX",
-  "text/plain": "Text",
-  "text/markdown": "Markdown",
-  "application/json": "JSON",
-  "text/csv": "CSV",
-};
+export { FILE_TYPE_DISPLAY_NAMES };
 
 /**
  * Validates file name for invalid characters and length
@@ -80,7 +59,7 @@ export function validateFileName(fileName: string): void {
 /**
  * Validates file size
  */
-export function validateFileSize(fileSize: number): void {
+export function validateFileSize(fileSize: number, fileType?: string): void {
   if (fileSize === 0) {
     throw new TRPCError({
       code: "BAD_REQUEST",
@@ -97,6 +76,19 @@ export function validateFileSize(fileSize: number): void {
       message: `File size exceeds ${maxSizeMB}MB limit. Current file size: ${(fileSize / 1024 / 1024).toFixed(2)}MB`,
     });
   }
+
+  if (fileType && isOCRImageFileType(fileType)) {
+    validateOCRImageFileSize(fileSize);
+  }
+}
+
+export function validateOCRImageFileSize(fileSize: number): void {
+  if (fileSize > OCR_MAX_IMAGE_SIZE_BYTES) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Image file size exceeds the ${OCR_MAX_IMAGE_SIZE_MB}MB OCR processing limit. Please compress the image or upload a smaller file.`,
+    });
+  }
 }
 
 /**
@@ -111,7 +103,7 @@ export function validateFileType(fileType: string): void {
     const displayName = FILE_TYPE_DISPLAY_NAMES[fileType] || fileType;
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: `Unsupported file type: ${displayName}. Supported types: PDF, Word (.doc, .docx), PowerPoint (.pptx), Text, Markdown, JSON, CSV`,
+      message: `Unsupported file type: ${displayName}. Supported types: PDF, Word (.doc, .docx), PowerPoint (.pptx), Images (JPG, PNG, WEBP, TIFF), Text, Markdown, JSON, CSV`,
     });
   }
 }
@@ -125,10 +117,18 @@ export function validateExtensionMatchesMimeType(
   fileType: string,
 ): void {
   const fileNameLower = fileName.toLowerCase();
-  const extension = fileNameLower.substring(fileNameLower.lastIndexOf(".") + 1);
+  const lastDot = fileNameLower.lastIndexOf(".");
+  const extension = lastDot >= 0 ? fileNameLower.substring(lastDot + 1) : "";
   const validMimeTypes = EXTENSION_MIME_MAP[extension];
 
-  if (extension && validMimeTypes && !validMimeTypes.includes(fileType)) {
+  if (!extension || !validMimeTypes) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `File extension${extension ? ` (.${extension})` : ""} is not supported.`,
+    });
+  }
+
+  if (!validMimeTypes.includes(fileType)) {
     const displayName = FILE_TYPE_DISPLAY_NAMES[fileType] || fileType;
     throw new TRPCError({
       code: "BAD_REQUEST",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.19.0"
       }
     },
     "apps/web": {
@@ -23877,6 +23877,7 @@
         "@langchain/core": "^1.1.42",
         "@langchain/textsplitters": "^1.0.0",
         "@mozilla/readability": "^0.6.0",
+        "@napi-rs/canvas": "^0.1.100",
         "@openrouter/ai-sdk-provider": "^1.5.4",
         "@teachanything/logger": "*",
         "@types/jsdom": "^21.1.7",
@@ -23890,7 +23891,9 @@
         "nanoid": "^5.1.9",
         "officeparser": "^6.1.0",
         "pdf-parse": "^1.1.1",
-        "robots-parser": "^3.0.1"
+        "pdfjs-dist": "^5.6.205",
+        "robots-parser": "^3.0.1",
+        "tesseract.js": "^7.0.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "packageManager": "npm@11.4.2",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "workspaces": [
     "apps/*",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -14,12 +14,14 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
-    "@teachanything/logger": "*",
     "@langchain/community": "^1.1.27",
     "@langchain/core": "^1.1.42",
     "@langchain/textsplitters": "^1.0.0",
     "@mozilla/readability": "^0.6.0",
+    "@napi-rs/canvas": "^0.1.100",
     "@openrouter/ai-sdk-provider": "^1.5.4",
+    "@teachanything/logger": "*",
+    "@types/jsdom": "^21.1.7",
     "@types/pdf-parse": "^1.1.4",
     "ai": "^6.0.168",
     "cheerio": "^1.2.0",
@@ -30,10 +32,12 @@
     "nanoid": "^5.1.9",
     "officeparser": "^6.1.0",
     "pdf-parse": "^1.1.1",
+    "pdfjs-dist": "^5.6.205",
     "robots-parser": "^3.0.1",
-    "@types/jsdom": "^21.1.7"
+    "tesseract.js": "^7.0.0"
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:cov": "NODE_OPTIONS=--experimental-vm-modules jest --coverage"

--- a/packages/ai/src/__tests__/extract-powerpoint.test.ts
+++ b/packages/ai/src/__tests__/extract-powerpoint.test.ts
@@ -1,8 +1,30 @@
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "@jest/globals";
+
+interface MockOfficeAST {
+  content: Array<{
+    type: string;
+    children: Array<{ type: string; text: string }>;
+    metadata: {
+      slideNumber: number;
+      noteId?: string;
+    };
+  }>;
+  toText: () => string;
+}
+
+const mockParseOffice = jest.fn<(buffer: Buffer) => Promise<MockOfficeAST>>();
 
 // Mock officeparser before importing the module under test
 jest.unstable_mockModule("officeparser", () => ({
-  parseOffice: jest.fn(),
+  parseOffice: mockParseOffice,
 }));
 
 // Dynamic import after mock setup (ESM pattern per AGENTS.md)
@@ -16,7 +38,7 @@ function buildMockAST(
     noteId?: string;
     children: Array<{ type: string; text: string }>;
   }>,
-) {
+): MockOfficeAST {
   return {
     content: nodes.map((n) => ({
       type: n.type,
@@ -33,12 +55,17 @@ function buildMockAST(
 
 describe("extractPowerPoint", () => {
   let service: InstanceType<typeof RAGService>;
-  let mockParseOffice: jest.Mock;
 
-  beforeEach(async () => {
+  beforeAll(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
     service = new RAGService();
-    const officeparser = await import("officeparser");
-    mockParseOffice = officeparser.parseOffice as jest.Mock;
     mockParseOffice.mockReset();
   });
 

--- a/packages/ai/src/__tests__/ocr-extraction.test.ts
+++ b/packages/ai/src/__tests__/ocr-extraction.test.ts
@@ -1,0 +1,484 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+interface TesseractResult {
+  data: { text: string };
+}
+
+interface PdfParseResult {
+  text: string;
+  numpages: number;
+}
+
+interface PdfPage {
+  getTextContent: () => Promise<{ items: Array<{ str: string }> }>;
+  getViewport: (opts: { scale: number }) => { width: number; height: number };
+  render: typeof renderMock;
+  cleanup: () => void;
+}
+
+const recognizeMock = jest.fn<(buffer: Buffer) => Promise<TesseractResult>>();
+const createWorkerMock = jest.fn<
+  (
+    language: string,
+    oem: number,
+    options: unknown,
+  ) => Promise<{
+    recognize: typeof recognizeMock;
+    terminate: () => Promise<void>;
+  }>
+>();
+const pdfParseMock = jest.fn<(buffer: Buffer) => Promise<PdfParseResult>>();
+const renderMock = jest.fn<() => { promise: Promise<void> }>();
+const getPageMock = jest.fn<(pageNumber: number) => Promise<PdfPage>>();
+const destroyMock = jest.fn();
+const getDocumentMock = jest.fn();
+const createCanvasMock = jest.fn();
+const loadImageMock =
+  jest.fn<() => Promise<{ width: number; height: number }>>();
+
+const pngBuffer = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
+]);
+
+jest.unstable_mockModule("@teachanything/logger", () => ({
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
+jest.unstable_mockModule("tesseract.js", () => ({
+  createWorker: createWorkerMock,
+}));
+
+jest.unstable_mockModule("pdf-parse", () => ({
+  default: pdfParseMock,
+}));
+
+jest.unstable_mockModule("@napi-rs/canvas", () => ({
+  DOMMatrix: class DOMMatrix {},
+  ImageData: class ImageData {},
+  Path2D: class Path2D {},
+  createCanvas: createCanvasMock,
+  loadImage: loadImageMock,
+}));
+
+jest.unstable_mockModule("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  getDocument: getDocumentMock,
+}));
+
+const { RAGService } = await import("../rag-service");
+
+describe("OCR extraction", () => {
+  let service: InstanceType<typeof RAGService>;
+
+  beforeEach(() => {
+    service = new RAGService();
+    recognizeMock.mockReset();
+    createWorkerMock.mockReset();
+    pdfParseMock.mockReset();
+    renderMock.mockReset();
+    getPageMock.mockReset();
+    destroyMock.mockReset();
+    getDocumentMock.mockReset();
+    createCanvasMock.mockReset();
+    loadImageMock.mockReset();
+
+    createWorkerMock.mockResolvedValue({
+      recognize: recognizeMock,
+      terminate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+    loadImageMock.mockResolvedValue({ width: 100, height: 100 });
+    pdfParseMock.mockResolvedValue({ text: "  \n", numpages: 2 });
+    getDocumentMock.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 2,
+        getPage: getPageMock,
+        destroy: destroyMock,
+      }),
+    });
+    renderMock.mockReturnValue({ promise: Promise.resolve() });
+    createCanvasMock.mockReturnValue({
+      getContext: jest.fn(() => ({})),
+      toBuffer: jest.fn(() => pngBuffer),
+    });
+    getPageMock.mockResolvedValue({
+      getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+      getViewport: jest.fn((opts: { scale: number }) => ({
+        width: 100 * opts.scale,
+        height: 200 * opts.scale,
+      })),
+      render: renderMock,
+      cleanup: jest.fn(),
+    });
+  });
+
+  afterEach(async () => {
+    service.cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("extracts and sanitizes text from supported images", async () => {
+    recognizeMock.mockResolvedValue({
+      data: { text: " Lecture notes\0\nwith text " },
+    });
+
+    await expect(
+      service.extractTextFromImage(pngBuffer, "image/png"),
+    ).resolves.toBe("Lecture notes\nwith text");
+    expect(recognizeMock).toHaveBeenCalledWith(pngBuffer);
+  });
+
+  it("creates the OCR worker with the default language", async () => {
+    recognizeMock.mockResolvedValue({ data: { text: "text" } });
+    await service.extractTextFromImage(pngBuffer, "image/png");
+    expect(createWorkerMock).toHaveBeenCalledWith(
+      "eng",
+      1,
+      expect.objectContaining({ logger: expect.any(Function) }),
+    );
+  });
+
+  it("reuses the same worker across multiple calls", async () => {
+    recognizeMock.mockResolvedValue({ data: { text: "text" } });
+    await service.extractTextFromImage(pngBuffer, "image/png");
+    await service.extractTextFromImage(pngBuffer, "image/png");
+    expect(createWorkerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects images whose header does not match the declared MIME type", async () => {
+    await expect(
+      service.extractTextFromImage(pngBuffer, "image/jpeg"),
+    ).rejects.toThrow("Invalid image format: expected image/jpeg");
+    expect(recognizeMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces OCR failures for images", async () => {
+    recognizeMock.mockRejectedValue(new Error("OCR worker failed"));
+
+    await expect(
+      service.extractTextFromImage(pngBuffer, "image/png"),
+    ).rejects.toThrow("OCR worker failed");
+  });
+
+  it("clears the worker init promise on failure so the next call retries", async () => {
+    createWorkerMock
+      .mockRejectedValueOnce(new Error("WASM load failed"))
+      .mockResolvedValueOnce({
+        recognize: recognizeMock,
+        terminate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      });
+    recognizeMock.mockResolvedValue({ data: { text: "retry worked" } });
+
+    await expect(
+      service.extractTextFromImage(pngBuffer, "image/png"),
+    ).rejects.toThrow("WASM load failed");
+
+    await expect(
+      service.extractTextFromImage(pngBuffer, "image/png"),
+    ).resolves.toBe("retry worked");
+
+    expect(createWorkerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("terminates the worker on cleanup even if init is still in flight", async () => {
+    const terminateMock = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+    let resolveWorker!: (w: {
+      recognize: typeof recognizeMock;
+      terminate: typeof terminateMock;
+    }) => void;
+    createWorkerMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorker = resolve;
+      }),
+    );
+
+    const ocr = service.extractTextFromImage(pngBuffer, "image/png");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    service.cleanup();
+    resolveWorker({ recognize: recognizeMock, terminate: terminateMock });
+
+    await expect(ocr).rejects.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(terminateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls page.cleanup() after rendering each PDF page", async () => {
+    recognizeMock.mockResolvedValue({ data: { text: "text" } });
+    const pages = [
+      {
+        getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+        getViewport: jest.fn((opts: { scale: number }) => ({
+          width: 100 * opts.scale,
+          height: 200 * opts.scale,
+        })),
+        render: renderMock,
+        cleanup: jest.fn(),
+      },
+      {
+        getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+        getViewport: jest.fn((opts: { scale: number }) => ({
+          width: 100 * opts.scale,
+          height: 200 * opts.scale,
+        })),
+        render: renderMock,
+        cleanup: jest.fn(),
+      },
+    ];
+    getPageMock
+      .mockResolvedValueOnce(pages[0] as PdfPage)
+      .mockResolvedValueOnce(pages[1] as PdfPage);
+
+    await service.extractContent(
+      Buffer.from("%PDF-1.7 scanned"),
+      "application/pdf",
+    );
+
+    for (const page of pages) {
+      expect(page.cleanup).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("continues processing remaining pages when one page fails to render", async () => {
+    recognizeMock.mockResolvedValueOnce({ data: { text: "page text" } });
+
+    const cleanupMock = jest.fn();
+    getPageMock
+      .mockResolvedValueOnce({
+        getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+        getViewport: jest.fn(() => ({ width: 200, height: 400 })),
+        render: jest.fn(() => ({
+          promise: Promise.reject(new Error("render crash")),
+        })),
+        cleanup: cleanupMock,
+      })
+      .mockResolvedValueOnce({
+        getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+        getViewport: jest.fn((opts: { scale: number }) => ({
+          width: 100 * opts.scale,
+          height: 200 * opts.scale,
+        })),
+        render: renderMock,
+        cleanup: cleanupMock,
+      });
+
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 scanned"),
+      "application/pdf",
+    );
+
+    expect(result).toBe("page text");
+    expect(recognizeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to OCR when PDF text extraction returns minimal text", async () => {
+    recognizeMock
+      .mockResolvedValueOnce({ data: { text: "Page one text" } })
+      .mockResolvedValueOnce({ data: { text: "Page two text" } });
+
+    const progressCalls: Array<{
+      stage: "ocr-page";
+      currentPage: number;
+      totalPages: number;
+      percentage: number;
+    }> = [];
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 scanned"),
+      "application/pdf",
+      (progress) => {
+        progressCalls.push(progress);
+      },
+    );
+
+    expect(result).toBe("Page one text\n\nPage two text");
+    expect(recognizeMock).toHaveBeenCalledTimes(2);
+    expect(progressCalls).toContainEqual({
+      stage: "ocr-page",
+      currentPage: 1,
+      totalPages: 2,
+      percentage: 0,
+    });
+    expect(progressCalls).toContainEqual({
+      stage: "ocr-page",
+      currentPage: 2,
+      totalPages: 2,
+      percentage: 50,
+    });
+    expect(progressCalls).toContainEqual({
+      stage: "ocr-page",
+      currentPage: 2,
+      totalPages: 2,
+      percentage: 100,
+    });
+    const firstPage = (await getPageMock.mock.results[0]?.value) as
+      | PdfPage
+      | undefined;
+    expect(firstPage?.getViewport).toHaveBeenCalledWith({ scale: 2 });
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not OCR PDFs with enough embedded text", async () => {
+    pdfParseMock.mockResolvedValue({
+      text: "Readable embedded PDF text. ".repeat(10),
+      numpages: 1,
+    });
+
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 text"),
+      "application/pdf",
+    );
+
+    expect(result).toContain("Readable embedded PDF text");
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(getDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it("does not OCR single-page PDFs with substantial embedded text", async () => {
+    pdfParseMock.mockResolvedValue({
+      text: "A".repeat(200),
+      numpages: 1,
+    });
+
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 text"),
+      "application/pdf",
+    );
+
+    expect(result).toBe("A".repeat(200));
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(getDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it("does not OCR short single-page PDFs with embedded text", async () => {
+    pdfParseMock.mockResolvedValue({
+      text: "Brief syllabus note.",
+      numpages: 1,
+    });
+
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 text"),
+      "application/pdf",
+    );
+
+    expect(result).toBe("Brief syllabus note.");
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(getDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves embedded text when OCR fallback adds scanned page text", async () => {
+    pdfParseMock.mockResolvedValue({
+      text: "Readable page one text",
+      numpages: 2,
+    });
+    recognizeMock.mockResolvedValueOnce({ data: { text: "Scanned page two" } });
+    getPageMock
+      .mockResolvedValueOnce({
+        getTextContent: jest.fn(() =>
+          Promise.resolve({ items: [{ str: "Readable page one text" }] }),
+        ),
+        getViewport: jest.fn((opts: { scale: number }) => ({
+          width: 100 * opts.scale,
+          height: 200 * opts.scale,
+        })),
+        render: renderMock,
+        cleanup: jest.fn(),
+      })
+      .mockResolvedValueOnce({
+        getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+        getViewport: jest.fn((opts: { scale: number }) => ({
+          width: 100 * opts.scale,
+          height: 200 * opts.scale,
+        })),
+        render: renderMock,
+        cleanup: jest.fn(),
+      });
+
+    const result = await service.extractContent(
+      Buffer.from("%PDF-1.7 mixed"),
+      "application/pdf",
+    );
+
+    expect(result).toBe("Readable page one text\n\nScanned page two");
+  });
+
+  it("uses embedded text when OCR fallback finds no additional text", async () => {
+    pdfParseMock.mockResolvedValue({ text: "Page 1", numpages: 2 });
+    recognizeMock
+      .mockResolvedValueOnce({ data: { text: "   " } })
+      .mockResolvedValueOnce({ data: { text: "   " } });
+
+    await expect(
+      service.extractContent(Buffer.from("%PDF-1.7 mixed"), "application/pdf"),
+    ).resolves.toBe("Page 1");
+  });
+
+  it("does not apply the OCR page limit to long text PDFs", async () => {
+    pdfParseMock.mockResolvedValue({
+      text: "Readable embedded PDF text. ".repeat(20),
+      numpages: 40,
+    });
+
+    await expect(
+      service.extractContent(
+        Buffer.from("%PDF-1.7 long-text"),
+        "application/pdf",
+      ),
+    ).resolves.toContain("Readable embedded PDF text");
+    expect(getDocumentMock).not.toHaveBeenCalled();
+    expect(recognizeMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects scanned PDFs above the OCR page limit", async () => {
+    pdfParseMock.mockResolvedValue({ text: "  \n", numpages: 31 });
+    getDocumentMock.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 31,
+        getPage: getPageMock,
+        destroy: destroyMock,
+      }),
+    });
+    recognizeMock.mockResolvedValue({ data: { text: "page text" } });
+
+    await expect(
+      service.extractContent(Buffer.from("%PDF-1.7 huge"), "application/pdf"),
+    ).rejects.toThrow("too many pages for OCR");
+    expect(recognizeMock).toHaveBeenCalledTimes(30);
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects PDF pages that are too large to render for OCR", async () => {
+    pdfParseMock.mockResolvedValue({ text: "  \n", numpages: 1 });
+    getDocumentMock.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 1,
+        getPage: getPageMock,
+        destroy: destroyMock,
+      }),
+    });
+    getPageMock.mockResolvedValueOnce({
+      getTextContent: jest.fn(() => Promise.resolve({ items: [] })),
+      getViewport: jest.fn(() => ({
+        width: 20_000,
+        height: 20_000,
+      })),
+      render: renderMock,
+      cleanup: jest.fn(),
+    });
+
+    await expect(
+      service.extractContent(
+        Buffer.from("%PDF-1.7 huge-page"),
+        "application/pdf",
+      ),
+    ).rejects.toThrow("too large to render for OCR");
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai/src/__tests__/rag-service.test.ts
+++ b/packages/ai/src/__tests__/rag-service.test.ts
@@ -8,7 +8,61 @@ import {
   beforeAll,
   afterAll,
 } from "@jest/globals";
-import { RAGService, createRAGService } from "../rag-service";
+import type { RAGService as RAGServiceInstance } from "../rag-service";
+
+const loadImageMock = jest.fn(() =>
+  Promise.resolve({ width: 100, height: 100 }),
+);
+const pdfParseMock = jest.fn(() =>
+  Promise.resolve({ text: "mocked pdf text", numpages: 1 }),
+);
+
+jest.unstable_mockModule("tesseract.js", () => ({
+  createWorker: jest.fn(() =>
+    Promise.resolve({
+      recognize: jest.fn(() =>
+        Promise.resolve({ data: { text: "mocked ocr text" } }),
+      ),
+      terminate: jest.fn(() => Promise.resolve(undefined)),
+    }),
+  ),
+}));
+
+jest.unstable_mockModule("pdf-parse", () => ({
+  default: pdfParseMock,
+}));
+
+jest.unstable_mockModule("@napi-rs/canvas", () => ({
+  loadImage: loadImageMock,
+  createCanvas: jest.fn().mockReturnValue({
+    getContext: jest.fn(),
+    toBuffer: jest.fn().mockReturnValue(Buffer.from("mock image png")),
+  }),
+  DOMMatrix: class {},
+  ImageData: class {},
+  Path2D: class {},
+}));
+
+jest.unstable_mockModule("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  getDocument: jest.fn(() => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      getPage: jest.fn(() =>
+        Promise.resolve({
+          getTextContent: jest.fn(() =>
+            Promise.resolve({ items: [{ str: "mocked pdf text" }] }),
+          ),
+          getViewport: jest.fn(() => ({ width: 100, height: 100 })),
+          render: jest.fn(() => ({ promise: Promise.resolve() })),
+          cleanup: jest.fn(),
+        }),
+      ),
+      destroy: jest.fn(() => Promise.resolve(undefined)),
+    }),
+  })),
+}));
+
+const { RAGService, createRAGService } = await import("../rag-service");
 
 // Suppress expected console.error from error-path tests
 beforeAll(() => {
@@ -21,10 +75,12 @@ afterAll(() => {
 });
 
 describe("RAGService", () => {
-  let service: RAGService;
+  let service: RAGServiceInstance;
 
   beforeEach(() => {
     service = new RAGService();
+    loadImageMock.mockResolvedValue({ width: 100, height: 100 });
+    pdfParseMock.mockResolvedValue({ text: "mocked pdf text", numpages: 1 });
   });
 
   afterEach(() => {
@@ -175,6 +231,43 @@ describe("RAGService", () => {
       await expect(
         service.extractContent(buffer, "application/zip"),
       ).rejects.toThrow("Unsupported file type");
+    });
+
+    it("extracts text from image buffer via OCR mock", async () => {
+      const buffer = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+      const result = await service.extractContent(buffer, "image/jpeg");
+      expect(result).toBe("mocked ocr text");
+    });
+
+    it("extracts text from PDF buffer", async () => {
+      const buffer = Buffer.from("%PDF-1.4 mock data");
+      const result = await service.extractContent(buffer, "application/pdf");
+      expect(result).toBe("mocked pdf text");
+    });
+
+    it("respects abort signals during extraction", async () => {
+      const controller = new AbortController();
+      controller.abort(new Error("Timeout Testing Abort"));
+      const buffer = Buffer.from("%PDF-1.4 mock data");
+
+      await expect(
+        service.extractContent(
+          buffer,
+          "application/pdf",
+          undefined,
+          controller.signal,
+        ),
+      ).rejects.toThrow("Timeout Testing Abort");
+    });
+
+    it("rejects oversized images during validation", async () => {
+      const buffer = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+
+      loadImageMock.mockResolvedValue({ width: 20000, height: 20000 });
+
+      await expect(
+        service.extractContent(buffer, "image/jpeg"),
+      ).rejects.toThrow("Image dimensions exceed maximum limit for OCR");
     });
   });
 

--- a/packages/ai/src/openrouter-client.ts
+++ b/packages/ai/src/openrouter-client.ts
@@ -1,9 +1,20 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateText, embed, streamText } from "ai";
+import {
+  generateText,
+  embed,
+  streamText,
+  type AsyncIterableStream,
+  type TextStreamPart,
+  type ToolSet,
+} from "ai";
 import { logInfo } from "@teachanything/logger";
 import { EMBEDDING_MODEL, type SupportedModel } from "./models";
 import { isTransientError } from "./error-utils";
+
+type OpenRouterStreamTextResult = {
+  readonly fullStream: AsyncIterableStream<TextStreamPart<ToolSet>>;
+};
 
 // Re-export so consumers of @teachanything/ai/openrouter subpath still get these
 export { SUPPORTED_MODELS, type SupportedModel } from "./models";
@@ -78,7 +89,7 @@ export class OpenRouterClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
     temperature?: number;
     maxTokens?: number;
-  }) {
+  }): Promise<OpenRouterStreamTextResult> {
     const result = await streamText({
       model: this.client(params.model),
       messages: params.messages,

--- a/packages/ai/src/rag-service.ts
+++ b/packages/ai/src/rag-service.ts
@@ -3,10 +3,80 @@ import { logWarn, logError } from "@teachanything/logger";
 import type { OpenRouterClient } from "./openrouter-client";
 import { CHARS_PER_TOKEN } from "./token-budget";
 
+/**
+ * OCR and extraction configuration
+ */
+const OCR_CONFIG = {
+  /** Max image size before rejecting (25MB) */
+  MAX_IMAGE_BYTES: 25 * 1024 * 1024,
+  /** Multi-page PDFs below this extracted text length are likely scanned. */
+  SCANNED_PDF_TEXT_THRESHOLD: 50,
+  /** Individual fallback-rendered pages below this length are OCR candidates. */
+  PDF_PAGE_OCR_TEXT_THRESHOLD: 10,
+  /** Canvas render scale for PDF→image OCR (2x for quality) */
+  PDF_RENDER_SCALE: 2,
+  /** Avoid unbounded OCR work for huge scanned documents */
+  MAX_PDF_OCR_PAGES: 30,
+  /** Maximum rendered pixels per PDF page before downscaling */
+  MAX_RENDERED_PAGE_PIXELS: 12_000_000,
+  /** Lowest useful scale before a page is too large for reliable OCR */
+  MIN_PDF_RENDER_SCALE: 0.75,
+  /** Default OCR language. Tesseract language code(s), e.g. "eng", "eng+fra" */
+  DEFAULT_OCR_LANGUAGE: "eng",
+  /** Max ms to wait for Tesseract WASM worker to initialise (30s) */
+  WORKER_INIT_TIMEOUT_MS: 30_000,
+  /** Max ms to wait for a single OCR recognition call (2m) */
+  RECOGNITION_TIMEOUT_MS: 120_000,
+} as const;
+
+type ExtractionStage = "ocr-page";
+
+export interface ExtractionProgress {
+  stage: ExtractionStage;
+  currentPage: number;
+  totalPages: number;
+  percentage: number;
+}
+
+export type ExtractionProgressCallback = (
+  progress: ExtractionProgress,
+) => void | Promise<void>;
+
 /** Recursive node type for officeparser AST */
 interface OfficeparserNode {
   text?: string;
   children?: OfficeparserNode[];
+}
+
+interface PdfParseResult {
+  text?: string;
+  numpages?: number;
+}
+
+interface PdfTextItem {
+  str?: string;
+}
+
+interface PdfViewport {
+  width: number;
+  height: number;
+}
+
+interface PdfPage {
+  getTextContent: () => Promise<{ items: PdfTextItem[] }>;
+  getViewport: (opts: { scale: number }) => PdfViewport;
+  render: (params: {
+    canvasContext: unknown;
+    canvas: unknown;
+    viewport: PdfViewport;
+  }) => { promise: Promise<void> };
+  cleanup: () => void;
+}
+
+interface PdfDocument {
+  numPages: number;
+  getPage: (pageNumber: number) => Promise<PdfPage>;
+  destroy: () => Promise<void>;
 }
 
 /**
@@ -18,7 +88,9 @@ export class RAGService {
     encode: (text: string) => number[];
     free?: () => void;
   } | null;
-  private encoderInitialized: boolean = false;
+  private encoderInitPromise: Promise<void> | null = null;
+  private ocrWorkerInitPromise: Promise<import("tesseract.js").Worker> | null =
+    null;
 
   constructor() {
     // Initialize text splitter with optimal chunk size
@@ -36,21 +108,21 @@ export class RAGService {
   /**
    * Lazily initialize tiktoken encoder
    */
-  private async initializeEncoder() {
-    if (this.encoderInitialized) {
-      return;
+  private initializeEncoder(): Promise<void> {
+    if (!this.encoderInitPromise) {
+      this.encoderInitPromise = (async () => {
+        try {
+          const { getEncoding } = await import("js-tiktoken");
+          this.encoder = getEncoding("o200k_base");
+        } catch {
+          logWarn(
+            "Failed to initialize tiktoken, using fallback token counter",
+          );
+          this.encoder = null;
+        }
+      })();
     }
-
-    try {
-      // Use js-tiktoken for better serverless compatibility (pure JS, no WASM)
-      // Use encoding name directly instead of model name to avoid deprecation issues
-      const { getEncoding } = await import("js-tiktoken");
-      this.encoder = getEncoding("o200k_base");
-    } catch (error) {
-      logWarn("Failed to initialize tiktoken, using fallback token counter");
-      this.encoder = null;
-    }
-    this.encoderInitialized = true;
+    return this.encoderInitPromise;
   }
 
   /**
@@ -64,14 +136,38 @@ export class RAGService {
       .trim();
   }
 
+  private withTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    message: string,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error(message)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() =>
+      clearTimeout(timeoutId),
+    );
+  }
+
   /**
    * Extract text content from various file types
    */
-  async extractContent(buffer: Buffer, mimeType: string): Promise<string> {
+  async extractContent(
+    buffer: Buffer,
+    mimeType: string,
+    onProgress?: ExtractionProgressCallback,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const onAbort = () => this.cleanup();
+    signal?.addEventListener("abort", onAbort, { once: true });
+
     try {
+      if (signal?.aborted) throw signal.reason;
+
       switch (mimeType) {
         case "application/pdf":
-          return await this.extractPDF(buffer);
+          return await this.extractPDF(buffer, onProgress, signal);
 
         case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
         case "application/msword":
@@ -79,6 +175,12 @@ export class RAGService {
 
         case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
           return await this.extractPowerPoint(buffer);
+
+        case "image/jpeg":
+        case "image/png":
+        case "image/webp":
+        case "image/tiff":
+          return await this.extractTextFromImage(buffer, mimeType, signal);
 
         case "application/vnd.ms-powerpoint":
           throw new Error(
@@ -99,16 +201,22 @@ export class RAGService {
       logError(error, "Content extraction error");
       throw new Error(
         `Failed to extract content: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
       );
+    } finally {
+      signal?.removeEventListener("abort", onAbort);
     }
   }
 
   /**
    * Extract text from PDF files
    */
-  private async extractPDF(buffer: Buffer): Promise<string> {
+  private async extractPDF(
+    buffer: Buffer,
+    onProgress?: ExtractionProgressCallback,
+    signal?: AbortSignal,
+  ): Promise<string> {
     try {
-      // Ensure we have a valid Buffer instance
       if (!Buffer.isBuffer(buffer)) {
         throw new Error("Invalid buffer: expected Buffer instance");
       }
@@ -117,7 +225,6 @@ export class RAGService {
         throw new Error("Empty buffer: cannot extract PDF from empty buffer");
       }
 
-      // Verify it looks like a PDF by checking the PDF header
       const pdfHeader = buffer.subarray(0, 4).toString();
       if (pdfHeader !== "%PDF") {
         throw new Error(
@@ -125,29 +232,387 @@ export class RAGService {
         );
       }
 
-      // Dynamic import to avoid build-time execution
-      const pdfParse = (await import("pdf-parse")).default;
-
-      // Pass the buffer directly - pdf-parse accepts Buffer instances
-      const data = await pdfParse(buffer);
-
-      if (!data || !data.text) {
-        throw new Error("PDF parsing returned no text content");
+      const parsed = await this.extractPDFText(buffer);
+      if (!this.shouldUsePDFOCRFallback(parsed)) {
+        if (!parsed.text) {
+          throw new Error("PDF contains no readable text content");
+        }
+        return parsed.text;
       }
 
-      // Sanitize the text to remove null bytes and other problematic characters
-      const sanitizedText = this.sanitizeText(data.text);
-
-      if (!sanitizedText) {
-        throw new Error("PDF contains no readable text content");
-      }
-
-      return sanitizedText;
+      return await this.extractPDFWithOCRFallback(
+        buffer,
+        parsed.text,
+        onProgress,
+        signal,
+      );
     } catch (error) {
       logError(error, "PDF extraction error");
       throw new Error(
         `Failed to extract PDF content: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
       );
+    }
+  }
+
+  private async extractPDFText(buffer: Buffer): Promise<{
+    text: string;
+    pageCount?: number;
+  }> {
+    const pdfParse = (await import("pdf-parse")).default as (
+      input: Buffer,
+    ) => Promise<PdfParseResult>;
+    const data = await pdfParse(buffer);
+    return {
+      text: this.sanitizeText(data.text ?? ""),
+      pageCount: data.numpages,
+    };
+  }
+
+  private shouldUsePDFOCRFallback(parsed: {
+    text: string;
+    pageCount?: number;
+  }): boolean {
+    if (!parsed.text) {
+      return true;
+    }
+
+    return (
+      parsed.pageCount !== undefined &&
+      parsed.pageCount > 1 &&
+      parsed.text.length < OCR_CONFIG.SCANNED_PDF_TEXT_THRESHOLD
+    );
+  }
+
+  private async loadPDFDocument(buffer: Buffer): Promise<PdfDocument> {
+    const pdfjsLib =
+      (await import("pdfjs-dist/legacy/build/pdf.mjs")) as unknown as {
+        getDocument: (source: unknown) => { promise: Promise<PdfDocument> };
+      };
+    const { DOMMatrix, ImageData, Path2D } = await import("@napi-rs/canvas");
+
+    const globals = globalThis as Record<
+      "DOMMatrix" | "ImageData" | "Path2D",
+      unknown
+    >;
+    globals.DOMMatrix ??= DOMMatrix;
+    globals.ImageData ??= ImageData;
+    globals.Path2D ??= Path2D;
+
+    const loadingTask = pdfjsLib.getDocument({
+      data: new Uint8Array(buffer),
+      disableWorker: true,
+    });
+    return await loadingTask.promise;
+  }
+
+  private async extractPDFWithOCRFallback(
+    buffer: Buffer,
+    fallbackText: string,
+    onProgress?: ExtractionProgressCallback,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const document = await this.loadPDFDocument(buffer);
+    const pageTexts: string[] = [];
+    let ocrPageCount = 0;
+
+    try {
+      for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
+        if (signal?.aborted) throw signal.reason;
+
+        await onProgress?.({
+          stage: "ocr-page",
+          currentPage: pageNumber,
+          totalPages: document.numPages,
+          percentage: ((pageNumber - 1) / document.numPages) * 100,
+        });
+
+        const page = await document.getPage(pageNumber);
+        try {
+          const textContent = await page.getTextContent();
+          const pageText = textContent.items
+            .map((item) => item.str ?? "")
+            .join(" ");
+          const sanitizedText = this.sanitizeText(pageText);
+
+          if (sanitizedText.length < OCR_CONFIG.PDF_PAGE_OCR_TEXT_THRESHOLD) {
+            ocrPageCount++;
+            if (ocrPageCount > OCR_CONFIG.MAX_PDF_OCR_PAGES) {
+              throw new Error(
+                `PDF has too many pages for OCR. Maximum supported scanned PDF length is ${OCR_CONFIG.MAX_PDF_OCR_PAGES} pages.`,
+              );
+            }
+
+            const ocrText = await this.extractTextFromRenderedPDFPage(
+              pageNumber,
+              document.numPages,
+              page,
+              signal,
+            );
+            pageTexts.push(ocrText || sanitizedText);
+          } else {
+            pageTexts.push(sanitizedText);
+          }
+        } finally {
+          page.cleanup();
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (signal?.aborted) throw signal.reason;
+
+        await onProgress?.({
+          stage: "ocr-page",
+          currentPage: pageNumber,
+          totalPages: document.numPages,
+          percentage: (pageNumber / document.numPages) * 100,
+        });
+      }
+    } finally {
+      await document.destroy();
+    }
+
+    const finalContent = this.sanitizeText(
+      pageTexts.filter(Boolean).join("\n\n"),
+    );
+    if (!finalContent && fallbackText) {
+      return fallbackText;
+    }
+
+    if (!finalContent) {
+      throw new Error("PDF contains no readable text content");
+    }
+
+    return finalContent;
+  }
+
+  /**
+   * Extract text from image files with OCR.
+   */
+  async extractTextFromImage(
+    buffer: Buffer,
+    mimeType?: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (signal?.aborted) throw signal.reason;
+    this.validateImageBuffer(buffer, mimeType);
+
+    const { loadImage } = await import("@napi-rs/canvas");
+    try {
+      const img = await loadImage(buffer);
+      if (img.width * img.height > OCR_CONFIG.MAX_RENDERED_PAGE_PIXELS) {
+        throw new Error("Image dimensions exceed maximum limit for OCR");
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("dimensions exceed")
+      ) {
+        throw error;
+      }
+      throw new Error("Invalid image format: unable to decode image");
+    }
+
+    const sanitizedText = await this.extractTextFromTrustedImage(
+      buffer,
+      signal,
+    );
+
+    if (!sanitizedText) {
+      throw new Error("Image contains no readable text content");
+    }
+
+    return sanitizedText;
+  }
+
+  private validateImageBuffer(buffer: Buffer, mimeType?: string): void {
+    if (!Buffer.isBuffer(buffer)) {
+      throw new Error("Invalid buffer: expected Buffer instance");
+    }
+
+    if (buffer.length === 0) {
+      throw new Error("Empty buffer: cannot extract image from empty buffer");
+    }
+
+    if (buffer.length > OCR_CONFIG.MAX_IMAGE_BYTES) {
+      throw new Error(
+        `Image exceeds OCR size limit of ${OCR_CONFIG.MAX_IMAGE_BYTES / 1024 / 1024}MB`,
+      );
+    }
+
+    if (!mimeType) {
+      return;
+    }
+
+    const detectedMimeType = this.detectImageMimeType(buffer);
+    if (!detectedMimeType) {
+      throw new Error("Invalid image format: unknown image header");
+    }
+
+    if (detectedMimeType !== mimeType) {
+      throw new Error(
+        `Invalid image format: expected ${mimeType}, got ${detectedMimeType}`,
+      );
+    }
+  }
+
+  private detectImageMimeType(buffer: Buffer): string | null {
+    if (
+      buffer.length >= 3 &&
+      buffer[0] === 0xff &&
+      buffer[1] === 0xd8 &&
+      buffer[2] === 0xff
+    ) {
+      return "image/jpeg";
+    }
+
+    if (
+      buffer.length >= 8 &&
+      buffer
+        .subarray(0, 8)
+        .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    ) {
+      return "image/png";
+    }
+
+    if (
+      buffer.length >= 12 &&
+      buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+      buffer.subarray(8, 12).toString("ascii") === "WEBP"
+    ) {
+      return "image/webp";
+    }
+
+    if (
+      buffer.length >= 4 &&
+      ((buffer[0] === 0x49 &&
+        buffer[1] === 0x49 &&
+        buffer[2] === 0x2a &&
+        buffer[3] === 0x00) ||
+        (buffer[0] === 0x4d &&
+          buffer[1] === 0x4d &&
+          buffer[2] === 0x00 &&
+          buffer[3] === 0x2a))
+    ) {
+      return "image/tiff";
+    }
+
+    return null;
+  }
+
+  private async getOCRWorker(): Promise<import("tesseract.js").Worker> {
+    if (!this.ocrWorkerInitPromise) {
+      this.ocrWorkerInitPromise = (async () => {
+        const { createWorker } = await import("tesseract.js");
+        const { tmpdir } = await import("node:os");
+        const { join } = await import("node:path");
+
+        return this.withTimeout(
+          createWorker(OCR_CONFIG.DEFAULT_OCR_LANGUAGE, 1, {
+            logger: () => {},
+            cachePath: join(tmpdir(), "tesseract-cache"),
+          }),
+          OCR_CONFIG.WORKER_INIT_TIMEOUT_MS,
+          "OCR worker initialisation timed out",
+        );
+      })().catch((err) => {
+        this.ocrWorkerInitPromise = null;
+        throw err;
+      });
+    }
+    return this.ocrWorkerInitPromise;
+  }
+
+  private async extractTextFromTrustedImage(
+    buffer: Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (signal?.aborted) throw signal.reason;
+    const worker = await this.getOCRWorker();
+    const result = await this.withTimeout(
+      worker.recognize(buffer),
+      OCR_CONFIG.RECOGNITION_TIMEOUT_MS,
+      "OCR recognition timed out",
+    );
+    if (signal?.aborted) throw signal.reason;
+
+    const sanitizedText = this.sanitizeText(result.data.text);
+    if (!sanitizedText) {
+      throw new Error("Image contains no readable text content");
+    }
+    return sanitizedText;
+  }
+
+  private async extractTextFromRenderedPDFPage(
+    pageNumber: number,
+    totalPages: number,
+    page: PdfPage,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (signal?.aborted) throw signal.reason;
+    const { createCanvas } = await import("@napi-rs/canvas");
+
+    let buffer: Buffer;
+    try {
+      const baseViewport = page.getViewport({ scale: 1 });
+      const basePixelCount = baseViewport.width * baseViewport.height;
+      if (basePixelCount <= 0) {
+        throw new Error(`PDF page ${pageNumber} has invalid dimensions`);
+      }
+
+      const scale = Math.min(
+        OCR_CONFIG.PDF_RENDER_SCALE,
+        Math.sqrt(OCR_CONFIG.MAX_RENDERED_PAGE_PIXELS / basePixelCount),
+      );
+
+      if (scale < OCR_CONFIG.MIN_PDF_RENDER_SCALE) {
+        throw new Error(
+          `PDF page ${pageNumber} is too large to render for OCR`,
+        );
+      }
+
+      const viewport = page.getViewport({ scale });
+      const canvas = createCanvas(
+        Math.ceil(viewport.width),
+        Math.ceil(viewport.height),
+      );
+      const context = canvas.getContext("2d");
+
+      await page.render({
+        canvasContext: context,
+        canvas,
+        viewport,
+      }).promise;
+
+      buffer = canvas.toBuffer("image/png");
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("too large to render for OCR")
+      ) {
+        throw error;
+      }
+      logWarn(
+        `Failed to render PDF page ${pageNumber} of ${totalPages}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return "";
+    }
+
+    try {
+      return await this.extractTextFromTrustedImage(buffer, signal);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Image contains no readable text content")
+      ) {
+        logWarn(
+          `OCR found no text on PDF page ${pageNumber} (blank or image-only)`,
+        );
+        return "";
+      }
+      logWarn(
+        `OCR failed on PDF page ${pageNumber} of ${totalPages}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return "";
     }
   }
 
@@ -181,16 +646,18 @@ export class RAGService {
    * Recursively extract text from an officeparser AST node
    */
   private extractNodeText(node: OfficeparserNode): string {
+    const parts: string[] = [];
     if (node.text) {
-      return node.text;
+      parts.push(node.text);
     }
     if (node.children) {
-      return node.children
+      const childText = node.children
         .map((child) => this.extractNodeText(child))
         .filter(Boolean)
         .join("\n");
+      if (childText) parts.push(childText);
     }
-    return "";
+    return parts.join("\n");
   }
 
   /**
@@ -397,7 +864,13 @@ export class RAGService {
       this.encoder.free();
     }
     this.encoder = null;
-    this.encoderInitialized = false;
+    this.encoderInitPromise = null;
+
+    const workerPromise = this.ocrWorkerInitPromise;
+    this.ocrWorkerInitPromise = null;
+    if (workerPromise) {
+      void workerPromise.then((w) => w.terminate()).catch(() => {});
+    }
   }
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -218,6 +218,8 @@ export const userFiles = pgTable("user_files", {
         percentage: number; // 0-100
         currentChunk?: number;
         totalChunks?: number;
+        currentPage?: number;
+        totalPages?: number;
         startedAt?: string;
         lastUpdatedAt?: string;
       };


### PR DESCRIPTION
## Summary

Closes #126.

This PR adds OCR support to the file processing pipeline so professors can upload image-based teaching materials and scanned PDFs. It expands upload validation for JPG, PNG, WEBP, and TIFF images, extracts text from supported images with OCR, and adds a scanned-PDF fallback that renders PDF pages to images only when normal PDF text extraction returns empty or minimal content.

## What Changed

- Added shared upload file type metadata for server and client validation.
- Added support for image/jpeg, image/png, image/webp, and image/tiff uploads.
- Added extension mappings for .jpg, .jpeg, .png, .webp, .tiff, and .tif.
- Added OCR extraction for image files through the existing RAG extraction pipeline.
- Preserved existing text-based PDF extraction as the first path.
- Added OCR fallback for scanned PDFs when extracted text is empty or minimal.
- Added PDF page rendering for OCR fallback with page count and render-size safeguards.
- Added per-page OCR progress metadata and UI display.
- Added stricter server-side validation during finalizeUpload.
- Added image size and image decode validation for graceful failures.
- Externalized OCR/rendering packages in Next config for server runtime use.
- Raised the Node engine floor to >=20.19.0 to match pdfjs-dist requirements.

## Library Choices

- tesseract.js: Used for OCR because it is the most common JavaScript OCR engine, works in Node, and fits the existing async file processing model.
- pdfjs-dist: Used to load and render PDF pages for scanned-PDF OCR fallback while keeping normal text PDFs on pdf-parse.
- @napi-rs/canvas: Used as the Node canvas backend for rendering PDF pages to images before OCR.

The implementation intentionally keeps pdf-parse as the primary PDF text extractor so existing text-based PDFs are not pushed through the heavier OCR path.

## Acceptance Criteria

- [x] Image files (JPG, PNG, WEBP, TIFF) can be uploaded and processed through the full pipeline.
- [x] Scanned PDFs that previously failed now extract text via OCR fallback.
- [x] OCR-extracted text is chunked and embedded through the same pipeline as other file types.
- [x] File validation rejects unsupported image formats gracefully.
- [x] Processing progress reports OCR page progress during PDF fallback.
- [x] Existing text-based PDF extraction remains text-first; OCR is fallback only.
- [x] Unit tests cover image extraction, scanned PDF detection, OCR error handling, and text PDF regression coverage.
- [x] npm run check-types passes.
- [x] npm run lint passes.
- [x] npm run test passes.

## Testing

- npm run check-types
- npm run lint
- npm run test

Full test run passed: web, ai, and db test suites all green.