### PR TITLE
feat(analytics): enhance chatbot analytics with session-level insights

### DIFF
--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -26,12 +26,14 @@ import { useFilePolling } from "@/hooks/useFilePolling";
 import { WebSourcesTab } from "@/components/chatbot/WebSourcesTab";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { ConversationsTab } from "@/components/chatbot/ConversationsTab";
+import { ChatbotAnalyticsTab } from "@/components/chatbot/analytics-tab";
 
 const VALID_TABS = [
   "chat",
   "files",
   "web-sources",
   "conversations",
+  "analytics",
   "settings",
   "embed",
 ];
@@ -194,11 +196,12 @@ export default function ChatbotDetailPage() {
           onValueChange={handleTabChange}
           className="space-y-6"
         >
-          <TabsList className="bg-muted-foreground/10 border border-border">
+          <TabsList className="h-auto flex-wrap justify-start gap-1 bg-muted-foreground/10 border border-border">
             <TabsTrigger value="chat">Chat</TabsTrigger>
             <TabsTrigger value="files">Files</TabsTrigger>
             <TabsTrigger value="web-sources">Web Sources</TabsTrigger>
             <TabsTrigger value="conversations">Student Chats</TabsTrigger>
+            <TabsTrigger value="analytics">Analytics</TabsTrigger>
             <TabsTrigger value="settings">Settings</TabsTrigger>
             {chatbot.sharingEnabled && chatbot.shareToken && (
               <TabsTrigger value="embed">Embed</TabsTrigger>
@@ -243,6 +246,10 @@ export default function ChatbotDetailPage() {
 
           <TabsContent value="conversations" className="mt-6">
             <ConversationsTab chatbotId={chatbotId} />
+          </TabsContent>
+
+          <TabsContent value="analytics" className="mt-6">
+            <ChatbotAnalyticsTab chatbotId={chatbotId} />
           </TabsContent>
 
           {/* Settings Tab */}

--- a/apps/web/src/components/chatbot/analytics-tab.tsx
+++ b/apps/web/src/components/chatbot/analytics-tab.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertCircle,
+  Clock,
+  Database,
+  HelpCircle,
+  MessageSquare,
+  Users,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+
+interface ChatbotAnalyticsTabProps {
+  chatbotId: string;
+}
+
+const chartColors = {
+  grid: "var(--muted)",
+  tick: "var(--muted-foreground)",
+  card: "var(--card)",
+  border: "var(--border)",
+  primary: "var(--primary)",
+  sessions: "#0f766e",
+} as const;
+
+function formatDurationSeconds(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return remainingSeconds > 0
+      ? `${minutes}m ${remainingSeconds}s`
+      : `${minutes}m`;
+  }
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+function formatChartDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function MetricCard({
+  title,
+  value,
+  description,
+  icon: Icon,
+  isLoading,
+}: {
+  title: string;
+  value: string | number;
+  description: string;
+  icon: LucideIcon;
+  isLoading: boolean;
+}) {
+  return (
+    <Card className="border border-border/60 shadow-xs">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+        <CardTitle className="text-sm font-semibold text-muted-foreground uppercase">
+          {title}
+        </CardTitle>
+        <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+          <Icon className="h-5 w-5 text-primary" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold">
+          {isLoading ? <Skeleton className="h-9 w-20 rounded" /> : value}
+        </div>
+        <p className="text-xs text-muted-foreground mt-2">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="h-[280px] flex items-end gap-3 px-4 pb-6 pt-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className="flex-1 rounded"
+          style={{ height: `${35 + ((i * 17) % 50)}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function EmptyChart({ label }: { label: string }) {
+  return (
+    <div className="h-[280px] flex items-center justify-center border border-dashed border-muted rounded-lg">
+      <p className="text-sm text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+export function ChatbotAnalyticsTab({ chatbotId }: ChatbotAnalyticsTabProps) {
+  const statsQuery = trpc.analytics.getChatbotStats.useQuery(
+    { chatbotId },
+    { enabled: !!chatbotId },
+  );
+  const sessionMetricsQuery = trpc.analytics.getSessionMetrics.useQuery(
+    { chatbotId },
+    { enabled: !!chatbotId },
+  );
+  const messageVolumeQuery = trpc.analytics.getMessageVolume.useQuery(
+    { chatbotId, timeRange: "month" },
+    { enabled: !!chatbotId },
+  );
+  const sessionsOverTimeQuery = trpc.analytics.getSessionsOverTime.useQuery(
+    { chatbotId, timeRange: "month", interval: "day" },
+    { enabled: !!chatbotId },
+  );
+  const distributionQuery =
+    trpc.analytics.getSessionLengthDistribution.useQuery(
+      { chatbotId },
+      { enabled: !!chatbotId },
+    );
+  const commonQuestionsQuery = trpc.analytics.getCommonQuestions.useQuery(
+    { chatbotId, limit: 10, offset: 0 },
+    { enabled: !!chatbotId },
+  );
+  const lowConfidenceQuery = trpc.analytics.getLowConfidenceQueries.useQuery(
+    { chatbotId, limit: 5, offset: 0 },
+    { enabled: !!chatbotId },
+  );
+
+  const sessionMetrics = sessionMetricsQuery.data;
+  const stats = statsQuery.data;
+  const summaryLoading = statsQuery.isLoading || sessionMetricsQuery.isLoading;
+  const messagesChartData =
+    messageVolumeQuery.data?.map((item) => ({
+      date: formatChartDate(item.date),
+      messages: item.count,
+    })) ?? [];
+  const sessionsChartData =
+    sessionsOverTimeQuery.data?.map((item) => ({
+      date: formatChartDate(item.date),
+      sessions: item.count,
+    })) ?? [];
+  const distributionData = distributionQuery.data ?? [];
+  const hasError =
+    statsQuery.isError ||
+    sessionMetricsQuery.isError ||
+    messageVolumeQuery.isError ||
+    sessionsOverTimeQuery.isError ||
+    distributionQuery.isError ||
+    commonQuestionsQuery.isError ||
+    lowConfidenceQuery.isError;
+
+  if (hasError) {
+    return (
+      <Card className="border border-destructive/30 shadow-xs">
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <AlertCircle className="h-10 w-10 text-destructive mb-3" />
+          <p className="text-lg font-medium text-destructive">
+            Analytics failed to load
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Please refresh and try again.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        <MetricCard
+          title="Unique Sessions"
+          value={sessionMetrics?.totalUniqueSessions ?? 0}
+          description="Student chat sessions"
+          icon={Users}
+          isLoading={summaryLoading}
+        />
+        <MetricCard
+          title="Avg Msgs/Session"
+          value={sessionMetrics?.avgMessagesPerSession ?? 0}
+          description="Student messages per session"
+          icon={MessageSquare}
+          isLoading={summaryLoading}
+        />
+        <MetricCard
+          title="Avg Duration"
+          value={formatDurationSeconds(
+            sessionMetrics?.avgSessionDurationSeconds ?? 0,
+          )}
+          description="First to last message"
+          icon={Clock}
+          isLoading={summaryLoading}
+        />
+        <MetricCard
+          title="RAG Hit Rate"
+          value={`${stats?.ragUsagePercentage ?? 0}%`}
+          description="Messages using source context"
+          icon={Database}
+          isLoading={summaryLoading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Card className="border border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Messages Over Time</CardTitle>
+            <CardDescription>Student messages by day</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {messageVolumeQuery.isLoading ? (
+              <ChartSkeleton />
+            ) : messagesChartData.length === 0 ? (
+              <EmptyChart label="No message data yet" />
+            ) : (
+              <div className="h-[280px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={messagesChartData}
+                    margin={{ top: 5, right: 16, left: -10, bottom: 5 }}
+                  >
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      stroke={chartColors.grid}
+                      opacity={0.3}
+                      vertical={false}
+                    />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      dy={8}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: chartColors.card,
+                        border: `1px solid ${chartColors.border}`,
+                        borderRadius: "8px",
+                        fontSize: "13px",
+                      }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="messages"
+                      stroke={chartColors.primary}
+                      strokeWidth={2.5}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Sessions Over Time</CardTitle>
+            <CardDescription>Unique active sessions by day</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sessionsOverTimeQuery.isLoading ? (
+              <ChartSkeleton />
+            ) : sessionsChartData.every((item) => item.sessions === 0) ? (
+              <EmptyChart label="No session data yet" />
+            ) : (
+              <div className="h-[280px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={sessionsChartData}
+                    margin={{ top: 5, right: 16, left: -10, bottom: 5 }}
+                  >
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      stroke={chartColors.grid}
+                      opacity={0.3}
+                      vertical={false}
+                    />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      dy={8}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: chartColors.card,
+                        border: `1px solid ${chartColors.border}`,
+                        borderRadius: "8px",
+                        fontSize: "13px",
+                      }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="sessions"
+                      stroke={chartColors.sessions}
+                      strokeWidth={2.5}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Session Lengths</CardTitle>
+            <CardDescription>Sessions grouped by message count</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {distributionQuery.isLoading ? (
+              <ChartSkeleton />
+            ) : distributionData.every((item) => item.count === 0) ? (
+              <EmptyChart label="No session lengths yet" />
+            ) : (
+              <div className="h-[280px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={distributionData}
+                    margin={{ top: 5, right: 16, left: -10, bottom: 5 }}
+                  >
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      stroke={chartColors.grid}
+                      opacity={0.3}
+                      vertical={false}
+                    />
+                    <XAxis
+                      dataKey="bucket"
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      dy={8}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 11, fill: chartColors.tick }}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: chartColors.card,
+                        border: `1px solid ${chartColors.border}`,
+                        borderRadius: "8px",
+                        fontSize: "13px",
+                      }}
+                    />
+                    <Bar
+                      dataKey="count"
+                      fill={chartColors.primary}
+                      radius={[4, 4, 0, 0]}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Card className="border border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Common Questions</CardTitle>
+            <CardDescription>
+              Top first messages across student sessions
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {commonQuestionsQuery.isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton key={i} className="h-12 w-full rounded" />
+                ))}
+              </div>
+            ) : !commonQuestionsQuery.data ||
+              commonQuestionsQuery.data.questions.length === 0 ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                No common questions yet
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {commonQuestionsQuery.data.questions.map((question, index) => (
+                  <div
+                    key={`${question.question}-${index}`}
+                    className="flex items-start gap-3 rounded-lg border p-3"
+                  >
+                    <div className="h-8 w-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold shrink-0">
+                      {question.count}
+                    </div>
+                    <p className="text-sm leading-6 break-words">
+                      {question.question}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <HelpCircle className="h-5 w-5" />
+              Low-Confidence Queries
+            </CardTitle>
+            <CardDescription>
+              Messages that did not use RAG context
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {lowConfidenceQuery.isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-16 w-full rounded" />
+                ))}
+              </div>
+            ) : !lowConfidenceQuery.data ||
+              lowConfidenceQuery.data.queries.length === 0 ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                No low-confidence queries found
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {lowConfidenceQuery.data.queries.map((query) => (
+                  <div key={query.id} className="rounded-lg border p-3">
+                    <p className="text-sm leading-6 break-words">
+                      {query.question}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                      <span>
+                        {new Date(query.createdAt).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </span>
+                      {query.sessionId && (
+                        <span>Session {query.sessionId.slice(0, 8)}...</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/server/routers/analytics.ts
+++ b/apps/web/src/server/routers/analytics.ts
@@ -15,6 +15,47 @@ import type { Context } from "@/server/trpc";
 import { checkRateLimit, conversationSearchRateLimit } from "@/lib/rate-limit";
 
 type AuthedContext = Context & { session: { user: { id: string } } };
+type SessionTimeRange = "week" | "month" | "quarter";
+
+const MESSAGE_EVENT_TYPES = ["message_sent", "shared_message_sent"];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function analyticsSessionId() {
+  return sql<string>`COALESCE(${analytics.sessionId}, ${analytics.eventData}->>'sessionId')`;
+}
+
+function getRangeStart(timeRange: SessionTimeRange): Date {
+  const now = new Date();
+  switch (timeRange) {
+    case "week":
+      return new Date(now.getTime() - 7 * DAY_MS);
+    case "quarter":
+      return new Date(now.getTime() - 90 * DAY_MS);
+    case "month":
+      return new Date(now.getTime() - 30 * DAY_MS);
+  }
+}
+
+function dateKey(date: Date): string {
+  return date.toISOString().split("T")[0]!;
+}
+
+function startOfUtcDay(date: Date): Date {
+  const next = new Date(date);
+  next.setUTCHours(0, 0, 0, 0);
+  return next;
+}
+
+function startOfUtcWeek(date: Date): Date {
+  const next = startOfUtcDay(date);
+  const day = (next.getUTCDay() + 6) % 7;
+  next.setUTCDate(next.getUTCDate() - day);
+  return next;
+}
+
+function roundToOne(value: number): number {
+  return Math.round(value * 10) / 10;
+}
 
 async function assertOwnedChatbot(
   ctx: AuthedContext,
@@ -90,39 +131,30 @@ export const analyticsRouter = router({
 
       const totalMessages = messageCount?.count ?? 0;
 
-      // Get average response time from analytics
-      const analyticsData = await ctx.db
-        .select()
+      const [analyticsSummary] = await ctx.db
+        .select({
+          eventCount: sql<number>`count(*)::int`,
+          avgResponseTime: sql<number>`COALESCE(ROUND(AVG((${analytics.eventData}->>'responseTime')::double precision)), 0)::int`,
+          ragHits: sql<number>`COALESCE(SUM(CASE WHEN ${analytics.eventData}->>'ragUsed' = 'true' THEN 1 ELSE 0 END), 0)::int`,
+        })
         .from(analytics)
         .where(
           and(
             eq(analytics.chatbotId, input.chatbotId),
-            eq(analytics.eventType, "message_sent"),
+            inArray(analytics.eventType, MESSAGE_EVENT_TYPES),
           ),
         );
 
-      let avgResponseTime = 0;
-      if (analyticsData.length > 0) {
-        const responseTimes = analyticsData
-          .map((a) => {
-            const eventData = a.eventData as Record<string, unknown> | null;
-            return eventData && typeof eventData.responseTime === "number"
-              ? eventData.responseTime
-              : null;
-          })
-          .filter((t): t is number => t !== null);
-
-        if (responseTimes.length > 0) {
-          const sum = responseTimes.reduce((a, b) => a + b, 0);
-          avgResponseTime = Math.round(sum / responseTimes.length);
-        }
-      }
+      const eventCount = analyticsSummary?.eventCount ?? 0;
+      const ragHits = analyticsSummary?.ragHits ?? 0;
+      const ragUsagePercentage =
+        eventCount > 0 ? Math.round((ragHits / eventCount) * 100) : 0;
 
       return {
         totalConversations,
         totalMessages,
-        avgResponseTime,
-        ragUsagePercentage: 0, // Can be calculated if needed
+        avgResponseTime: analyticsSummary?.avgResponseTime ?? 0,
+        ragUsagePercentage,
       };
     }),
 
@@ -167,7 +199,7 @@ export const analyticsRouter = router({
         .where(
           and(
             eq(conversations.chatbotId, input.chatbotId),
-            gte(conversations.createdAt, startDate),
+            gte(messages.createdAt, startDate),
           ),
         )
         .groupBy(sql`DATE(${messages.createdAt})`)
@@ -178,6 +210,270 @@ export const analyticsRouter = router({
         date: row.date,
         count: row.count,
       }));
+    }),
+
+  getSessionMetrics: protectedProcedure
+    .input(z.object({ chatbotId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      const sessionId = analyticsSessionId();
+      const sessionEvents = ctx.db
+        .select({
+          sessionId: sessionId.as("session_id"),
+          messageCount: sql<number>`count(*)::int`.as("message_count"),
+          firstEventAt: sql<Date>`MIN(${analytics.createdAt})`.as(
+            "first_event_at",
+          ),
+          lastEventAt: sql<Date>`MAX(${analytics.createdAt})`.as(
+            "last_event_at",
+          ),
+        })
+        .from(analytics)
+        .where(
+          and(
+            eq(analytics.chatbotId, input.chatbotId),
+            inArray(analytics.eventType, MESSAGE_EVENT_TYPES),
+            sql`${sessionId} IS NOT NULL`,
+          ),
+        )
+        .groupBy(sessionId)
+        .as("session_events");
+
+      const [summary] = await ctx.db
+        .select({
+          totalUniqueSessions: sql<number>`count(*)::int`,
+          avgMessagesPerSession: sql<number>`COALESCE(AVG(${sessionEvents.messageCount}), 0)::double precision`,
+          avgSessionDurationSeconds: sql<number>`COALESCE(AVG(EXTRACT(EPOCH FROM (${sessionEvents.lastEventAt} - ${sessionEvents.firstEventAt}))), 0)::double precision`,
+        })
+        .from(sessionEvents);
+
+      return {
+        totalUniqueSessions: summary?.totalUniqueSessions ?? 0,
+        avgMessagesPerSession: roundToOne(summary?.avgMessagesPerSession ?? 0),
+        avgSessionDurationSeconds: Math.round(
+          summary?.avgSessionDurationSeconds ?? 0,
+        ),
+      };
+    }),
+
+  getSessionsOverTime: protectedProcedure
+    .input(
+      z.object({
+        chatbotId: z.string().uuid(),
+        timeRange: z.enum(["week", "month", "quarter"]).default("month"),
+        interval: z.enum(["day", "week"]).default("day"),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      const startDate = getRangeStart(input.timeRange);
+      const now = new Date();
+      const sessionId = analyticsSessionId();
+      const periodExpr =
+        input.interval === "week"
+          ? sql<string>`DATE(date_trunc('week', ${analytics.createdAt}))`
+          : sql<string>`DATE(${analytics.createdAt})`;
+
+      const sessionsData = await ctx.db
+        .select({
+          date: periodExpr,
+          count: sql<number>`count(distinct ${sessionId})::int`,
+        })
+        .from(analytics)
+        .where(
+          and(
+            eq(analytics.chatbotId, input.chatbotId),
+            inArray(analytics.eventType, MESSAGE_EVENT_TYPES),
+            gte(analytics.createdAt, startDate),
+            sql`${sessionId} IS NOT NULL`,
+          ),
+        )
+        .groupBy(periodExpr)
+        .orderBy(periodExpr);
+
+      const dataMap = new Map<string, number>(
+        sessionsData.map((row) => [row.date, row.count]),
+      );
+      const stepDays = input.interval === "week" ? 7 : 1;
+      const firstPeriod =
+        input.interval === "week"
+          ? startOfUtcWeek(startDate)
+          : startOfUtcDay(startDate);
+      const filledData: Array<{ date: string; count: number }> = [];
+
+      for (
+        let current = firstPeriod;
+        current <= now;
+        current = new Date(current.getTime() + stepDays * DAY_MS)
+      ) {
+        const key = dateKey(current);
+        filledData.push({ date: key, count: dataMap.get(key) ?? 0 });
+      }
+
+      return filledData;
+    }),
+
+  getSessionLengthDistribution: protectedProcedure
+    .input(z.object({ chatbotId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      const sessionId = analyticsSessionId();
+      const sessionEvents = ctx.db
+        .select({
+          sessionId: sessionId.as("session_id"),
+          messageCount: sql<number>`count(*)::int`.as("message_count"),
+        })
+        .from(analytics)
+        .where(
+          and(
+            eq(analytics.chatbotId, input.chatbotId),
+            inArray(analytics.eventType, MESSAGE_EVENT_TYPES),
+            sql`${sessionId} IS NOT NULL`,
+          ),
+        )
+        .groupBy(sessionId)
+        .as("session_events");
+
+      const [distribution] = await ctx.db
+        .select({
+          one: sql<number>`count(*) FILTER (WHERE ${sessionEvents.messageCount} = 1)::int`,
+          twoToFive: sql<number>`count(*) FILTER (WHERE ${sessionEvents.messageCount} BETWEEN 2 AND 5)::int`,
+          sixToTen: sql<number>`count(*) FILTER (WHERE ${sessionEvents.messageCount} BETWEEN 6 AND 10)::int`,
+          tenPlus: sql<number>`count(*) FILTER (WHERE ${sessionEvents.messageCount} > 10)::int`,
+        })
+        .from(sessionEvents);
+
+      return [
+        { bucket: "1 message", count: distribution?.one ?? 0 },
+        { bucket: "2-5 messages", count: distribution?.twoToFive ?? 0 },
+        { bucket: "6-10 messages", count: distribution?.sixToTen ?? 0 },
+        { bucket: "10+ messages", count: distribution?.tenPlus ?? 0 },
+      ];
+    }),
+
+  getCommonQuestions: protectedProcedure
+    .input(
+      z.object({
+        chatbotId: z.string().uuid(),
+        limit: z.number().int().min(1).max(50).default(10),
+        offset: z.number().int().min(0).default(0),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      const firstUserMessages = ctx.db
+        .select({
+          conversationId: messages.conversationId,
+          question: sql<string>`trim(${messages.content})`.as("question"),
+          normalizedQuestion: sql<string>`lower(trim(${messages.content}))`.as(
+            "normalized_question",
+          ),
+          rowNumber:
+            sql<number>`row_number() over (partition by ${messages.conversationId} order by ${messages.createdAt} asc)`.as(
+              "row_number",
+            ),
+        })
+        .from(messages)
+        .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+        .where(
+          and(
+            eq(conversations.chatbotId, input.chatbotId),
+            eq(messages.role, "user"),
+          ),
+        )
+        .as("first_user_messages");
+
+      const groupedQuestions = ctx.db
+        .select({
+          question: sql<string>`MIN(${firstUserMessages.question})`.as(
+            "question",
+          ),
+          count: sql<number>`count(*)::int`.as("count"),
+          totalCount: sql<number>`count(*) OVER()::int`.as("total_count"),
+        })
+        .from(firstUserMessages)
+        .where(
+          and(
+            sql`${firstUserMessages.rowNumber} = 1`,
+            sql`${firstUserMessages.normalizedQuestion} <> ''`,
+          ),
+        )
+        .groupBy(firstUserMessages.normalizedQuestion)
+        .as("grouped_questions");
+
+      const questions = await ctx.db
+        .select()
+        .from(groupedQuestions)
+        .orderBy(desc(groupedQuestions.count), asc(groupedQuestions.question))
+        .limit(input.limit)
+        .offset(input.offset);
+
+      return {
+        questions: questions.map((q) => ({
+          question: q.question,
+          count: q.count,
+        })),
+        totalCount: questions[0]?.totalCount ?? 0,
+      };
+    }),
+
+  getLowConfidenceQueries: protectedProcedure
+    .input(
+      z.object({
+        chatbotId: z.string().uuid(),
+        limit: z.number().int().min(1).max(50).default(10),
+        offset: z.number().int().min(0).default(0),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      const sessionId = analyticsSessionId();
+      const lowConfidenceWhere = and(
+        eq(analytics.chatbotId, input.chatbotId),
+        inArray(analytics.eventType, MESSAGE_EVENT_TYPES),
+        sql`${analytics.eventData}->>'ragUsed' = 'false'`,
+      );
+
+      const [total] = await ctx.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(analytics)
+        .where(lowConfidenceWhere);
+
+      const rows = await ctx.db
+        .select({
+          id: analytics.id,
+          sessionId,
+          createdAt: analytics.createdAt,
+          responseTime: sql<
+            number | null
+          >`(${analytics.eventData}->>'responseTime')::int`,
+          sourcesCount: sql<
+            number | null
+          >`(${analytics.eventData}->>'sourcesCount')::int`,
+          question: sql<string | null>`${analytics.eventData}->>'question'`,
+        })
+        .from(analytics)
+        .where(lowConfidenceWhere)
+        .orderBy(desc(analytics.createdAt), desc(analytics.id))
+        .limit(input.limit)
+        .offset(input.offset);
+
+      return {
+        queries: rows.map((row) => ({
+          id: row.id,
+          sessionId: row.sessionId,
+          createdAt: row.createdAt,
+          responseTime: row.responseTime,
+          sourcesCount: row.sourcesCount,
+          question: formatPreview(row.question) ?? "Question unavailable",
+        })),
+        totalCount: total?.count ?? 0,
+      };
     }),
 
   /**

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -340,14 +340,24 @@ async function* processMessage(params: {
     },
   });
 
+  const ragSimilarityScore =
+    ragResult.sources.length > 0
+      ? Math.max(...ragResult.sources.map((source) => source.similarity))
+      : undefined;
+
   // Track analytics
   await database.insert(analytics).values({
     chatbotId: chatbot.id,
     eventType,
     eventData: {
+      sessionId,
       responseTime,
       messageLength: message.length,
+      responseLength: fullResponse.length,
       ragUsed: ragResult.ragUsed,
+      ragSimilarityScore,
+      sourcesCount: ragResult.sources.length,
+      question: message.slice(0, 500),
     },
     sessionId,
   });

--- a/packages/db/drizzle/0014_certain_moon_knight.sql
+++ b/packages/db/drizzle/0014_certain_moon_knight.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "analytics_chatbot_event_type_created_at_idx" ON "analytics" USING btree ("chatbot_id","event_type","created_at");--> statement-breakpoint
+CREATE INDEX "analytics_chatbot_event_type_session_id_idx" ON "analytics" USING btree ("chatbot_id","event_type","session_id");--> statement-breakpoint
+CREATE INDEX "analytics_chatbot_event_type_rag_used_idx" ON "analytics" USING btree ("chatbot_id","event_type",("event_data"->>'ragUsed'));

--- a/packages/db/drizzle/meta/0014_snapshot.json
+++ b/packages/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1725 @@
+{
+  "id": "a87abba1-b462-4f65-a4b1-f8bb762cd6cd",
+  "prevId": "a8e7dc6a-f8db-4162-bb5e-f9f4ca309292",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics": {
+      "name": "analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_chatbot_event_type_created_at_idx": {
+          "name": "analytics_chatbot_event_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_chatbot_event_type_session_id_idx": {
+          "name": "analytics_chatbot_event_type_session_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_chatbot_event_type_rag_used_idx": {
+          "name": "analytics_chatbot_event_type_rag_used_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"event_data\"->>'ragUsed')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_chatbot_id_chatbots_id_fk": {
+          "name": "analytics_chatbot_id_chatbots_id_fk",
+          "tableFrom": "analytics",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_domains": {
+      "name": "approved_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approved_domains_created_by_user_id_fk": {
+          "name": "approved_domains_created_by_user_id_fk",
+          "tableFrom": "approved_domains",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_domains_domain_unique": {
+          "name": "approved_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_file_associations": {
+      "name": "chatbot_file_associations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatbot_file_associations_chatbot_id_file_id_idx": {
+          "name": "chatbot_file_associations_chatbot_id_file_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chatbot_file_associations_chatbot_id_chatbots_id_fk": {
+          "name": "chatbot_file_associations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chatbot_file_associations_file_id_user_files_id_fk": {
+          "name": "chatbot_file_associations_file_id_user_files_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbots": {
+      "name": "chatbots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meta-llama/llama-3.3-70b-instruct'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 70
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2000
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_questions": {
+          "name": "suggested_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_sources": {
+          "name": "show_sources",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_author_name": {
+          "name": "custom_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_settings": {
+          "name": "embed_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"light\",\"position\":\"bottom-right\",\"buttonColor\":\"#000000\",\"chatColor\":\"#ffffff\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chatbots_user_id_user_id_fk": {
+          "name": "chatbots_user_id_user_id_fk",
+          "tableFrom": "chatbots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chatbots_share_token_unique": {
+          "name": "chatbots_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_chatbot_id_created_at_idx": {
+          "name": "conversations_chatbot_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_chatbot_id_chatbots_id_fk": {
+          "name": "conversations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_session_id_unique": {
+          "name": "conversations_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawl_sources": {
+      "name": "crawl_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_url": {
+          "name": "root_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "crawl_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "include_patterns": {
+          "name": "include_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawl_sources_chatbot_id": {
+          "name": "idx_crawl_sources_chatbot_id",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_sources_chatbot_id_chatbots_id_fk": {
+          "name": "crawl_sources_chatbot_id_chatbots_id_fk",
+          "tableFrom": "crawl_sources",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawled_pages": {
+      "name": "crawled_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crawl_source_id": {
+          "name": "crawl_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_file_id": {
+          "name": "user_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "crawled_page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawled_pages_source_status": {
+          "name": "idx_crawled_pages_source_status",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crawled_pages_source_url": {
+          "name": "idx_crawled_pages_source_url",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crawled_pages_user_file_id": {
+          "name": "idx_crawled_pages_user_file_id",
+          "columns": [
+            {
+              "expression": "user_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawled_pages_crawl_source_id_crawl_sources_id_fk": {
+          "name": "crawled_pages_crawl_source_id_crawl_sources_id_fk",
+          "tableFrom": "crawled_pages",
+          "tableTo": "crawl_sources",
+          "columnsFrom": [
+            "crawl_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawled_pages_user_file_id_user_files_id_fk": {
+          "name": "crawled_pages_user_file_id_user_files_id_fk",
+          "tableFrom": "crawled_pages",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "user_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_deliveries": {
+      "name": "email_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_message_id": {
+          "name": "resend_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_message_id": {
+          "name": "qstash_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "email_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_deliveries_resend_message_id_idx": {
+          "name": "email_deliveries_resend_message_id_idx",
+          "columns": [
+            {
+              "expression": "resend_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_deliveries_idempotency_key_unique": {
+          "name": "email_deliveries_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_chunks": {
+      "name": "file_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_chunks_embedding_idx": {
+          "name": "file_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 24,
+            "ef_construction": 128
+          }
+        },
+        "file_chunks_file_id_idx": {
+          "name": "file_chunks_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_chunks_file_id_user_files_id_fk": {
+          "name": "file_chunks_file_id_user_files_id_fk",
+          "tableFrom": "file_chunks",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_chunks_file_id_chunk_index_unique": {
+          "name": "file_chunks_file_id_chunk_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_content_trgm_idx": {
+          "name": "messages_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_affiliation": {
+          "name": "institutional_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faculty_webpage": {
+          "name": "faculty_webpage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_files": {
+      "name": "user_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "processing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_files_user_id_user_id_fk": {
+          "name": "user_files_user_id_user_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.crawl_status": {
+      "name": "crawl_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "discovering",
+        "crawling",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.crawled_page_status": {
+      "name": "crawled_page_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed",
+        "blocked",
+        "skipped"
+      ]
+    },
+    "public.email_delivery_status": {
+      "name": "email_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "delivered",
+        "delayed",
+        "bounced",
+        "complained",
+        "failed"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "admin_notification",
+        "approval",
+        "rejection",
+        "promote_admin",
+        "demote_admin",
+        "account_disabled",
+        "account_enabled",
+        "account_deleted",
+        "password_reset"
+      ]
+    },
+    "public.processing_status": {
+      "name": "processing_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1776898316705,
       "tag": "0013_messages_content_trgm",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780082546786,
+      "tag": "0014_certain_moon_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -350,24 +350,47 @@ export const messages = pgTable(
 );
 
 // Analytics table
-export const analytics = pgTable("analytics", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  chatbotId: uuid("chatbot_id")
-    .references(() => chatbots.id, { onDelete: "cascade" })
-    .notNull(),
-  eventType: text("event_type").notNull(), // 'session_start', 'message_sent', etc.
-  eventData: jsonb("event_data")
-    .$type<{
-      sessionId?: string;
-      messageLength?: number;
-      responseLength?: number;
-      responseTime?: number;
-      ragUsed?: boolean;
-    }>()
-    .default({}),
-  sessionId: text("session_id"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+export const analytics = pgTable(
+  "analytics",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    chatbotId: uuid("chatbot_id")
+      .references(() => chatbots.id, { onDelete: "cascade" })
+      .notNull(),
+    eventType: text("event_type").notNull(), // 'session_start', 'message_sent', etc.
+    eventData: jsonb("event_data")
+      .$type<{
+        sessionId?: string;
+        messageLength?: number;
+        responseLength?: number;
+        responseTime?: number;
+        ragUsed?: boolean;
+        ragSimilarityScore?: number;
+        sourcesCount?: number;
+        question?: string;
+      }>()
+      .default({}),
+    sessionId: text("session_id"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("analytics_chatbot_event_type_created_at_idx").on(
+      table.chatbotId,
+      table.eventType,
+      table.createdAt,
+    ),
+    index("analytics_chatbot_event_type_session_id_idx").on(
+      table.chatbotId,
+      table.eventType,
+      table.sessionId,
+    ),
+    index("analytics_chatbot_event_type_rag_used_idx").on(
+      table.chatbotId,
+      table.eventType,
+      sql`(${table.eventData}->>'ragUsed')`,
+    ),
+  ],
+);
 
 // Email delivery tracking table
 export const emailDeliveries = pgTable(


### PR DESCRIPTION
Restored from closed PR #301 after accidental deletion of the head repository (gum1x/agents-a1fc9e35ba).

Original PR: https://github.com/akhileshrangani4/teachanything/pull/301

The changes were still available via the PR refs and have been reapplied cleanly on top of current main.

Closes #131 (from original commit)