### PR TITLE
chore(build): exclude .next/standalone from turbo cache outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "outputs": [".next/**", "!.next/cache/**", "!.next/standalone/**", "dist/**"],
       "env": [
         "OPENROUTER_API_KEY",
         "NODE_ENV",

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,12 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "!.next/standalone/**", "dist/**"],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "!.next/standalone/**",
+        "dist/**"
+      ],
       "env": [
         "OPENROUTER_API_KEY",
         "NODE_ENV",


### PR DESCRIPTION
## Summary
- Add `!.next/standalone/**` to the `build` task outputs in `turbo.json`

## Why
`next.config.js` uses `output: "standalone"`, which copies a full traced `node_modules` into `.next/standalone`. Since turbo cached `.next/**`, every build produced a 1.6-2.1GB cache tarball. Turborepo never prunes its local cache, so `.turbo/cache` quietly grew to 31GB (1390 tarballs accumulated since October).

Excluding the standalone dir drops tarballs to ~100MB. The tradeoff is that a cache hit won't restore `.next/standalone` — that only matters for self-host/docker-from-cache workflows. Vercel builds independently and never consumes it from the turbo cache, so deploys are unaffected.

## Test Plan
- `npx turbo build --dry-run` — resolved task definition includes `!.next/standalone/**`
- Run `npm run build` twice: second run is a cache hit, and the new tarball in `.turbo/cache` is ~100MB instead of ~2GB