### PR TITLE
feat(chat): structured study modes (quiz, flashcards, test, mind map, matching) with confirmation gate

### DIFF
--- a/apps/web/src/__tests__/lib/flashcards.test.ts
+++ b/apps/web/src/__tests__/lib/flashcards.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "@jest/globals";
+import { isFlashcardRequest, flashcardsSchema } from "@/lib/flashcards";
+
+describe("isFlashcardRequest", () => {
+  it("matches common flashcard phrasings", () => {
+    const positives = [
+      "make flashcards",
+      "Make flashcards",
+      "  MAKE FLASHCARDS  ",
+      "flashcard me",
+      "flash card me",
+      "study cards",
+      "give me flashcards on python",
+      "make me flashcards on the cell cycle",
+      "create flashcards on photosynthesis",
+      "can you make flashcards",
+    ];
+    for (const message of positives) {
+      expect(isFlashcardRequest(message)).toBe(true);
+    }
+  });
+
+  it("does not match unrelated messages", () => {
+    const negatives = [
+      "what is a flashcard",
+      "I made flashcards yesterday",
+      "tell me about the syllabus",
+      "explain recursion",
+      "",
+      "thanks!",
+    ];
+    for (const message of negatives) {
+      expect(isFlashcardRequest(message)).toBe(false);
+    }
+  });
+});
+
+describe("flashcardsSchema", () => {
+  const validDeck = {
+    deck_title: "Python Basics Deck",
+    cards: [
+      {
+        front: "What keyword defines a function?",
+        back: "The 'def' keyword defines functions in Python.",
+      },
+      {
+        front: "What does print() do?",
+        back: "It writes output to standard output.",
+      },
+    ],
+  };
+
+  it("parses a well-formed deck", () => {
+    const result = flashcardsSchema.safeParse(validDeck);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a deck with no cards", () => {
+    const result = flashcardsSchema.safeParse({
+      deck_title: "Empty",
+      cards: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a deck with more than ten cards", () => {
+    const result = flashcardsSchema.safeParse({
+      deck_title: "Too many cards",
+      cards: Array.from({ length: 11 }, (_, i) => ({
+        front: `front ${i}`,
+        back: `back ${i}`,
+      })),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a card missing its front", () => {
+    const result = flashcardsSchema.safeParse({
+      deck_title: "Missing front",
+      cards: [{ front: "", back: "an answer" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a card missing its back", () => {
+    const result = flashcardsSchema.safeParse({
+      deck_title: "Missing back",
+      cards: [{ front: "a question", back: "" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/lib/grading.test.ts
+++ b/apps/web/src/__tests__/lib/grading.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  buildOpenAnswerReviewMessage,
+  computeGrade,
+  PASS_THRESHOLD,
+} from "@/lib/grading";
+
+describe("PASS_THRESHOLD", () => {
+  it("is 60", () => {
+    expect(PASS_THRESHOLD).toBe(60);
+  });
+});
+
+describe("computeGrade", () => {
+  it("10/10 → 100% → A, passed", () => {
+    const grade = computeGrade(10, 10);
+    expect(grade.percentage).toBe(100);
+    expect(grade.letter).toBe("A");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("9/10 → 90% → A, passed", () => {
+    const grade = computeGrade(9, 10);
+    expect(grade.percentage).toBe(90);
+    expect(grade.letter).toBe("A");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("89/100 → 89% → B, passed", () => {
+    const grade = computeGrade(89, 100);
+    expect(grade.percentage).toBe(89);
+    expect(grade.letter).toBe("B");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("8/10 → 80% → B, passed", () => {
+    const grade = computeGrade(8, 10);
+    expect(grade.percentage).toBe(80);
+    expect(grade.letter).toBe("B");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("7/10 → 70% → C, passed", () => {
+    const grade = computeGrade(7, 10);
+    expect(grade.percentage).toBe(70);
+    expect(grade.letter).toBe("C");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("6/10 → 60% → D, passed (boundary: exactly PASS_THRESHOLD passes)", () => {
+    const grade = computeGrade(6, 10);
+    expect(grade.percentage).toBe(60);
+    expect(grade.letter).toBe("D");
+    expect(grade.passed).toBe(true);
+  });
+
+  it("59/100 → 59% → F, not passed", () => {
+    const grade = computeGrade(59, 100);
+    expect(grade.percentage).toBe(59);
+    expect(grade.letter).toBe("F");
+    expect(grade.passed).toBe(false);
+  });
+
+  it("5/10 → 50% → F, not passed", () => {
+    const grade = computeGrade(5, 10);
+    expect(grade.percentage).toBe(50);
+    expect(grade.letter).toBe("F");
+    expect(grade.passed).toBe(false);
+  });
+
+  it("0/10 → 0% → F, not passed", () => {
+    const grade = computeGrade(0, 10);
+    expect(grade.percentage).toBe(0);
+    expect(grade.letter).toBe("F");
+    expect(grade.passed).toBe(false);
+  });
+
+  it("0/0 → 0% → F, not passed (guards divide-by-zero)", () => {
+    const grade = computeGrade(0, 0);
+    expect(grade.percentage).toBe(0);
+    expect(grade.letter).toBe("F");
+    expect(grade.passed).toBe(false);
+  });
+
+  it("rounds percentage to nearest integer (2/3 → 67)", () => {
+    const grade = computeGrade(2, 3);
+    expect(grade.percentage).toBe(67);
+  });
+
+  it("preserves score and total in the result", () => {
+    const grade = computeGrade(7, 10);
+    expect(grade.score).toBe(7);
+    expect(grade.total).toBe(10);
+  });
+});
+
+describe("buildOpenAnswerReviewMessage", () => {
+  it("returns null for an empty answers array", () => {
+    expect(buildOpenAnswerReviewMessage("Some Test", [])).toBeNull();
+  });
+
+  it("returns null when every answer is empty or whitespace", () => {
+    const message = buildOpenAnswerReviewMessage("Some Test", [
+      { question: "Explain TCP.", answer: "" },
+      { question: "Explain UDP.", answer: "   " },
+      { question: "Explain DNS.", answer: "\n\t " },
+    ]);
+    expect(message).toBeNull();
+  });
+
+  it("omits empty answers, keeps filled ones, and renumbers from filled only", () => {
+    const message = buildOpenAnswerReviewMessage("Networking Test", [
+      { question: "What is a subnet mask?", answer: "" },
+      {
+        question: "Explain the three-way handshake.",
+        answer: "SYN, SYN-ACK, then ACK to establish a TCP connection.",
+      },
+    ]);
+    expect(message).not.toBeNull();
+    expect(message).toContain("Explain the three-way handshake.");
+    expect(message).not.toContain("What is a subnet mask?");
+    // Only one filled answer, so numbering starts (and ends) at Q1.
+    expect(message).toContain("Q1: Explain the three-way handshake.");
+    expect(message).not.toContain("Q2:");
+  });
+
+  it("includes the test title, each filled question, and a 'My answer:' line", () => {
+    const message = buildOpenAnswerReviewMessage("OSI Model Test", [
+      {
+        question: "Name the transport layer.",
+        answer: "Layer 4.",
+      },
+      {
+        question: "What does the network layer do?",
+        answer: "Handles logical addressing and routing.",
+      },
+    ]);
+    expect(message).not.toBeNull();
+    expect(message).toContain("OSI Model Test");
+    expect(message).toContain("Q1: Name the transport layer.");
+    expect(message).toContain("My answer: Layer 4.");
+    expect(message).toContain("Q2: What does the network layer do?");
+    expect(message).toContain(
+      "My answer: Handles logical addressing and routing.",
+    );
+  });
+
+  it("contains the question and answer text and trims surrounding whitespace", () => {
+    const message = buildOpenAnswerReviewMessage("Trim Test", [
+      {
+        question: "Describe encapsulation.",
+        answer: "  Wrapping data with protocol headers.  ",
+      },
+    ]);
+    expect(message).not.toBeNull();
+    expect(message).toContain("Describe encapsulation.");
+    expect(message).toContain(
+      "My answer: Wrapping data with protocol headers.",
+    );
+    // Whitespace around the answer is trimmed in the output.
+    expect(message).not.toContain("My answer:   Wrapping");
+  });
+});

--- a/apps/web/src/__tests__/lib/matching-game.test.ts
+++ b/apps/web/src/__tests__/lib/matching-game.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "@jest/globals";
+import { shuffleRight, computeAccuracy } from "@/lib/matching-game";
+
+const PAIRS = [
+  { left: "France", right: "Paris" },
+  { left: "Japan", right: "Tokyo" },
+  { left: "Egypt", right: "Cairo" },
+  { left: "Peru", right: "Lima" },
+];
+
+describe("shuffleRight", () => {
+  it("returns one entry per pair, each tagged with its original pairIndex", () => {
+    const result = shuffleRight(PAIRS);
+    expect(result).toHaveLength(PAIRS.length);
+    // Every entry's text must still correspond to its pairIndex's right value,
+    // so a match check (right.pairIndex === leftIndex) stays correct after shuffle.
+    for (const entry of result) {
+      expect(entry.text).toBe(PAIRS[entry.pairIndex]!.right);
+    }
+  });
+
+  it("preserves the full set of pairIndexes exactly once (no drop/dup)", () => {
+    const indexes = shuffleRight(PAIRS)
+      .map((e) => e.pairIndex)
+      .sort((a, b) => a - b);
+    expect(indexes).toEqual([0, 1, 2, 3]);
+  });
+
+  it("handles a single-pair input without error", () => {
+    const result = shuffleRight([{ left: "a", right: "b" }]);
+    expect(result).toEqual([{ text: "b", pairIndex: 0 }]);
+  });
+
+  it("produces every position for an index over many runs (unbiased enough)", () => {
+    // A correct Fisher-Yates puts element 0 into each of the N positions with
+    // roughly equal probability. Assert it lands in every slot at least once
+    // across many runs -- catches an off-by-one (j in [0,i) bias) that would
+    // pin element 0 to a subset of positions.
+    const seenPositionsForPair0 = new Set<number>();
+    for (let run = 0; run < 500; run++) {
+      const result = shuffleRight(PAIRS);
+      seenPositionsForPair0.add(result.findIndex((e) => e.pairIndex === 0));
+    }
+    expect(seenPositionsForPair0).toEqual(new Set([0, 1, 2, 3]));
+  });
+});
+
+describe("computeAccuracy", () => {
+  it("is 100% for a perfect run (one attempt per pair)", () => {
+    expect(computeAccuracy(4, 4)).toBe(100);
+  });
+
+  it("drops below 100% when there are wrong attempts", () => {
+    expect(computeAccuracy(4, 8)).toBe(50);
+    expect(computeAccuracy(4, 5)).toBe(80);
+  });
+
+  it("rounds to the nearest whole percent", () => {
+    // 4 / 6 = 66.66% -> 67
+    expect(computeAccuracy(4, 6)).toBe(67);
+  });
+
+  it("guards the zero-attempt case to 100", () => {
+    expect(computeAccuracy(4, 0)).toBe(100);
+    expect(computeAccuracy(0, 0)).toBe(100);
+  });
+});

--- a/apps/web/src/__tests__/lib/matching.test.ts
+++ b/apps/web/src/__tests__/lib/matching.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "@jest/globals";
+import { isMatchingRequest, matchingSchema } from "@/lib/matching";
+
+describe("isMatchingRequest", () => {
+  it("matches common matching phrasings", () => {
+    const positives = [
+      "matching game on spanish vocab",
+      "make a matching exercise",
+      "create a matching game",
+      "match these",
+      "matching pairs of countries and capitals",
+      "give me a matching quiz",
+      "Matching Game",
+      "  match these  ",
+    ];
+    for (const message of positives) {
+      expect(isMatchingRequest(message)).toBe(true);
+    }
+  });
+
+  it("does not match unrelated messages", () => {
+    const negatives = [
+      "what is matching",
+      "I matched the colors",
+      "tell me about matching algorithms",
+      "",
+      "the matching page is broken",
+    ];
+    for (const message of negatives) {
+      expect(isMatchingRequest(message)).toBe(false);
+    }
+  });
+});
+
+describe("matchingSchema", () => {
+  const validMatching = {
+    matching_title: "Countries and Capitals",
+    pairs: [
+      { left: "France", right: "Paris" },
+      { left: "Japan", right: "Tokyo" },
+      { left: "Egypt", right: "Cairo" },
+    ],
+  };
+
+  it("parses a well-formed matching object", () => {
+    const result = matchingSchema.parse(validMatching);
+    expect(result).toEqual(validMatching);
+  });
+
+  it("rejects fewer than three pairs", () => {
+    const result = matchingSchema.safeParse({
+      matching_title: "Too few",
+      pairs: [
+        { left: "France", right: "Paris" },
+        { left: "Japan", right: "Tokyo" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more than eight pairs", () => {
+    const result = matchingSchema.safeParse({
+      matching_title: "Too many",
+      pairs: Array.from({ length: 9 }, (_, i) => ({
+        left: `left-${i}`,
+        right: `right-${i}`,
+      })),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty left or right string", () => {
+    const result = matchingSchema.safeParse({
+      matching_title: "Empty entry",
+      pairs: [
+        { left: "", right: "Paris" },
+        { left: "Japan", right: "" },
+        { left: "Egypt", right: "Cairo" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing matching_title", () => {
+    const result = matchingSchema.safeParse({
+      pairs: [
+        { left: "France", right: "Paris" },
+        { left: "Japan", right: "Tokyo" },
+        { left: "Egypt", right: "Cairo" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate left values (board would be unsolvable)", () => {
+    const result = matchingSchema.safeParse({
+      matching_title: "Capitals",
+      pairs: [
+        { left: "France", right: "Paris" },
+        { left: "France", right: "Tokyo" },
+        { left: "Egypt", right: "Cairo" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate right values (board would be unsolvable)", () => {
+    const result = matchingSchema.safeParse({
+      matching_title: "Capitals",
+      pairs: [
+        { left: "France", right: "Paris" },
+        { left: "Japan", right: "Paris" },
+        { left: "Egypt", right: "Cairo" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/lib/mindmap.test.ts
+++ b/apps/web/src/__tests__/lib/mindmap.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "@jest/globals";
+import { isMindMapRequest, mindMapSchema } from "@/lib/mindmap";
+
+describe("isMindMapRequest", () => {
+  it("matches common mind map phrasings", () => {
+    const positives = [
+      "make a mind map",
+      "Make a mind map",
+      "create a mind map on photosynthesis",
+      "concept map",
+      "show mind map for the water cycle",
+      "mind map cellular respiration",
+      "draw a concept map",
+      "mindmap",
+      "give me a mind map",
+    ];
+    for (const message of positives) {
+      expect(isMindMapRequest(message)).toBe(true);
+    }
+  });
+
+  it("does not match unrelated messages", () => {
+    const negatives = [
+      "what is a mind map",
+      "I love mind maps",
+      "explain the mind",
+      "tell me about maps",
+      "",
+      "thanks!",
+    ];
+    for (const message of negatives) {
+      expect(isMindMapRequest(message)).toBe(false);
+    }
+  });
+});
+
+describe("mindMapSchema", () => {
+  const validMindMap = {
+    title: "Photosynthesis",
+    root: {
+      label: "Photosynthesis",
+      children: [
+        {
+          label: "Light Reactions",
+          children: [{ label: "Chlorophyll" }, { label: "ATP" }],
+        },
+        {
+          label: "Calvin Cycle",
+          children: [{ label: "Carbon Fixation" }],
+        },
+      ],
+    },
+  };
+
+  it("parses a well-formed nested map", () => {
+    const result = mindMapSchema.safeParse(validMindMap);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a leaf root with no children", () => {
+    const result = mindMapSchema.safeParse({
+      title: "Single Concept",
+      root: { label: "Mitochondria" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty label", () => {
+    const result = mindMapSchema.safeParse({
+      title: "Bad",
+      root: { label: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing root", () => {
+    const result = mindMapSchema.safeParse({
+      title: "No root",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a node with more than eight children", () => {
+    const result = mindMapSchema.safeParse({
+      title: "Too many children",
+      root: {
+        label: "Center",
+        children: Array.from({ length: 9 }, (_, i) => ({
+          label: `Child ${i + 1}`,
+        })),
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/lib/modes/detection.test.ts
+++ b/apps/web/src/__tests__/lib/modes/detection.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "@jest/globals";
+import { detectModeEager } from "@/lib/modes/detection";
+import { STRUCTURED_MODES } from "@/lib/modes/registry";
+
+describe("detectModeEager", () => {
+  it("catches casual phrasings the strict matcher misses", () => {
+    expect(
+      detectModeEager("i want u to make me flashcards about ai")?.mode.id,
+    ).toBe("flashcards");
+    expect(detectModeEager("can we do a quiz on cells")?.mode.id).toBe("quiz");
+    expect(
+      detectModeEager("lets make a test about photosynthesis")?.mode.id,
+    ).toBe("test");
+    expect(
+      detectModeEager("how about a mind map of the water cycle")?.mode.id,
+    ).toBe("mindmap");
+    expect(
+      detectModeEager("set up a matching game on spanish vocab")?.mode.id,
+    ).toBe("matching");
+    expect(detectModeEager("i need a quiz on world war 2")?.mode.id).toBe(
+      "quiz",
+    );
+  });
+
+  it("bows out on leading negation (treated as normal chat)", () => {
+    expect(detectModeEager("dont make me flashcards")).toBeUndefined();
+    expect(
+      detectModeEager("do not make flashcards, just explain"),
+    ).toBeUndefined();
+    expect(detectModeEager("no quiz please")).toBeUndefined();
+    expect(detectModeEager("stop the quiz")).toBeUndefined();
+    expect(detectModeEager("skip the test for now")).toBeUndefined();
+  });
+
+  it("bows out on questions about the tool", () => {
+    expect(detectModeEager("what are flashcards")).toBeUndefined();
+    expect(detectModeEager("explain quizzes to me")).toBeUndefined();
+    expect(detectModeEager("why do we use mind maps")).toBeUndefined();
+  });
+
+  it("bows out when there is no request verb", () => {
+    // Without a verb we can't be confident it's a request; stay in normal chat.
+    expect(detectModeEager("flashcards")).toBeUndefined();
+    expect(detectModeEager("the test was hard")).toBeUndefined();
+  });
+
+  it("extracts the topic after a connector", () => {
+    expect(detectModeEager("make me flashcards about ai")?.topic).toBe("ai");
+    expect(detectModeEager("can we do a quiz on cells")?.topic).toBe("cells");
+    expect(detectModeEager("i need a quiz on world war 2")?.topic).toBe(
+      "world war 2",
+    );
+    // No connector -> empty topic, still detects the mode.
+    expect(detectModeEager("make me flashcards")?.topic).toBe("");
+  });
+
+  it("does not fire on 'make flashcards, dont hold back' negation only when leading", () => {
+    // Negation guard is anchored to the start, so a non-leading 'dont' still detects.
+    expect(
+      detectModeEager("make flashcards about cells, dont hold back")?.mode.id,
+    ).toBe("flashcards");
+  });
+});
+
+describe("canonicalTrigger round-trip", () => {
+  it("every mode's canonical phrase satisfies its own strict detect", () => {
+    for (const mode of STRUCTURED_MODES) {
+      for (const topic of ["", "photosynthesis", "world war 2"]) {
+        const phrase = mode.canonicalTrigger(topic);
+        expect(mode.detect(phrase)).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/__tests__/lib/modes/registry.test.ts
+++ b/apps/web/src/__tests__/lib/modes/registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@jest/globals";
+import { detectMode, STRUCTURED_MODES } from "@/lib/modes/registry";
+
+describe("detectMode routing", () => {
+  it("routes quiz requests to the quiz mode", () => {
+    expect(detectMode("quiz me")?.id).toBe("quiz");
+  });
+
+  it("routes flashcard requests to the flashcards mode", () => {
+    expect(detectMode("flashcard me")?.id).toBe("flashcards");
+    expect(detectMode("make flashcards")?.id).toBe("flashcards");
+  });
+
+  it("routes test requests to the test mode", () => {
+    expect(detectMode("test me")?.id).toBe("test");
+    expect(detectMode("give me a test")?.id).toBe("test");
+  });
+
+  it("routes mind map requests to the mindmap mode", () => {
+    expect(detectMode("make a mind map")?.id).toBe("mindmap");
+    expect(detectMode("concept map")?.id).toBe("mindmap");
+  });
+
+  it("returns undefined for normal chat turns", () => {
+    expect(detectMode("hello there")).toBeUndefined();
+    expect(detectMode("explain recursion")).toBeUndefined();
+  });
+});
+
+describe("STRUCTURED_MODES registry", () => {
+  it("locks the precedence ordering", () => {
+    expect(STRUCTURED_MODES.map((m) => m.id)).toEqual([
+      "quiz",
+      "flashcards",
+      "test",
+      "mindmap",
+      "matching",
+    ]);
+  });
+
+  it("exposes the full descriptor for every mode", () => {
+    for (const m of STRUCTURED_MODES) {
+      expect(typeof m.detect).toBe("function");
+      expect(typeof m.summarize).toBe("function");
+      expect(typeof m.instruction).toBe("string");
+      expect(typeof m.fallbackMessage).toBe("string");
+      expect(m.schema).toBeDefined();
+    }
+  });
+});

--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "@jest/globals";
+import { isQuizRequest, quizSchema } from "@/lib/quiz";
+
+describe("isQuizRequest", () => {
+  it("matches common quiz phrasings", () => {
+    const positives = [
+      "quiz me",
+      "Quiz me",
+      "  QUIZ ME  ",
+      "Can you quiz me?",
+      "quiz me on python",
+      "Start a quiz",
+      "start the quiz",
+      "begin a quiz",
+      "give me a quiz",
+      "make me a quiz on photosynthesis",
+      "generate a quiz for me",
+      "generate me a quiz on Python",
+    ];
+    for (const message of positives) {
+      expect(isQuizRequest(message)).toBe(true);
+    }
+  });
+
+  it("does not match unrelated messages", () => {
+    const negatives = [
+      "what is a quiz",
+      "tell me about the syllabus",
+      "explain recursion",
+      "I took a quiz yesterday",
+      // "quiz me" buried mid-sentence should not trigger
+      "open the quiz me page",
+      "the latest quiz mentioned this",
+      // "test me" now belongs to Test Mode, not Quiz Mode
+      "test me",
+      "",
+      "thanks!",
+    ];
+    for (const message of negatives) {
+      expect(isQuizRequest(message)).toBe(false);
+    }
+  });
+});
+
+describe("quizSchema", () => {
+  const validQuiz = {
+    quiz_title: "Python Basics Quiz",
+    questions: [
+      {
+        question: "What is the output of print(2 + 2)?",
+        options: ["3", "4", "5", "Error"],
+        correct_answer: "4",
+        explanation: "2 + 2 equals 4 in Python.",
+      },
+      {
+        question: "Which keyword defines a function?",
+        options: ["func", "def", "function", "lambda"],
+        correct_answer: "def",
+        explanation: "The 'def' keyword defines functions in Python.",
+      },
+    ],
+  };
+
+  it("parses a well-formed quiz", () => {
+    const result = quizSchema.safeParse(validQuiz);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a quiz whose correct_answer is not among the options", () => {
+    const broken = {
+      ...validQuiz,
+      questions: [
+        {
+          question: "What is the output of print(2 + 2)?",
+          options: ["3", "5", "Error"],
+          correct_answer: "4",
+          explanation: "2 + 2 equals 4 in Python.",
+        },
+      ],
+    };
+    const result = quizSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a quiz with no questions", () => {
+    const result = quizSchema.safeParse({
+      quiz_title: "Empty",
+      questions: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a question with more than four options", () => {
+    const result = quizSchema.safeParse({
+      quiz_title: "Too many options",
+      questions: [
+        {
+          question: "Pick one",
+          options: ["a", "b", "c", "d", "e"],
+          correct_answer: "a",
+          explanation: "n/a",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a question with fewer than two options", () => {
+    const result = quizSchema.safeParse({
+      quiz_title: "One option",
+      questions: [
+        {
+          question: "Pick one",
+          options: ["only"],
+          correct_answer: "only",
+          explanation: "n/a",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/lib/test.test.ts
+++ b/apps/web/src/__tests__/lib/test.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "@jest/globals";
+import { isTestRequest, testSchema } from "@/lib/test-mode";
+
+describe("isTestRequest", () => {
+  it("matches common test phrasings", () => {
+    const positives = [
+      "test me",
+      "Test me",
+      "  TEST ME  ",
+      "exam me",
+      "examine me",
+      "can you test me",
+      "give me a test",
+      "make me a test on networking",
+      "create an exam",
+      "start a test",
+      "begin an exam",
+      "generate a test",
+    ];
+    for (const message of positives) {
+      expect(isTestRequest(message)).toBe(true);
+    }
+  });
+
+  it("does not match unrelated messages", () => {
+    const negatives = [
+      "what is a test",
+      "I failed my exam yesterday",
+      "tell me about the syllabus",
+      "the test page",
+      "",
+      "thanks!",
+    ];
+    for (const message of negatives) {
+      expect(isTestRequest(message)).toBe(false);
+    }
+  });
+});
+
+describe("testSchema", () => {
+  const makeQuestions = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      question: `Question ${i + 1}: what is ${i} + 1?`,
+      options: ["wrong", `${i + 1}`, "also wrong", "nope"],
+      correct_answer: `${i + 1}`,
+      explanation: `${i} + 1 equals ${i + 1}.`,
+    }));
+
+  const validTest = {
+    test_title: "Networking Fundamentals Test",
+    questions: makeQuestions(8),
+  };
+
+  it("parses a well-formed test", () => {
+    const result = testSchema.safeParse(validTest);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a test with no questions", () => {
+    const result = testSchema.safeParse({
+      test_title: "Empty",
+      questions: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a test with more than fifteen questions", () => {
+    const result = testSchema.safeParse({
+      test_title: "Too long",
+      questions: makeQuestions(16),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a question whose correct_answer is not among the options", () => {
+    const result = testSchema.safeParse({
+      test_title: "Broken answer",
+      questions: [
+        {
+          question: "What is 2 + 2?",
+          options: ["3", "5", "Error"],
+          correct_answer: "4",
+          explanation: "2 + 2 equals 4.",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("parses a mixed test and retains type discriminants", () => {
+    const result = testSchema.safeParse({
+      test_title: "Mixed Test",
+      questions: [
+        {
+          type: "multiple_choice",
+          question: "Which protocol is connection-oriented?",
+          options: ["UDP", "TCP", "ICMP"],
+          correct_answer: "TCP",
+          explanation: "TCP establishes a connection before sending data.",
+        },
+        {
+          type: "open",
+          question: "Explain the purpose of the OSI model in your own words.",
+          guidance:
+            "Layered abstraction, interoperability, separation of concerns.",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.questions[0].type).toBe("multiple_choice");
+    expect(result.data.questions[1].type).toBe("open");
+  });
+
+  it("back-compat: a legacy MC question with no type field defaults to multiple_choice", () => {
+    const result = testSchema.safeParse({
+      test_title: "Legacy Test",
+      questions: [
+        {
+          question: "What does DNS resolve?",
+          options: ["Domain names to IPs", "IPs to MAC addresses"],
+          correct_answer: "Domain names to IPs",
+          explanation: "DNS maps human-readable names to IP addresses.",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.questions[0].type).toBe("multiple_choice");
+  });
+
+  it("rejects an open question missing guidance", () => {
+    const result = testSchema.safeParse({
+      test_title: "Bad open question",
+      questions: [
+        {
+          type: "open",
+          question: "Describe how routing works.",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a tagged MC question whose correct_answer is not among the options", () => {
+    const result = testSchema.safeParse({
+      test_title: "Broken tagged MC",
+      questions: [
+        {
+          type: "multiple_choice",
+          question: "What is 2 + 2?",
+          options: ["3", "5", "Error"],
+          correct_answer: "4",
+          explanation: "2 + 2 equals 4.",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -31,6 +31,9 @@ export default function SharedChatPage() {
     chatbot,
     chatbotLoading,
     handleSendMessage,
+    handleSendText,
+    confirmYes,
+    confirmNo,
     resetChat,
     stopStreaming,
     error,
@@ -87,6 +90,9 @@ export default function SharedChatPage() {
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}
             handleSendMessage={handleSendMessage}
+            onSendText={handleSendText}
+            onConfirmYes={confirmYes}
+            onConfirmNo={confirmNo}
             messagesEndRef={messagesEndRef as React.RefObject<HTMLDivElement>}
             chatbotName={chatbot.name || "Chatbot"}
             resetChat={resetChat}

--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -74,6 +74,9 @@ export default function ChatbotDetailPage() {
     chatbot,
     chatbotLoading,
     handleSendMessage,
+    handleSendText,
+    confirmYes,
+    confirmNo,
     resetChat,
     stopStreaming,
   } = useChatbot(chatbotId, session);
@@ -216,6 +219,9 @@ export default function ChatbotDetailPage() {
                 currentMessage={currentMessage}
                 setCurrentMessage={setCurrentMessage}
                 handleSendMessage={handleSendMessage}
+                onSendText={handleSendText}
+                onConfirmYes={confirmYes}
+                onConfirmNo={confirmNo}
                 messagesEndRef={
                   messagesEndRef as React.RefObject<HTMLDivElement>
                 }

--- a/apps/web/src/app/embed/[shareToken]/window/page.tsx
+++ b/apps/web/src/app/embed/[shareToken]/window/page.tsx
@@ -27,6 +27,9 @@ export default function EmbedWindowPage() {
     chatbot,
     chatbotLoading,
     handleSendMessage,
+    handleSendText,
+    confirmYes,
+    confirmNo,
     resetChat,
     stopStreaming,
     error,
@@ -75,6 +78,9 @@ export default function EmbedWindowPage() {
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}
             handleSendMessage={handleSendMessage}
+            onSendText={handleSendText}
+            onConfirmYes={confirmYes}
+            onConfirmNo={confirmNo}
             messagesEndRef={messagesEndRef as React.RefObject<HTMLDivElement>}
             chatbotName={chatbot.name || "Chatbot"}
             resetChat={resetChat}

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -1,6 +1,9 @@
 import { ChatMessage, StreamingMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
-import type { ChatMessage as MessageType } from "@/types/database";
+import type {
+  ChatMessage as MessageType,
+  StructuredMessage,
+} from "@/types/database";
 import {
   ChatContainerRoot,
   ChatContainerContent,
@@ -29,6 +32,12 @@ interface ChatInterfaceProps {
   showFrame?: boolean;
   showSources?: boolean;
   brandingText?: React.ReactNode;
+  onSendText?: (text: string) => boolean;
+  onConfirmYes?: (
+    mode: StructuredMessage["messageType"],
+    topic: string,
+  ) => void;
+  onConfirmNo?: (originalMessage: string) => void;
 }
 
 export function ChatInterface({
@@ -49,6 +58,9 @@ export function ChatInterface({
   showFrame,
   showSources = false,
   brandingText,
+  onSendText,
+  onConfirmYes,
+  onConfirmNo,
 }: ChatInterfaceProps) {
   return (
     <div
@@ -130,6 +142,9 @@ export function ChatInterface({
                     key={`${msg.role}-${idx}`}
                     message={msg}
                     showSources={showSources}
+                    onSendText={onSendText}
+                    onConfirmYes={onConfirmYes}
+                    onConfirmNo={onConfirmNo}
                   />
                 ))}
                 {isStreaming && (

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -1,4 +1,9 @@
 import type { ChatMessage as MessageType } from "@/types/database";
+import type { Quiz } from "@/lib/quiz";
+import type { Flashcards } from "@/lib/flashcards";
+import type { Test } from "@/lib/test-mode";
+import type { MindMap } from "@/lib/mindmap";
+import type { Matching } from "@/lib/matching";
 import {
   Message,
   MessageContent,
@@ -9,18 +14,35 @@ import {
 import { CopyButton } from "@/components/ui/copy-button";
 import { TypingLoader } from "@/components/ui/loader";
 import { SourceBadge } from "@/components/ui/source-badge";
+import { QuizMessage } from "./QuizMessage";
+import { FlashcardMessage } from "./FlashcardMessage";
+import { TestMessage } from "./TestMessage";
+import { MindMapMessage } from "./MindMapMessage";
+import { MatchingMessage } from "./MatchingMessage";
+import { ConfirmModeCard } from "./ConfirmModeCard";
 import { FileText, StopCircle, AlertTriangle } from "lucide-react";
 import { useMemo } from "react";
 import { dedupeSourcesByFileName } from "@/lib/message-sources";
+import type { StructuredMessage } from "@/types/database";
 
 interface ChatMessageProps {
   message: MessageType;
   showSources?: boolean;
+  onSendText?: (text: string) => boolean;
+  /** Confirm card actions. Yes generates the tool; No answers as normal chat. */
+  onConfirmYes?: (
+    mode: StructuredMessage["messageType"],
+    topic: string,
+  ) => void;
+  onConfirmNo?: (originalMessage: string) => void;
 }
 
 export function ChatMessage({
   message,
   showSources = false,
+  onSendText,
+  onConfirmYes,
+  onConfirmNo,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
 
@@ -87,9 +109,33 @@ export function ChatMessage({
           imageClassName="grayscale"
         />
         <div className="flex-1 min-w-0">
-          <MessageContent markdown={true} className="bg-secondary">
-            {message.content}
-          </MessageContent>
+          {message.confirm ? (
+            <ConfirmModeCard
+              mode={message.confirm.mode}
+              label={message.confirm.label}
+              topic={message.confirm.topic}
+              originalMessage={message.confirm.originalMessage}
+              onYes={(mode, topic) => onConfirmYes?.(mode, topic)}
+              onNo={(original) => onConfirmNo?.(original)}
+            />
+          ) : message.messageType === "quiz" && message.structured ? (
+            <QuizMessage quiz={message.structured as Quiz} />
+          ) : message.messageType === "flashcards" && message.structured ? (
+            <FlashcardMessage flashcards={message.structured as Flashcards} />
+          ) : message.messageType === "test" && message.structured ? (
+            <TestMessage
+              test={message.structured as Test}
+              onSendText={onSendText}
+            />
+          ) : message.messageType === "mindmap" && message.structured ? (
+            <MindMapMessage mindMap={message.structured as MindMap} />
+          ) : message.messageType === "matching" && message.structured ? (
+            <MatchingMessage matching={message.structured as Matching} />
+          ) : (
+            <MessageContent markdown={true} className="bg-secondary">
+              {message.content}
+            </MessageContent>
+          )}
           {/* Display cancelled indicator */}
           {message.cancelled && (
             <div className="mt-1.5 md:mt-2 flex items-center gap-1.5 text-xs text-muted-foreground italic">

--- a/apps/web/src/components/chat/messages/ConfirmModeCard.tsx
+++ b/apps/web/src/components/chat/messages/ConfirmModeCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { StructuredMessage } from "@/types/database";
+
+interface ConfirmModeCardProps {
+  /** Which structured tool to build on Yes (e.g. "flashcards"). */
+  mode: StructuredMessage["messageType"];
+  /** Human label for the prompt, e.g. "flashcard deck". */
+  label: string;
+  /** Best-effort topic; shown as "about <topic>" when present. */
+  topic: string;
+  /** The student's original message, re-sent as normal chat on No. */
+  originalMessage: string;
+  onYes: (mode: StructuredMessage["messageType"], topic: string) => void;
+  onNo: (originalMessage: string) => void;
+}
+
+/**
+ * Ephemeral confirmation card shown when the chatbot eager-detects a study-tool
+ * request. Asks before generating so a misread ("don't make flashcards") or a
+ * passing mention never produces an unwanted widget. Yes runs generation; No
+ * answers the original message as normal chat. Buttons lock after one click so
+ * the choice can't double-fire.
+ */
+export function ConfirmModeCard({
+  mode,
+  label,
+  topic,
+  originalMessage,
+  onYes,
+  onNo,
+}: ConfirmModeCardProps) {
+  const [chosen, setChosen] = useState(false);
+
+  const handleYes = () => {
+    if (chosen) return;
+    setChosen(true);
+    onYes(mode, topic);
+  };
+
+  const handleNo = () => {
+    if (chosen) return;
+    setChosen(true);
+    onNo(originalMessage);
+  };
+
+  return (
+    <Card className="bg-secondary">
+      <CardHeader>
+        <CardTitle className="text-sm md:text-base font-medium">
+          Would you like me to make a {label}
+          {topic ? ` about ${topic}` : ""}?
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="text-xs md:text-sm text-muted-foreground">
+        I can build it as an interactive activity, or just answer normally.
+      </CardContent>
+      <CardFooter className="gap-2">
+        <Button size="sm" onClick={handleYes} disabled={chosen}>
+          Yes, make it
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleNo}
+          disabled={chosen}
+        >
+          No thanks
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chat/messages/FlashcardMessage.tsx
+++ b/apps/web/src/components/chat/messages/FlashcardMessage.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import type { Flashcards } from "@/lib/flashcards";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight, Layers, RotateCcw } from "lucide-react";
+
+interface FlashcardMessageProps {
+  flashcards: Flashcards;
+}
+
+export function FlashcardMessage({ flashcards }: FlashcardMessageProps) {
+  const total = flashcards.cards.length;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  // Schema guarantees at least one card, but the indexed access is optional
+  // under strict settings -- guard so TS is satisfied.
+  const card = flashcards.cards[currentIndex];
+  if (!card) return null;
+
+  const isFirst = currentIndex === 0;
+  const isLast = currentIndex === total - 1;
+
+  const handlePrev = () => {
+    if (isFirst) return;
+    setIsFlipped(false);
+    setCurrentIndex((i) => i - 1);
+  };
+
+  const handleNext = () => {
+    if (isLast) return;
+    setIsFlipped(false);
+    setCurrentIndex((i) => i + 1);
+  };
+
+  const handleFlip = () => setIsFlipped((flipped) => !flipped);
+
+  return (
+    <Card className="bg-secondary">
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Layers
+              className="h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            {flashcards.deck_title}
+          </CardTitle>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            Card {currentIndex + 1} of {total}
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        <div className="[perspective:1000px]">
+          <button
+            type="button"
+            onClick={handleFlip}
+            aria-pressed={isFlipped}
+            aria-label={
+              isFlipped
+                ? `Flashcard answer: ${card.back}`
+                : `Flashcard: ${card.front}. Click to reveal answer.`
+            }
+            className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-secondary rounded-lg"
+          >
+            <div
+              className={cn(
+                "relative h-44 [transform-style:preserve-3d] transition-transform duration-500",
+                isFlipped && "[transform:rotateY(180deg)]",
+              )}
+            >
+              {/* Front face */}
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-lg border bg-background p-4 text-center [backface-visibility:hidden]">
+                <p className="text-base md:text-lg font-medium">{card.front}</p>
+                <span className="text-xs text-muted-foreground">
+                  click to flip
+                </span>
+              </div>
+
+              {/* Back face (pre-rotated) */}
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-lg border bg-background p-4 text-center [backface-visibility:hidden] [transform:rotateY(180deg)]">
+                <p className="text-sm md:text-base text-foreground">
+                  {card.back}
+                </p>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <p className="sr-only" role="status" aria-live="polite">
+          Card {currentIndex + 1} of {total}
+        </p>
+      </CardContent>
+
+      <CardFooter className="justify-between gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handlePrev}
+          disabled={isFirst}
+          aria-label="Previous card"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 mr-1.5" />
+          Prev
+        </Button>
+        {isFlipped && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsFlipped(false)}
+            aria-label="Flip back to front"
+          >
+            <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+            Flip back
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleNext}
+          disabled={isLast}
+          aria-label="Next card"
+        >
+          Next
+          <ChevronRight className="h-3.5 w-3.5 ml-1.5" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chat/messages/MatchingMessage.tsx
+++ b/apps/web/src/components/chat/messages/MatchingMessage.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Matching } from "@/lib/matching";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  shuffleRight,
+  computeAccuracy,
+  type ShuffledRight,
+} from "@/lib/matching-game";
+import { Check, X, RotateCcw, Trophy } from "lucide-react";
+
+interface MatchingMessageProps {
+  matching: Matching;
+}
+
+export function MatchingMessage({ matching }: MatchingMessageProps) {
+  const pairs = matching.pairs;
+  const total = pairs.length;
+
+  const [shuffledRight, setShuffledRight] = useState<ShuffledRight[]>(() =>
+    shuffleRight(pairs),
+  );
+  const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
+  const [matched, setMatched] = useState<Set<number>>(() => new Set());
+  const [wrong, setWrong] = useState<{ left: number; right: number } | null>(
+    null,
+  );
+  const [attempts, setAttempts] = useState(0);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending wrong-flash timer on unmount to avoid leaks/races.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const finished = matched.size === total;
+
+  const handleLeftClick = (left: number) => {
+    // Ignore input while a wrong-match flash is animating: the 600ms timer is
+    // about to clear the selection, so accepting clicks here would flicker the
+    // board and let a fast clicker re-select mid-flash.
+    if (wrong !== null) return;
+    if (matched.has(left)) return;
+    setSelectedLeft(left);
+  };
+
+  const handleRightClick = (right: number) => {
+    // Same flash-window guard as the left column. Without it, repeated clicks
+    // during the 600ms flash inflate `attempts` (corrupting first-try accuracy)
+    // and can fire a second setWrong before the first clears.
+    if (wrong !== null) return;
+    if (matched.has(right)) return;
+    if (selectedLeft === null) return;
+    setAttempts((a) => a + 1);
+
+    if (right === selectedLeft) {
+      setMatched((prev) => {
+        const next = new Set(prev);
+        next.add(right);
+        return next;
+      });
+      setSelectedLeft(null);
+      setWrong(null);
+      return;
+    }
+
+    setWrong({ left: selectedLeft, right });
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setWrong(null);
+      setSelectedLeft(null);
+    }, 600);
+  };
+
+  const handleReset = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setShuffledRight(shuffleRight(pairs));
+    setMatched(new Set());
+    setSelectedLeft(null);
+    setWrong(null);
+    setAttempts(0);
+  };
+
+  if (finished) {
+    const accuracy = computeAccuracy(total, attempts);
+    return (
+      <Card className="bg-secondary">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Trophy className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            {matching.matching_title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent
+          className="flex flex-col items-center gap-2 py-4"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-3xl font-bold" aria-hidden="true">
+            {accuracy}%
+          </p>
+          <p className="text-sm text-muted-foreground">
+            You matched all {total} pairs in {attempts} attempts ({accuracy}%
+            first-try accuracy).
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Button variant="outline" size="sm" onClick={handleReset}>
+            <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+            Play again
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-secondary">
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base md:text-lg">
+            {matching.matching_title}
+          </CardTitle>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {matched.size} of {total} matched
+          </span>
+        </div>
+        <Progress
+          value={(matched.size / total) * 100}
+          className="h-2"
+          aria-label={`${matched.size} of ${total} pairs matched`}
+        />
+      </CardHeader>
+
+      <CardContent>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-2" role="group" aria-label="Terms">
+            {pairs.map((pair, left) => {
+              const isMatched = matched.has(left);
+              const isSelected = selectedLeft === left;
+              const isWrong = wrong?.left === left;
+              const state = isMatched
+                ? " (matched)"
+                : isSelected
+                  ? " (selected)"
+                  : "";
+              return (
+                <button
+                  key={left}
+                  type="button"
+                  onClick={() => handleLeftClick(left)}
+                  disabled={isMatched}
+                  aria-label={`${pair.left}${state}`}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                    "disabled:cursor-default",
+                    !isMatched &&
+                      !isSelected &&
+                      "border-border/60 bg-background hover:bg-accent hover:text-accent-foreground",
+                    isSelected &&
+                      "border-primary/60 bg-primary/10 text-foreground",
+                    isMatched &&
+                      "border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-400 opacity-60",
+                    isWrong &&
+                      "border-red-500/60 bg-red-500/10 text-red-700 dark:text-red-400",
+                  )}
+                >
+                  <span>{pair.left}</span>
+                  {isMatched && (
+                    <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          <div
+            className="flex flex-col gap-2"
+            role="group"
+            aria-label="Matches"
+          >
+            {shuffledRight.map((entry) => {
+              const isMatched = matched.has(entry.pairIndex);
+              const isWrong = wrong?.right === entry.pairIndex;
+              const state = isMatched ? " (matched)" : "";
+              return (
+                <button
+                  key={entry.pairIndex}
+                  type="button"
+                  onClick={() => handleRightClick(entry.pairIndex)}
+                  disabled={isMatched}
+                  aria-label={`${entry.text}${state}`}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                    "disabled:cursor-default",
+                    !isMatched &&
+                      !isWrong &&
+                      "border-border/60 bg-background hover:bg-accent hover:text-accent-foreground",
+                    isMatched &&
+                      "border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-400 opacity-60",
+                    isWrong &&
+                      "border-red-500/60 bg-red-500/10 text-red-700 dark:text-red-400",
+                  )}
+                >
+                  <span>{entry.text}</span>
+                  {isMatched && (
+                    <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  )}
+                  {isWrong && (
+                    <X className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </CardContent>
+
+      <CardFooter className="justify-end">
+        <Button variant="outline" size="sm" onClick={handleReset}>
+          <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+          Reset
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chat/messages/MindMapMessage.tsx
+++ b/apps/web/src/components/chat/messages/MindMapMessage.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import type { MindMap, MindMapNode } from "@/lib/mindmap";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Network, ChevronDown, ChevronRight, Dot } from "lucide-react";
+
+interface MindMapMessageProps {
+  mindMap: MindMap;
+}
+
+// Top this many levels open by default; deeper branches collapse to keep
+// large maps tidy on first render.
+const DEFAULT_OPEN_DEPTH = 2;
+// Defensive cap so pathological model output can't blow the stack/DOM.
+const MAX_DEPTH = 6;
+
+function MindMapNodeView({
+  node,
+  depth,
+}: {
+  node: MindMapNode;
+  depth: number;
+}) {
+  const hasChildren = !!node.children?.length;
+  const [isExpanded, setIsExpanded] = useState(depth < DEFAULT_OPEN_DEPTH);
+
+  // Stop recursing past the cap; surface that the branch was truncated.
+  if (depth > MAX_DEPTH) {
+    return (
+      <div role="treeitem" className="flex items-center gap-1.5 py-1">
+        <Dot
+          className="h-4 w-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="text-sm text-muted-foreground">{node.label} …</span>
+      </div>
+    );
+  }
+
+  return (
+    <div role="treeitem" aria-expanded={hasChildren ? isExpanded : undefined}>
+      <div className="flex items-center gap-1.5 py-1">
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((open) => !open)}
+            aria-expanded={isExpanded}
+            aria-label={`Toggle ${node.label}`}
+            className="flex shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            )}
+          </button>
+        ) : (
+          <Dot
+            className="h-4 w-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+        )}
+        <span
+          className={cn(
+            "text-sm",
+            depth === 0 ? "font-medium md:text-base" : "text-foreground",
+          )}
+        >
+          {node.label}
+        </span>
+      </div>
+
+      {hasChildren && isExpanded && (
+        <div role="group" className="ml-2 border-l border-border/60 pl-3">
+          {node.children?.map((child, index) => (
+            <MindMapNodeView
+              key={`${child.label}-${index}`}
+              node={child}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MindMapMessage({ mindMap }: MindMapMessageProps) {
+  return (
+    <Card className="bg-secondary">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+          <Network className="h-4 w-4 text-primary" aria-hidden="true" />
+          {mindMap.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div role="tree" aria-label={mindMap.title}>
+          <MindMapNodeView node={mindMap.root} depth={0} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chat/messages/QuizMessage.tsx
+++ b/apps/web/src/components/chat/messages/QuizMessage.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import type { Quiz } from "@/lib/quiz";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Check, X, RotateCcw, Trophy } from "lucide-react";
+
+interface QuizMessageProps {
+  quiz: Quiz;
+}
+
+export function QuizMessage({ quiz }: QuizMessageProps) {
+  const total = quiz.questions.length;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // One selected answer per question; null until the student picks.
+  const [selected, setSelected] = useState<(string | null)[]>(() =>
+    Array(total).fill(null),
+  );
+  const [finished, setFinished] = useState(false);
+
+  const question = quiz.questions[currentIndex];
+  const chosen = selected[currentIndex] ?? null;
+  const answered = chosen !== null;
+  const isLast = currentIndex === total - 1;
+
+  const score = selected.reduce(
+    (acc, answer, idx) =>
+      answer !== null && answer === quiz.questions[idx]?.correct_answer
+        ? acc + 1
+        : acc,
+    0,
+  );
+
+  const handleSelect = (option: string) => {
+    if (answered) return; // lock the answer once chosen
+    setSelected((prev) => {
+      const next = [...prev];
+      next[currentIndex] = option;
+      return next;
+    });
+  };
+
+  const handleNext = () => {
+    if (isLast) {
+      setFinished(true);
+    } else {
+      setCurrentIndex((i) => i + 1);
+    }
+  };
+
+  const handleRetake = () => {
+    setSelected(Array(total).fill(null));
+    setCurrentIndex(0);
+    setFinished(false);
+  };
+
+  // Schema guarantees at least one question, but the indexed access is
+  // optional under strict settings -- guard so TS is satisfied.
+  if (!question) return null;
+
+  if (finished) {
+    return (
+      <Card className="bg-secondary">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Trophy className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            {quiz.quiz_title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent
+          className="flex flex-col items-center gap-2 py-4"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-3xl font-bold" aria-hidden="true">
+            {score}
+            <span className="text-muted-foreground text-xl"> / {total}</span>
+          </p>
+          <p className="text-sm text-muted-foreground">
+            You answered {score} of {total} correctly.
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Button variant="outline" size="sm" onClick={handleRetake}>
+            <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+            Retake quiz
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-secondary">
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base md:text-lg">
+            {quiz.quiz_title}
+          </CardTitle>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            Question {currentIndex + 1} of {total}
+          </span>
+        </div>
+        <Progress
+          value={((currentIndex + 1) / total) * 100}
+          className="h-2"
+          aria-label={`Question ${currentIndex + 1} of ${total}`}
+        />
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        <p className="text-sm md:text-base font-medium">{question.question}</p>
+
+        <div
+          className="flex flex-col gap-2"
+          role="group"
+          aria-label={question.question}
+        >
+          {question.options.map((option, optionIndex) => {
+            const isCorrect = option === question.correct_answer;
+            const isChosen = option === chosen;
+            const answerState =
+              answered && isCorrect
+                ? " (correct answer)"
+                : answered && isChosen && !isCorrect
+                  ? " (your answer, incorrect)"
+                  : "";
+
+            return (
+              <button
+                // Composite key: options aren't guaranteed unique by the schema,
+                // so option text alone can collide. Index disambiguates.
+                key={`${optionIndex}-${option}`}
+                type="button"
+                onClick={() => handleSelect(option)}
+                disabled={answered}
+                aria-label={`${option}${answerState}`}
+                className={cn(
+                  "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  "disabled:cursor-default",
+                  !answered &&
+                    "border-border/60 bg-background hover:bg-accent hover:text-accent-foreground",
+                  answered &&
+                    isCorrect &&
+                    "border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-400",
+                  answered &&
+                    isChosen &&
+                    !isCorrect &&
+                    "border-red-500/60 bg-red-500/10 text-red-700 dark:text-red-400",
+                  answered &&
+                    !isCorrect &&
+                    !isChosen &&
+                    "border-border/40 bg-background opacity-60",
+                )}
+              >
+                <span>{option}</span>
+                {answered && isCorrect && (
+                  <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
+                )}
+                {answered && isChosen && !isCorrect && (
+                  <X className="h-4 w-4 shrink-0" aria-hidden="true" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {answered && (
+          <div
+            className="rounded-lg border border-border/50 bg-background/60 px-3 py-2 text-xs md:text-sm text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="font-medium text-foreground">
+              {chosen === question.correct_answer ? "Correct! " : "Not quite. "}
+            </span>
+            {question.explanation}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="justify-end">
+        <Button size="sm" onClick={handleNext} disabled={!answered}>
+          {isLast ? "Finish" : "Next"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chat/messages/TestMessage.tsx
+++ b/apps/web/src/components/chat/messages/TestMessage.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Test } from "@/lib/test-mode";
+import type { TestQuestion } from "@/lib/questions";
+import {
+  computeGrade,
+  PASS_THRESHOLD,
+  buildOpenAnswerReviewMessage,
+  type OpenAnswer,
+} from "@/lib/grading";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Check, X, RotateCcw, Trophy, Clock } from "lucide-react";
+
+interface TestMessageProps {
+  test: Test;
+  onSendText?: (text: string) => boolean;
+}
+
+/** Format a whole number of seconds as mm:ss. */
+function formatElapsed(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
+ * Soft ceiling for an open answer. Open questions target ~50-80 words; this is a
+ * generous cap that only nudges (a warning, not a hard block) so a student who
+ * over-writes still gets graded but is steered toward a focused response.
+ */
+const MAX_WORDS_PER_ANSWER = 500;
+
+/** Count whitespace-separated words in a string. */
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+}
+
+/** Has the student answered this question? MC needs a selection; open needs non-empty text. */
+function isAnswered(question: TestQuestion, answer: string | null): boolean {
+  if (question.type === "open") {
+    return (answer ?? "").trim().length > 0;
+  }
+  return answer !== null;
+}
+
+export function TestMessage({ test, onSendText }: TestMessageProps) {
+  const total = test.questions.length;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // One answer per question, keyed by question index. For MC this stores the
+  // chosen option; for open questions it stores the typed free-response text.
+  // null until the student answers.
+  const [answers, setAnswers] = useState<(string | null)[]>(() =>
+    Array(total).fill(null),
+  );
+  const [finished, setFinished] = useState(false);
+
+  // Guards the one-time auto-send of written answers for feedback. We only send
+  // on the FIRST finish so a retake + re-finish does not re-post the message.
+  const sentOpenAnswersRef = useRef(false);
+  const [openAnswersSent, setOpenAnswersSent] = useState(false);
+
+  // Count-up timer. Elapsed is derived from a stored start timestamp so it
+  // stays accurate even when the tab is throttled in the background.
+  const startedAtRef = useRef<number>(Date.now());
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  // Frozen elapsed captured the moment the test is finished.
+  const [finalElapsedSeconds, setFinalElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (finished) return; // freeze the timer once finished
+    const tick = () => {
+      setElapsedSeconds(Math.floor((Date.now() - startedAtRef.current) / 1000));
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [finished]);
+
+  const question = test.questions[currentIndex];
+  const answer = answers[currentIndex] ?? null;
+  const answered = question ? isAnswered(question, answer) : false;
+  const isLast = currentIndex === total - 1;
+
+  // Only multiple-choice questions are auto-graded. Open questions are reviewed
+  // by the AI in the chat stream, so they are excluded from the numeric grade.
+  const mcTotal = test.questions.filter(
+    (q) => q.type === "multiple_choice",
+  ).length;
+  const hasOpenQuestions = test.questions.some((q) => q.type === "open");
+  // Whether AI feedback on written answers is even possible here. Public/embed
+  // pages may not pass onSendText; in that case we must not promise "see the
+  // chat" feedback that will never arrive.
+  const canGradeWritten = onSendText !== undefined;
+  const score = test.questions.reduce((acc, q, idx) => {
+    if (q.type !== "multiple_choice") return acc;
+    return answers[idx] !== null && answers[idx] === q.correct_answer
+      ? acc + 1
+      : acc;
+  }, 0);
+
+  const handleSelect = (option: string) => {
+    if (!question || question.type !== "multiple_choice") return;
+    if (answered) return; // lock MC answer once chosen
+    setAnswers((prev) => {
+      const next = [...prev];
+      next[currentIndex] = option;
+      return next;
+    });
+  };
+
+  const handleOpenChange = (text: string) => {
+    setAnswers((prev) => {
+      const next = [...prev];
+      next[currentIndex] = text;
+      return next;
+    });
+  };
+
+  const finish = () => {
+    setFinalElapsedSeconds(
+      Math.floor((Date.now() - startedAtRef.current) / 1000),
+    );
+    setFinished(true);
+
+    // Build and send the written-answer review message exactly once.
+    if (sentOpenAnswersRef.current) return;
+    const openAnswers: OpenAnswer[] = test.questions.flatMap((q, idx) =>
+      q.type === "open"
+        ? [{ question: q.question, answer: answers[idx] ?? "" }]
+        : [],
+    );
+    const message = buildOpenAnswerReviewMessage(test.test_title, openAnswers);
+    if (message && onSendText) {
+      // Only mark as sent if the send was actually accepted. If a stream is
+      // already in flight onSendText returns false (and toasts), so we leave
+      // the guard down and let the next Finish re-attempt rather than silently
+      // dropping the student's answers.
+      const accepted = onSendText(message);
+      if (accepted) {
+        sentOpenAnswersRef.current = true;
+        setOpenAnswersSent(true);
+      }
+    }
+  };
+
+  const handleNext = () => {
+    if (isLast) {
+      finish();
+    } else {
+      setCurrentIndex((i) => i + 1);
+    }
+  };
+
+  const handleRetake = () => {
+    setAnswers(Array(total).fill(null));
+    setCurrentIndex(0);
+    setFinished(false);
+    // Restart the timer from scratch.
+    startedAtRef.current = Date.now();
+    setElapsedSeconds(0);
+    setFinalElapsedSeconds(0);
+    // Note: sentOpenAnswersRef stays true so a re-finish does not re-send.
+  };
+
+  // Schema guarantees at least one question, but the indexed access is
+  // optional under strict settings -- guard so TS is satisfied.
+  if (!question) return null;
+
+  if (finished) {
+    const grade = computeGrade(score, mcTotal);
+
+    return (
+      <Card className="bg-secondary">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Trophy className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            {test.test_title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent
+          className="flex flex-col gap-4"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex flex-col items-center gap-2 py-2">
+            {mcTotal > 0 ? (
+              <>
+                <p className="text-3xl font-bold" aria-hidden="true">
+                  {score}
+                  <span className="text-muted-foreground text-xl">
+                    {" "}
+                    / {mcTotal}
+                  </span>
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Multiple choice: {score} / {mcTotal} · {grade.percentage}% ·
+                  Grade: {grade.letter}
+                </p>
+                {grade.passed ? (
+                  <p className="flex items-center gap-1.5 text-sm font-medium text-green-700 dark:text-green-400">
+                    <Trophy className="h-4 w-4" aria-hidden="true" />
+                    Passed (≥{PASS_THRESHOLD}%)
+                  </p>
+                ) : (
+                  <p className="flex items-center gap-1.5 text-sm font-medium text-red-700 dark:text-red-400">
+                    <X className="h-4 w-4" aria-hidden="true" />
+                    Did not pass (need ≥{PASS_THRESHOLD}%)
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground text-center">
+                {canGradeWritten
+                  ? "This test has only written answers — see the chat for feedback."
+                  : "This test has only written answers. Review them below against the suggested points."}
+              </p>
+            )}
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              Finished in {formatElapsed(finalElapsedSeconds)}
+            </p>
+            {openAnswersSent ? (
+              <p className="text-xs text-muted-foreground text-center">
+                Your written answers were sent for feedback — see the chat
+                below.
+              </p>
+            ) : (
+              hasOpenQuestions &&
+              !canGradeWritten && (
+                <p className="text-xs text-muted-foreground text-center">
+                  Written-answer feedback isn’t available here — compare your
+                  answers with the suggested points below.
+                </p>
+              )
+            )}
+          </div>
+
+          <TestReview test={test} answers={answers} />
+        </CardContent>
+        <CardFooter>
+          <Button variant="outline" size="sm" onClick={handleRetake}>
+            <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+            Retake test
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-secondary">
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base md:text-lg">
+            {test.test_title}
+          </CardTitle>
+          <div className="flex items-center gap-3 whitespace-nowrap">
+            <span
+              className="flex items-center gap-1 text-xs text-muted-foreground"
+              aria-label={`Elapsed time ${formatElapsed(elapsedSeconds)}`}
+            >
+              <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              {formatElapsed(elapsedSeconds)}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Question {currentIndex + 1} of {total}
+            </span>
+          </div>
+        </div>
+        <Progress
+          value={((currentIndex + 1) / total) * 100}
+          className="h-2"
+          aria-label={`Question ${currentIndex + 1} of ${total}`}
+        />
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        <p className="text-sm md:text-base font-medium">{question.question}</p>
+
+        {question.type === "open" ? (
+          <div className="flex flex-col gap-1.5">
+            <Textarea
+              value={answer ?? ""}
+              onChange={(e) => handleOpenChange(e.target.value)}
+              placeholder="Write your answer…"
+              className="min-h-[120px] bg-background"
+              aria-label={question.question}
+            />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Aim for 50–80 words.</span>
+              <span
+                aria-live="polite"
+                className={cn(
+                  countWords(answer ?? "") > MAX_WORDS_PER_ANSWER &&
+                    "text-amber-600 dark:text-amber-500",
+                )}
+              >
+                {countWords(answer ?? "")} word
+                {countWords(answer ?? "") === 1 ? "" : "s"}
+                {countWords(answer ?? "") > MAX_WORDS_PER_ANSWER &&
+                  ` · recommended ≤ ${MAX_WORDS_PER_ANSWER}`}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div
+            className="flex flex-col gap-2"
+            role="group"
+            aria-label={question.question}
+          >
+            {question.options.map((option, optionIndex) => {
+              const isCorrect = option === question.correct_answer;
+              const isChosen = option === answer;
+              const answerState =
+                answered && isCorrect
+                  ? " (correct answer)"
+                  : answered && isChosen && !isCorrect
+                    ? " (your answer, incorrect)"
+                    : "";
+
+              return (
+                <button
+                  // Composite key: schema doesn't guarantee unique option text.
+                  key={`${optionIndex}-${option}`}
+                  type="button"
+                  onClick={() => handleSelect(option)}
+                  disabled={answered}
+                  aria-label={`${option}${answerState}`}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                    "disabled:cursor-default",
+                    !answered &&
+                      "border-border/60 bg-background hover:bg-accent hover:text-accent-foreground",
+                    answered &&
+                      isCorrect &&
+                      "border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-400",
+                    answered &&
+                      isChosen &&
+                      !isCorrect &&
+                      "border-red-500/60 bg-red-500/10 text-red-700 dark:text-red-400",
+                    answered &&
+                      !isCorrect &&
+                      !isChosen &&
+                      "border-border/40 bg-background opacity-60",
+                  )}
+                >
+                  <span>{option}</span>
+                  {answered && isCorrect && (
+                    <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  )}
+                  {answered && isChosen && !isCorrect && (
+                    <X className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {question.type === "multiple_choice" && answered && (
+          <div
+            className="rounded-lg border border-border/50 bg-background/60 px-3 py-2 text-xs md:text-sm text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="font-medium text-foreground">
+              {answer === question.correct_answer ? "Correct! " : "Not quite. "}
+            </span>
+            {question.explanation}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="justify-end">
+        <Button size="sm" onClick={handleNext} disabled={!answered}>
+          {isLast ? "Finish" : "Next"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+interface TestReviewProps {
+  test: Test;
+  answers: (string | null)[];
+}
+
+/** Per-question review list shown on the results screen. */
+function TestReview({ test, answers }: TestReviewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      {test.questions.map((question, idx) => {
+        const answer = answers[idx] ?? null;
+
+        return (
+          <div key={idx} className="flex flex-col gap-2">
+            <p className="text-sm md:text-base font-medium">
+              <span className="text-muted-foreground">{idx + 1}. </span>
+              {question.question}
+            </p>
+
+            {question.type === "open" ? (
+              <>
+                <div className="rounded-lg border border-border/50 bg-background px-3 py-2 text-sm whitespace-pre-wrap">
+                  {answer && answer.trim().length > 0 ? (
+                    answer
+                  ) : (
+                    <span className="text-muted-foreground italic">
+                      No answer written.
+                    </span>
+                  )}
+                </div>
+                <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2 text-xs md:text-sm text-muted-foreground">
+                  <p className="font-medium text-foreground mb-1">
+                    What a strong answer covers:
+                  </p>
+                  {question.guidance}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2" role="group">
+                  {question.options.map((option, optionIndex) => {
+                    const isCorrect = option === question.correct_answer;
+                    const isChosen = option === answer;
+                    const answerState = isCorrect
+                      ? " (correct answer)"
+                      : isChosen && !isCorrect
+                        ? " (your answer, incorrect)"
+                        : "";
+
+                    return (
+                      <div
+                        key={`${optionIndex}-${option}`}
+                        aria-label={`${option}${answerState}`}
+                        className={cn(
+                          "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-sm",
+                          isCorrect &&
+                            "border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-400",
+                          isChosen &&
+                            !isCorrect &&
+                            "border-red-500/60 bg-red-500/10 text-red-700 dark:text-red-400",
+                          !isCorrect &&
+                            !isChosen &&
+                            "border-border/40 bg-background opacity-60",
+                        )}
+                      >
+                        <span>{option}</span>
+                        {isCorrect && (
+                          <Check
+                            className="h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
+                        )}
+                        {isChosen && !isCorrect && (
+                          <X className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2 text-xs md:text-sm text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    {answer === question.correct_answer
+                      ? "Correct! "
+                      : "Not quite. "}
+                  </span>
+                  {question.explanation}
+                </div>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { useChatState } from "./useChatState";
+import { getMode } from "@/lib/modes/registry";
+import type { StructuredMessage } from "@/types/database";
 
 /**
  * Hook for managing chat interactions with a shared/public chatbot.
@@ -16,6 +18,8 @@ export function useChat(shareToken: string) {
     shareToken: string;
     message: string;
     sessionId?: string;
+    skipConfirm?: boolean;
+    forceNormalChat?: boolean;
   } | null>(null);
 
   const {
@@ -47,6 +51,59 @@ export function useChat(shareToken: string) {
     });
   };
 
+  /** Returns true if the message was accepted and queued, false if rejected. */
+  const handleSendText = (text: string): boolean => {
+    const message = state.prepareSendText(text);
+    if (!message) return false;
+    state.startStreaming();
+    setMessageToSend({
+      shareToken,
+      message,
+      sessionId: state.sessionId || undefined,
+    });
+    return true;
+  };
+
+  /**
+   * Student clicked "Yes" on a confirm card: dismiss it, append the mode's
+   * canonical trigger phrase as a clean user message, and generate (skipConfirm
+   * bypasses the gate so the strict detector runs on a phrase that's guaranteed
+   * to match).
+   */
+  const confirmYes = (
+    mode: StructuredMessage["messageType"],
+    topic: string,
+  ) => {
+    state.resolveConfirm();
+    const resolved = getMode(mode);
+    if (!resolved) return;
+    const message = state.prepareSendText(resolved.canonicalTrigger(topic));
+    if (!message) return;
+    state.startStreaming();
+    setMessageToSend({
+      shareToken,
+      message,
+      sessionId: state.sessionId || undefined,
+      skipConfirm: true,
+    });
+  };
+
+  /**
+   * Student clicked "No": dismiss the card and answer their ORIGINAL message as
+   * normal chat. The original user message is already in history, so we don't
+   * re-append it -- forceNormalChat just bypasses detection on the server.
+   */
+  const confirmNo = (originalMessage: string) => {
+    state.resolveConfirm();
+    state.startStreaming();
+    setMessageToSend({
+      shareToken,
+      message: originalMessage,
+      sessionId: state.sessionId || undefined,
+      forceNormalChat: true,
+    });
+  };
+
   const resetChat = () => {
     state.resetChat();
     setMessageToSend(null);
@@ -69,6 +126,9 @@ export function useChat(shareToken: string) {
     chatbot,
     chatbotLoading,
     handleSendMessage,
+    handleSendText,
+    confirmYes,
+    confirmNo,
     resetChat,
     stopStreaming,
     error: chatbotError,

--- a/apps/web/src/hooks/useChatState.ts
+++ b/apps/web/src/hooks/useChatState.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { toast } from "sonner";
-import type { ChatMessage } from "@/types/database";
+import type { ChatMessage, StructuredMessage } from "@/types/database";
+import { STRUCTURED_MODES } from "@/lib/modes/registry";
 
 type StreamSource = {
   fileName: string;
@@ -12,6 +13,14 @@ type StreamData =
   | { type: "metadata"; sessionId?: string; sources?: StreamSource[] }
   | { type: "text"; content: string }
   | { type: "thinking" }
+  | { type: "structured"; mode: string; payload: unknown }
+  | {
+      type: "confirm";
+      mode: string;
+      label: string;
+      topic: string;
+      originalMessage: string;
+    }
   | { type: "done"; truncated?: boolean; responseTime?: number };
 
 /**
@@ -139,6 +148,80 @@ export function useChatState() {
       // Model is in a reasoning phase. Flip the indicator so the UI doesn't
       // look frozen during long pauses.
       setIsThinking(true);
+    } else if (data.type === "structured") {
+      // A structured mode (quiz/flashcards/test/mindmap) finalizes the message
+      // itself: no text was streamed, so commit the assistant message here and
+      // end the streaming UI. A trailing `done` event is harmless -- it no-ops
+      // because streamingContentRef is empty. The matching registry mode
+      // validates the payload and produces the human-readable summary; an
+      // unknown mode id is dropped rather than rendered.
+      const mode = STRUCTURED_MODES.find((m) => m.id === data.mode);
+      if (!mode) {
+        // Unknown mode id (client/server version skew). Reset the streaming UI
+        // instead of leaving it spinning until the 5-minute timeout, and tell
+        // the user, matching the safeParse-failure branch below.
+        clearStreamingTimeout();
+        setIsThinking(false);
+        updateStreamingContent("");
+        setIsStreaming(false);
+        toast.error("Couldn't display that response. Please try again.");
+        return;
+      }
+
+      const parsed = mode.schema.safeParse(data.payload);
+      if (!parsed.success) {
+        // The server validated this payload before sending, so a client-side
+        // failure means a schema/version mismatch. Don't drop it silently --
+        // tell the user and end the streaming UI so they can retry.
+        clearStreamingTimeout();
+        setIsThinking(false);
+        updateStreamingContent("");
+        setIsStreaming(false);
+        toast.error("Couldn't display that response. Please try again.");
+        return;
+      }
+
+      clearStreamingTimeout();
+      setIsThinking(false);
+      updateStreamingContent("");
+      setIsStreaming(false);
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: mode.summarize(parsed.data),
+          messageType: mode.id as StructuredMessage["messageType"],
+          structured: parsed.data as ChatMessage["structured"],
+        },
+      ]);
+
+      sourcesRef.current = [];
+    } else if (data.type === "confirm") {
+      // Confirm gate: the server eager-detected a study-tool request but didn't
+      // generate. Render an ephemeral Yes/No card instead. No content streamed,
+      // so commit the card message and end the streaming UI here; a trailing
+      // `done` no-ops because streamingContentRef is empty.
+      clearStreamingTimeout();
+      setIsThinking(false);
+      updateStreamingContent("");
+      setIsStreaming(false);
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: "",
+          confirm: {
+            mode: data.mode as StructuredMessage["messageType"],
+            label: data.label,
+            topic: data.topic,
+            originalMessage: data.originalMessage,
+          },
+        },
+      ]);
+
+      sourcesRef.current = [];
     } else if (data.type === "done") {
       clearStreamingTimeout();
       setIsThinking(false);
@@ -220,7 +303,37 @@ export function useChatState() {
     return userMessage;
   };
 
+  /**
+   * Queue an arbitrary text message programmatically (e.g. a test's written
+   * answers submitted from its results screen). Mirrors prepareSendMessage's
+   * state updates but takes a string instead of a form event. Returns the
+   * message, or null if empty or a stream is already in flight.
+   */
+  const prepareSendText = (text: string): string | null => {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    if (isStreaming) {
+      // Unlike the input box (which is disabled mid-stream), a programmatic
+      // send -- e.g. submitting a test's written answers -- has no visible
+      // disabled state, so surface why nothing happened.
+      toast.error("Please wait for the current response to finish.");
+      return null;
+    }
+    setMessages((prev) => [...prev, { role: "user", content: trimmed }]);
+    return trimmed;
+  };
+
+  /**
+   * Dismiss the pending confirm card (the most recent assistant message carrying
+   * a `confirm` payload). Called when the student clicks Yes or No so the card
+   * doesn't linger alongside the answer that follows.
+   */
+  const resolveConfirm = () => {
+    setMessages((prev) => prev.filter((m) => !m.confirm));
+  };
+
   return {
+    resolveConfirm,
     messages,
     currentMessage,
     setCurrentMessage,
@@ -234,6 +347,7 @@ export function useChatState() {
     handleStreamError,
     startStreaming,
     prepareSendMessage,
+    prepareSendText,
     clearStreamingTimeout,
     resetChat,
     stopStreaming,

--- a/apps/web/src/hooks/useChatbot.ts
+++ b/apps/web/src/hooks/useChatbot.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { useChatState } from "./useChatState";
+import { getMode } from "@/lib/modes/registry";
+import type { StructuredMessage } from "@/types/database";
 
 /**
  * Hook for managing chat interactions with an authenticated chatbot.
@@ -19,6 +21,8 @@ export function useChatbot(
     chatbotId: string;
     message: string;
     sessionId?: string;
+    skipConfirm?: boolean;
+    forceNormalChat?: boolean;
   } | null>(null);
 
   const { data: chatbot, isLoading: chatbotLoading } =
@@ -44,6 +48,58 @@ export function useChatbot(
     });
   };
 
+  /** Returns true if the message was accepted and queued, false if rejected. */
+  const handleSendText = (text: string): boolean => {
+    const message = state.prepareSendText(text);
+    if (!message) return false;
+    state.startStreaming();
+    setMessageToSend({
+      chatbotId,
+      message,
+      sessionId: state.sessionId || undefined,
+    });
+    return true;
+  };
+
+  /**
+   * Student clicked "Yes" on a confirm card: dismiss it, append the canonical
+   * trigger phrase as a clean user message, and generate (skipConfirm bypasses
+   * the gate so the strict detector runs).
+   */
+  const confirmYes = (
+    mode: StructuredMessage["messageType"],
+    topic: string,
+  ) => {
+    state.resolveConfirm();
+    const resolved = getMode(mode);
+    if (!resolved) return;
+    const message = state.prepareSendText(resolved.canonicalTrigger(topic));
+    if (!message) return;
+    state.startStreaming();
+    setMessageToSend({
+      chatbotId,
+      message,
+      sessionId: state.sessionId || undefined,
+      skipConfirm: true,
+    });
+  };
+
+  /**
+   * Student clicked "No": dismiss the card and answer their ORIGINAL message as
+   * normal chat. The original user message is already in history, so we don't
+   * re-append it -- forceNormalChat just bypasses detection on the server.
+   */
+  const confirmNo = (originalMessage: string) => {
+    state.resolveConfirm();
+    state.startStreaming();
+    setMessageToSend({
+      chatbotId,
+      message: originalMessage,
+      sessionId: state.sessionId || undefined,
+      forceNormalChat: true,
+    });
+  };
+
   const resetChat = () => {
     state.resetChat();
     setMessageToSend(null);
@@ -66,6 +122,9 @@ export function useChatbot(
     chatbot,
     chatbotLoading,
     handleSendMessage,
+    handleSendText,
+    confirmYes,
+    confirmNo,
     resetChat,
     stopStreaming,
   };

--- a/apps/web/src/lib/flashcards.ts
+++ b/apps/web/src/lib/flashcards.ts
@@ -1,0 +1,66 @@
+/**
+ * Flashcard Mode: shared types, validation, trigger detection, and the model
+ * instruction used to coax a strict-JSON deck out of the LLM.
+ *
+ * The backend detects a flashcard request, appends FLASHCARDS_SYSTEM_INSTRUCTION
+ * to the system prompt, buffers the streamed response, and validates it with
+ * `flashcardsSchema` before emitting a structured `flashcards` event to the
+ * client.
+ */
+import { z } from "zod";
+
+const flashcardSchema = z.object({
+  front: z.string().min(1),
+  back: z.string().min(1),
+});
+
+export const flashcardsSchema = z.object({
+  deck_title: z.string().min(1),
+  // Bounds mirror FLASHCARDS_SYSTEM_INSTRUCTION (5-10 cards). Min 1 stays
+  // tolerant of a model that returns slightly fewer rather than failing the deck.
+  cards: z.array(flashcardSchema).min(1).max(10),
+});
+
+export type Flashcard = z.infer<typeof flashcardSchema>;
+export type Flashcards = z.infer<typeof flashcardsSchema>;
+
+/**
+ * Phrases that switch the chatbot into Flashcard Mode. Matched against the
+ * lowercased, trimmed message. Kept as a readable allowlist rather than one
+ * dense regex so it's easy to extend.
+ */
+const FLASHCARD_TRIGGER_PATTERNS: RegExp[] = [
+  // "make flashcards", "make me flashcards", "create flashcards on python", "give me flashcards on X"
+  /^(?:can you |could you |please )?(?:make|create|generate|build|give me)\b.*\bflash\s?cards?\b/,
+  // "flashcard me", "flash card me"
+  /^(?:can you |could you |please )?flash\s?cards?\s+me\b/,
+  // "study cards", "give me study cards on X"
+  /\bstudy cards?\b/,
+];
+
+/**
+ * Detect whether the user is asking for flashcards.
+ */
+export function isFlashcardRequest(message: string): boolean {
+  const normalized = message.toLowerCase().trim();
+  return FLASHCARD_TRIGGER_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Appended to the system prompt when flashcards are requested. Instructs the
+ * model to reply with ONLY minified JSON matching `flashcardsSchema` -- no
+ * prose, markdown, or code fences -- so the backend can parse it
+ * deterministically.
+ */
+export const FLASHCARDS_SYSTEM_INSTRUCTION = `
+
+FLASHCARD MODE: The student has asked for flashcards. Generate a study deck based on the course material and context above. Reply with ONLY a single minified JSON object and nothing else -- no prose, no markdown, no code fences, no explanation before or after.
+
+The JSON must match exactly this shape:
+{"deck_title":"<short title>","cards":[{"front":"<term or question>","back":"<answer or definition>"}]}
+
+Rules:
+- Produce 5 to 10 cards.
+- "front" is a concise term/question; "back" is its answer/definition.
+- Base cards on the provided course material when available; otherwise use general knowledge of the topic the student asked about.
+- Output valid JSON only.`;

--- a/apps/web/src/lib/grading.ts
+++ b/apps/web/src/lib/grading.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side grade computation for Test Mode. Pure and dependency-free so it can
+ * be unit-tested in isolation and reused by the results screen.
+ */
+export interface Grade {
+  score: number;
+  total: number;
+  percentage: number; // 0-100, rounded to nearest integer
+  letter: "A" | "B" | "C" | "D" | "F";
+  passed: boolean; // percentage >= PASS_THRESHOLD
+}
+
+export const PASS_THRESHOLD = 60;
+
+export function computeGrade(score: number, total: number): Grade {
+  const percentage = total > 0 ? Math.round((score / total) * 100) : 0;
+  const letter =
+    percentage >= 90
+      ? "A"
+      : percentage >= 80
+        ? "B"
+        : percentage >= 70
+          ? "C"
+          : percentage >= 60
+            ? "D"
+            : "F";
+  return {
+    score,
+    total,
+    percentage,
+    letter,
+    passed: percentage >= PASS_THRESHOLD,
+  };
+}
+
+/** A student's written answer to one open-ended test question. */
+export interface OpenAnswer {
+  question: string;
+  answer: string;
+}
+
+/**
+ * Build the plain-text chat message a student sends to have their written
+ * (open-ended) test answers graded. The AI replies with feedback through the
+ * normal chat stream, so this is just deterministic formatting. Answers whose
+ * text is empty/whitespace are omitted. Returns null when nothing to grade.
+ *
+ * Note: we intentionally do NOT include the question "guidance" (the model's
+ * crib of key points) in the message — let the model judge from the question.
+ */
+export function buildOpenAnswerReviewMessage(
+  testTitle: string,
+  answers: OpenAnswer[],
+): string | null {
+  const filled = answers.filter((a) => a.answer.trim().length > 0);
+  if (filled.length === 0) return null;
+
+  const body = filled
+    .map((a, i) => `Q${i + 1}: ${a.question}\nMy answer: ${a.answer.trim()}`)
+    .join("\n\n");
+
+  return `Here are my written answers to the test "${testTitle}". Please grade each one and give me specific feedback on what I got right and how to improve.\n\n${body}`;
+}

--- a/apps/web/src/lib/matching-game.ts
+++ b/apps/web/src/lib/matching-game.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure game logic for Matching Mode, extracted from MatchingMessage so it can be
+ * unit-tested without rendering React. The component owns only the interaction
+ * state (selection, matched set, wrong-flash timer) and delegates the shuffle and
+ * scoring to these helpers.
+ */
+import type { Matching } from "@/lib/matching";
+
+/** One right-column entry: its display text plus the pair index it belongs to. */
+export interface ShuffledRight {
+  text: string;
+  pairIndex: number;
+}
+
+/**
+ * Fisher-Yates shuffle of the right column. The left column stays in pair order;
+ * shuffling the right side is what makes the game non-trivial. Each entry keeps
+ * its original `pairIndex` so a match is "right.pairIndex === selected left index".
+ */
+export function shuffleRight(pairs: Matching["pairs"]): ShuffledRight[] {
+  const arr: ShuffledRight[] = pairs.map((p, i) => ({
+    text: p.right,
+    pairIndex: i,
+  }));
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
+  }
+  return arr;
+}
+
+/**
+ * First-try accuracy as a whole percent: pairs solved over attempts made. A
+ * perfect run (one attempt per pair) is 100%; every wrong click lowers it.
+ * Guards the zero-attempt case (finished with no clicks logged) to 100.
+ */
+export function computeAccuracy(totalPairs: number, attempts: number): number {
+  if (attempts <= 0) return 100;
+  return Math.round((totalPairs / attempts) * 100);
+}

--- a/apps/web/src/lib/matching.ts
+++ b/apps/web/src/lib/matching.ts
@@ -1,0 +1,84 @@
+/**
+ * Matching Mode: a two-column matching game. The model returns a title plus an
+ * array of left/right pairs; the client renders it as an interactive matching
+ * exercise. Shares the structured-mode pipeline (detect -> strict-JSON
+ * instruction -> buffer -> validate -> structured event) with Quiz, Flashcard,
+ * Test, and Mind Map mode.
+ */
+import { z } from "zod";
+
+export const matchingPairSchema = z.object({
+  left: z.string().min(1),
+  right: z.string().min(1),
+});
+
+export const matchingSchema = z
+  .object({
+    matching_title: z.string().min(1),
+    pairs: z.array(matchingPairSchema).min(3).max(8),
+  })
+  // The game is only solvable if every term and every match is distinct: a
+  // duplicate left or right would make two cells indistinguishable. The model
+  // is instructed to avoid duplicates, but enforce it so a slip falls back to a
+  // friendly message rather than rendering a broken, unwinnable board.
+  .superRefine((m, ctx) => {
+    const lefts = m.pairs.map((p) => p.left);
+    const rights = m.pairs.map((p) => p.right);
+    if (new Set(lefts).size !== lefts.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "pairs must not contain duplicate left values",
+        path: ["pairs"],
+      });
+    }
+    if (new Set(rights).size !== rights.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "pairs must not contain duplicate right values",
+        path: ["pairs"],
+      });
+    }
+  });
+
+export type MatchingPair = z.infer<typeof matchingPairSchema>;
+export type Matching = z.infer<typeof matchingSchema>;
+
+/**
+ * Phrases that switch the chatbot into Matching Mode. Matched against the
+ * lowercased, trimmed message. Anchored to the start of the message to avoid
+ * mid-sentence false positives ("what is matching", "I matched the colors").
+ */
+const MATCHING_TRIGGER_PATTERNS: RegExp[] = [
+  // verb-led: "make a matching game", "create a matching exercise", "give me a matching quiz", "match these"
+  /^(?:can you |could you |please )?(?:make|create|build|generate|give me|start|show) (?:me )?(?:a |an |the )?match(?:ing)?(?: pairs| game| exercise| quiz)?\b/,
+  // "matching game on X", "matching pairs of X", "match these" -- matching/match followed by a topic
+  /^match(?:ing)?(?: pairs| game| exercise)?\b/,
+];
+
+/**
+ * Detect whether the user is asking for a matching game.
+ */
+export function isMatchingRequest(message: string): boolean {
+  const normalized = message.toLowerCase().trim();
+  return MATCHING_TRIGGER_PATTERNS.some((p) => p.test(normalized));
+}
+
+/**
+ * Appended to the system prompt when a matching game is requested. Instructs the
+ * model to reply with ONLY minified JSON matching `matchingSchema` -- no prose,
+ * markdown, or code fences -- so the backend can parse it deterministically.
+ */
+export const MATCHING_SYSTEM_INSTRUCTION = `
+
+MATCHING MODE: The student has asked for a matching game. Generate a two-column matching exercise based on the course material and context above. Reply with ONLY a single minified JSON object and nothing else -- no prose, no markdown, no code fences, no explanation before or after.
+
+The JSON must match exactly this shape:
+{"matching_title":"<short title>","pairs":[{"left":"<term>","right":"<match>"}]}
+
+Rules:
+- Produce 4 to 8 pairs.
+- The left column is one set (e.g. Spanish vocabulary words); the right column holds the corresponding matches (e.g. their English meanings).
+- Keep each entry short -- a word or short phrase, not a full sentence.
+- Every left maps to exactly one right; no duplicate lefts and no duplicate rights.
+- Base the pairs on the provided course material when available; otherwise use general knowledge of the topic.
+- Output valid JSON only.`;

--- a/apps/web/src/lib/mindmap.ts
+++ b/apps/web/src/lib/mindmap.ts
@@ -1,0 +1,66 @@
+/**
+ * Mind Map Mode: a hierarchical concept map. The model returns a recursive tree
+ * (one `root` concept with nested `children`); the client renders it as an
+ * interactive collapsible outline. Shares the structured-mode pipeline (detect ->
+ * strict-JSON instruction -> buffer -> validate -> structured event) with Quiz,
+ * Flashcard, and Test mode.
+ */
+import { z } from "zod";
+
+export interface MindMapNode {
+  label: string;
+  children?: MindMapNode[];
+}
+
+export const mindMapNodeSchema: z.ZodType<MindMapNode> = z.lazy(() =>
+  z.object({
+    label: z.string().min(1),
+    children: z.array(mindMapNodeSchema).max(8).optional(),
+  }),
+);
+
+export const mindMapSchema = z.object({
+  title: z.string().min(1),
+  root: mindMapNodeSchema,
+});
+
+export type MindMap = z.infer<typeof mindMapSchema>;
+
+/**
+ * Phrases that switch the chatbot into Mind Map Mode. Matched against the
+ * lowercased, trimmed message. Anchored to the start of the message to avoid
+ * mid-sentence false positives ("what is a mind map", "I love mind maps").
+ */
+const MINDMAP_TRIGGER_PATTERNS: RegExp[] = [
+  // verb-led: "make a mind map", "create a mind map on X", "show mind map for X", "draw a concept map"
+  /^(?:can you |could you |please )?(?:make|create|build|generate|draw|show|give me) (?:me )?(?:a |an |the )?(?:mind|concept) ?map\b/,
+  // "mind map photosynthesis", "concept map of X" -- mind/concept map followed by a topic
+  /^(?:mind|concept) ?map\b/,
+];
+
+/**
+ * Detect whether the user is asking for a mind map.
+ */
+export function isMindMapRequest(message: string): boolean {
+  const normalized = message.toLowerCase().trim();
+  return MINDMAP_TRIGGER_PATTERNS.some((p) => p.test(normalized));
+}
+
+/**
+ * Appended to the system prompt when a mind map is requested. Instructs the
+ * model to reply with ONLY minified JSON matching `mindMapSchema` -- no prose,
+ * markdown, or code fences -- so the backend can parse it deterministically.
+ */
+export const MINDMAP_SYSTEM_INSTRUCTION = `
+
+MIND MAP MODE: The student has asked for a mind map. Generate a hierarchical concept map based on the course material and context above. Reply with ONLY a single minified JSON object and nothing else -- no prose, no markdown, no code fences, no explanation before or after.
+
+The JSON must match exactly this shape:
+{"title":"<short title>","root":{"label":"<central concept>","children":[{"label":"<subtopic>","children":[{"label":"<detail>"}]}]}}
+
+Rules:
+- One central "root" concept; nest related ideas as "children" to a sensible depth (2 to 4 levels).
+- Keep each "label" short (a few words), not full sentences.
+- Aim for 3 to 6 top-level branches; do not exceed 8 children on any node.
+- Base the map on the provided course material when available; otherwise use general knowledge of the topic.
+- Output valid JSON only.`;

--- a/apps/web/src/lib/modes/detection.ts
+++ b/apps/web/src/lib/modes/detection.ts
@@ -1,0 +1,89 @@
+/**
+ * Two-phase mode detection.
+ *
+ * STRICT detection (each mode's `detect`, in registry.ts) is what actually
+ * triggers JSON generation -- it is intentionally narrow to avoid false
+ * positives. EAGER detection (here) is looser: it catches casual phrasings the
+ * strict matcher misses ("i want u to make flashcards", "flashcards pls") so we
+ * can show a Yes/No confirmation card. Because the confirmation is the real
+ * safety net, eager detection can be generous; a leading-negation guard handles
+ * the obvious "don't make me flashcards" case cheaply.
+ *
+ * Flow: eager match -> confirm card -> on Yes, send `mode.canonicalTrigger(topic)`
+ * which is guaranteed to pass the STRICT `detect`, running the normal pipeline.
+ */
+import { STRUCTURED_MODES } from "./registry";
+import type { StructuredMode, StructuredModeId } from "./types";
+
+/**
+ * Loose noun patterns per mode, matched anywhere in the lowercased message. The
+ * study verb is checked separately so order/phrasing is flexible.
+ */
+const EAGER_NOUN_PATTERNS: Record<StructuredModeId, RegExp> = {
+  flashcards: /\bflash\s?cards?\b|\bstudy cards?\b/,
+  quiz: /\bquiz(?:zes)?\b/,
+  test: /\b(?:test|exam)\b/,
+  mindmap: /\b(?:mind|concept)\s?maps?\b/,
+  matching:
+    /\bmatching (?:game|exercise|pairs)\b|\bmatch (?:these|the following)\b/,
+};
+
+/** A request verb somewhere in the message (make/create/give me/do/want/...). */
+const REQUEST_VERB =
+  /\b(?:make|create|generate|build|give|do|want|need|can|could|let'?s|how about|set up|put together|whip up)\b/;
+
+/**
+ * Leading negation: if the message opens by rejecting the action ("don't make
+ * flashcards", "no quiz", "stop the test"), eager detection bows out and the
+ * turn is treated as normal chat. Anchored near the start so "make flashcards,
+ * don't hold back" is unaffected.
+ */
+const LEADING_NEGATION =
+  /^(?:no\b|nope\b|don'?t\b|do not\b|stop\b|never\b|without\b|skip\b|not\b|rather not\b|no need\b)/;
+
+/** Words that signal a QUESTION about the tool rather than a request for one. */
+const QUESTION_PREFIX =
+  /^(?:what|what'?s|whats|why|when|who|which|explain|define|tell me about|how do|how does|how to)\b/;
+
+export interface EagerMatch {
+  mode: StructuredMode<unknown>;
+  /** Best-effort topic extracted from the message; "" if none found. */
+  topic: string;
+}
+
+/**
+ * Extract the topic after a connector ("about/on/for/of") or fall back to "".
+ * Strips the noun phrase and common request boilerplate so the topic reads
+ * naturally in the confirm prompt and the canonical trigger.
+ */
+function extractTopic(normalized: string): string {
+  const connector = normalized.match(
+    /\b(?:about|on|for|of|regarding|covering)\s+(.+)$/,
+  );
+  if (!connector?.[1]) return "";
+  return connector[1]
+    .replace(/[?!.]+$/, "")
+    .replace(/\b(?:please|pls|thanks|thank you|asap)\b/g, "")
+    .trim();
+}
+
+/**
+ * Eager, confirmation-gated detection. Returns the first mode (registry order)
+ * whose noun appears alongside a request verb, unless the message is a leading
+ * negation or a question about the tool. Undefined means "treat as normal chat".
+ */
+export function detectModeEager(message: string): EagerMatch | undefined {
+  const normalized = message.toLowerCase().trim();
+  if (!normalized) return undefined;
+  if (LEADING_NEGATION.test(normalized)) return undefined;
+  if (QUESTION_PREFIX.test(normalized)) return undefined;
+  if (!REQUEST_VERB.test(normalized)) return undefined;
+
+  for (const mode of STRUCTURED_MODES) {
+    const noun = EAGER_NOUN_PATTERNS[mode.id];
+    if (noun.test(normalized)) {
+      return { mode, topic: extractTopic(normalized) };
+    }
+  }
+  return undefined;
+}

--- a/apps/web/src/lib/modes/flashcards.ts
+++ b/apps/web/src/lib/modes/flashcards.ts
@@ -1,0 +1,20 @@
+import {
+  isFlashcardRequest,
+  flashcardsSchema,
+  FLASHCARDS_SYSTEM_INSTRUCTION,
+  type Flashcards,
+} from "@/lib/flashcards";
+import type { StructuredMode } from "./types";
+
+export const flashcardsMode: StructuredMode<Flashcards> = {
+  id: "flashcards",
+  label: "flashcard deck",
+  detect: isFlashcardRequest,
+  canonicalTrigger: (topic) =>
+    topic ? `make me flashcards about ${topic}` : "make me flashcards",
+  instruction: FLASHCARDS_SYSTEM_INSTRUCTION,
+  schema: flashcardsSchema,
+  summarize: (f) => `Flashcards: ${f.deck_title}`,
+  fallbackMessage:
+    "Sorry, I couldn't put a flashcard deck together just now. Please try asking me for flashcards again.",
+};

--- a/apps/web/src/lib/modes/matching.ts
+++ b/apps/web/src/lib/modes/matching.ts
@@ -1,0 +1,20 @@
+import {
+  isMatchingRequest,
+  matchingSchema,
+  MATCHING_SYSTEM_INSTRUCTION,
+  type Matching,
+} from "@/lib/matching";
+import type { StructuredMode } from "./types";
+
+export const matchingMode: StructuredMode<Matching> = {
+  id: "matching",
+  label: "matching game",
+  detect: isMatchingRequest,
+  canonicalTrigger: (topic) =>
+    topic ? `make a matching game on ${topic}` : "make a matching game",
+  instruction: MATCHING_SYSTEM_INSTRUCTION,
+  schema: matchingSchema,
+  summarize: (m) => `Matching: ${m.matching_title}`,
+  fallbackMessage:
+    "Sorry, I couldn't put a matching game together just now. Please try asking me again.",
+};

--- a/apps/web/src/lib/modes/mindmap.ts
+++ b/apps/web/src/lib/modes/mindmap.ts
@@ -1,0 +1,20 @@
+import {
+  isMindMapRequest,
+  mindMapSchema,
+  MINDMAP_SYSTEM_INSTRUCTION,
+  type MindMap,
+} from "@/lib/mindmap";
+import type { StructuredMode } from "./types";
+
+export const mindmapMode: StructuredMode<MindMap> = {
+  id: "mindmap",
+  label: "mind map",
+  detect: isMindMapRequest,
+  canonicalTrigger: (topic) =>
+    topic ? `make a mind map of ${topic}` : "make a mind map",
+  instruction: MINDMAP_SYSTEM_INSTRUCTION,
+  schema: mindMapSchema,
+  summarize: (m) => `Mind map: ${m.title}`,
+  fallbackMessage:
+    "Sorry, I couldn't put a mind map together just now. Please try asking me for a mind map again.",
+};

--- a/apps/web/src/lib/modes/quiz.ts
+++ b/apps/web/src/lib/modes/quiz.ts
@@ -1,0 +1,19 @@
+import {
+  isQuizRequest,
+  quizSchema,
+  QUIZ_SYSTEM_INSTRUCTION,
+  type Quiz,
+} from "@/lib/quiz";
+import type { StructuredMode } from "./types";
+
+export const quizMode: StructuredMode<Quiz> = {
+  id: "quiz",
+  label: "quiz",
+  detect: isQuizRequest,
+  canonicalTrigger: (topic) => (topic ? `quiz me on ${topic}` : "quiz me"),
+  instruction: QUIZ_SYSTEM_INSTRUCTION,
+  schema: quizSchema,
+  summarize: (q) => `Quiz: ${q.quiz_title}`,
+  fallbackMessage:
+    "Sorry, I couldn't put a quiz together just now. Please try asking me to quiz you again.",
+};

--- a/apps/web/src/lib/modes/registry.ts
+++ b/apps/web/src/lib/modes/registry.ts
@@ -1,0 +1,33 @@
+import { quizMode } from "./quiz";
+import { flashcardsMode } from "./flashcards";
+import { testMode } from "./test-mode";
+import { mindmapMode } from "./mindmap";
+import { matchingMode } from "./matching";
+import type { StructuredMode } from "./types";
+
+/**
+ * Ordered registry. Array order defines precedence: the FIRST mode whose `detect`
+ * matches wins, preserving the original mutual-exclusivity ladder
+ * (quiz -> flashcards -> test -> mindmap -> matching).
+ */
+export const STRUCTURED_MODES: readonly StructuredMode<unknown>[] = [
+  quizMode,
+  flashcardsMode,
+  testMode,
+  mindmapMode,
+  matchingMode,
+] as StructuredMode<unknown>[];
+
+/** First matching mode for a message, or undefined for a normal chat turn. */
+export function detectMode(
+  message: string,
+): StructuredMode<unknown> | undefined {
+  return STRUCTURED_MODES.find((m) => m.detect(message));
+}
+
+/** Look up a registered mode by id (used to resolve a confirm card's canonical trigger). */
+export function getMode(
+  id: string | undefined,
+): StructuredMode<unknown> | undefined {
+  return STRUCTURED_MODES.find((m) => m.id === id);
+}

--- a/apps/web/src/lib/modes/test-mode.ts
+++ b/apps/web/src/lib/modes/test-mode.ts
@@ -1,0 +1,19 @@
+import {
+  isTestRequest,
+  testSchema,
+  TEST_SYSTEM_INSTRUCTION,
+  type Test,
+} from "@/lib/test-mode";
+import type { StructuredMode } from "./types";
+
+export const testMode: StructuredMode<Test> = {
+  id: "test",
+  label: "test",
+  detect: isTestRequest,
+  canonicalTrigger: (topic) => (topic ? `test me on ${topic}` : "test me"),
+  instruction: TEST_SYSTEM_INSTRUCTION,
+  schema: testSchema,
+  summarize: (t) => `Test: ${t.test_title}`,
+  fallbackMessage:
+    "Sorry, I couldn't put a test together just now. Please try asking me for a test again.",
+};

--- a/apps/web/src/lib/modes/types.ts
+++ b/apps/web/src/lib/modes/types.ts
@@ -1,0 +1,52 @@
+import type { z } from "zod";
+
+/**
+ * Canonical set of structured-mode ids. This is the single source of truth for
+ * the `messageType` literal: the registry, the persisted JSONB `messageType`
+ * column (packages/db/src/schema.ts), the client `StructuredMessage` union
+ * (types/database.ts), and the server persistence cast (routers/chat.ts) must
+ * all agree with this. Typing `StructuredMode.id` as this union (rather than
+ * `string`) makes a new/renamed mode a compile error in every consumer instead
+ * of a silent runtime drift.
+ */
+export type StructuredModeId =
+  | "quiz"
+  | "flashcards"
+  | "test"
+  | "mindmap"
+  | "matching";
+
+/**
+ * Descriptor for a "structured response mode" -- a chat mode where the model is
+ * asked to return strict JSON, the stream is buffered, the JSON is validated, and
+ * a structured widget is rendered instead of text. Quiz, Flashcard, Test, Mind
+ * Map, and Matching modes all implement this shape; the registry drives
+ * detection, parsing, persistence, and event emission from it.
+ */
+export interface StructuredMode<TPayload> {
+  /** Stable key: used as both the `messageType` literal and the stream event mode id. */
+  id: StructuredModeId;
+  /**
+   * Human-readable noun phrase for the confirmation prompt, e.g. "flashcard
+   * deck", "quiz", "test", "mind map", "matching game". Used as
+   * "Would you like me to make a ${label}?".
+   */
+  label: string;
+  /** True when this user message should STRICTLY trigger generation (phase 2). */
+  detect: (message: string) => boolean;
+  /**
+   * Build a canonical request phrase for a topic that is GUARANTEED to satisfy
+   * this mode's strict `detect`. Sent when the student confirms (clicks Yes) so
+   * phase 2 runs the normal generation pipeline. Must round-trip:
+   * `detect(canonicalTrigger(topic))` is always true.
+   */
+  canonicalTrigger: (topic: string) => string;
+  /** Appended to the system prompt to coax strict JSON from the model. */
+  instruction: string;
+  /** Zod schema the buffered JSON must satisfy. */
+  schema: z.ZodType<TPayload>;
+  /** Short human-readable label for the persisted `content` and the client message. */
+  summarize: (payload: TPayload) => string;
+  /** Friendly text shown if the model returns unparseable JSON. */
+  fallbackMessage: string;
+}

--- a/apps/web/src/lib/questions.ts
+++ b/apps/web/src/lib/questions.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+/** Shared multiple-choice question shape used by Quiz Mode and Test Mode. */
+export const mcQuestionSchema = z
+  .object({
+    question: z.string().min(1),
+    options: z.array(z.string().min(1)).min(2).max(4),
+    correct_answer: z.string().min(1),
+    explanation: z.string().min(1),
+  })
+  .superRefine((q, ctx) => {
+    if (!q.options.includes(q.correct_answer)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "correct_answer must be one of the options",
+        path: ["correct_answer"],
+      });
+    }
+  });
+
+export type MCQuestion = z.infer<typeof mcQuestionSchema>;
+
+// Tagged MC variant for tests: same shape as mcQuestionSchema plus a discriminant.
+// `type` defaults to "multiple_choice" so OLD persisted tests (which have no
+// `type` field) still parse.
+export const testMcQuestionSchema = z
+  .object({
+    type: z.literal("multiple_choice").default("multiple_choice"),
+    question: z.string().min(1),
+    options: z.array(z.string().min(1)).min(2).max(4),
+    correct_answer: z.string().min(1),
+    explanation: z.string().min(1),
+  })
+  .superRefine((q, ctx) => {
+    if (!q.options.includes(q.correct_answer)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "correct_answer must be one of the options",
+        path: ["correct_answer"],
+      });
+    }
+  });
+
+export const openQuestionSchema = z.object({
+  type: z.literal("open"),
+  question: z.string().min(1),
+  guidance: z.string().min(1), // key points a strong answer should cover
+});
+
+// A test question is either tagged-MC or open. We do NOT use
+// z.discriminatedUnion here because testMcQuestionSchema is a ZodEffects
+// (has superRefine) and its `type` is defaulted -- discriminatedUnion requires a
+// bare literal. A plain union with the default handles untagged legacy MC:
+// legacy questions (no `type`) fail the `open` branch and match the MC branch,
+// where `type` defaults in. openQuestionSchema is placed FIRST so that a
+// question with type:"open" matches it before the MC branch (which would
+// otherwise reject the unknown `guidance`/missing MC fields anyway).
+export const testQuestionSchema = z.union([
+  openQuestionSchema,
+  testMcQuestionSchema,
+]);
+
+export type TestMcQuestion = z.infer<typeof testMcQuestionSchema>;
+export type OpenQuestion = z.infer<typeof openQuestionSchema>;
+export type TestQuestion = z.infer<typeof testQuestionSchema>;

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -1,0 +1,63 @@
+/**
+ * Quiz Mode: shared types, validation, trigger detection, and the model
+ * instruction used to coax a strict-JSON quiz out of the LLM.
+ *
+ * The backend detects a quiz request, appends QUIZ_SYSTEM_INSTRUCTION to the
+ * system prompt, buffers the streamed response, and validates it with
+ * `quizSchema` before emitting a structured `quiz` event to the client.
+ */
+import { z } from "zod";
+import { mcQuestionSchema, type MCQuestion } from "@/lib/questions";
+
+export const quizSchema = z.object({
+  quiz_title: z.string().min(1),
+  // Bounds mirror QUIZ_SYSTEM_INSTRUCTION (3-5 questions) so the schema and the
+  // model instruction agree. Min is 1 to stay tolerant of a model that returns
+  // slightly fewer rather than failing the whole quiz.
+  questions: z.array(mcQuestionSchema).min(1).max(5),
+});
+
+export type QuizQuestion = MCQuestion;
+export type Quiz = z.infer<typeof quizSchema>;
+
+/**
+ * Phrases that switch the chatbot into Quiz Mode. Matched against the
+ * lowercased, trimmed message. Kept as a readable allowlist rather than one
+ * dense regex so it's easy to extend.
+ */
+const QUIZ_TRIGGER_PATTERNS: RegExp[] = [
+  // "quiz me", "can you quiz me", "quiz me on python" -- "quiz me" near the
+  // start of the message, not buried mid-sentence ("...the quiz me page").
+  /^(?:can you |could you |please )?quiz me\b/,
+  // "start/begin a quiz"
+  /\b(?:start|begin) (?:a |the )?quiz\b/,
+  // "give me a quiz", "generate a quiz for me", "make a quiz on python"
+  /\b(?:give|make|create|generate|build) (?:me )?(?:a |an )?quiz\b/,
+];
+
+/**
+ * Detect whether the user is asking to be quizzed.
+ */
+export function isQuizRequest(message: string): boolean {
+  const normalized = message.toLowerCase().trim();
+  return QUIZ_TRIGGER_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Appended to the system prompt when a quiz is requested. Instructs the model
+ * to reply with ONLY minified JSON matching `quizSchema` -- no prose, markdown,
+ * or code fences -- so the backend can parse it deterministically.
+ */
+export const QUIZ_SYSTEM_INSTRUCTION = `
+
+QUIZ MODE: The student has asked to be quizzed. Generate a multiple-choice quiz based on the course material and context above. Reply with ONLY a single minified JSON object and nothing else -- no prose, no markdown, no code fences, no explanation before or after.
+
+The JSON must match exactly this shape:
+{"quiz_title":"<short title>","questions":[{"question":"<question text>","options":["<option1>","<option2>","<option3>","<option4>"],"correct_answer":"<must be exactly one of the options>","explanation":"<why the answer is correct>"}]}
+
+Rules:
+- Produce 3 to 5 questions.
+- Each question must have 2 to 4 options.
+- "correct_answer" must be an exact, character-for-character copy of one of the "options".
+- Base questions on the provided course material when available; otherwise use general knowledge of the topic the student asked about.
+- Output valid JSON only.`;

--- a/apps/web/src/lib/test-mode.ts
+++ b/apps/web/src/lib/test-mode.ts
@@ -1,0 +1,62 @@
+/**
+ * Test Mode: a longer, graded version of Quiz Mode. Shares the multiple-choice
+ * question shape (`mcQuestionSchema`) with Quiz Mode; differs in length (8-15
+ * questions), trigger phrases, and the client-side timer + grade + review UI.
+ *
+ * The backend detects a test request, appends TEST_SYSTEM_INSTRUCTION to the
+ * system prompt, buffers the streamed response, and validates it with
+ * `testSchema` before emitting a structured `test` event to the client.
+ */
+import { z } from "zod";
+import { testQuestionSchema } from "@/lib/questions";
+
+export const testSchema = z.object({
+  test_title: z.string().min(1),
+  // Bounds mirror TEST_SYSTEM_INSTRUCTION (8-15 questions). Min is 1 to stay
+  // tolerant of a model that returns slightly fewer rather than failing the test.
+  questions: z.array(testQuestionSchema).min(1).max(15),
+});
+
+export type Test = z.infer<typeof testSchema>;
+
+/**
+ * Phrases that switch the chatbot into Test Mode. Matched against the
+ * lowercased, trimmed message. Anchored like Quiz Mode to avoid mid-sentence
+ * false positives.
+ */
+const TEST_TRIGGER_PATTERNS: RegExp[] = [
+  /^(?:can you |could you |please )?test me\b/,
+  /^(?:can you |could you |please )?exam(?:ine)? me\b/,
+  /\b(?:give|make|create|generate|build) (?:me )?(?:a |an )?(?:test|exam)\b/,
+  /\b(?:start|begin) (?:a |an |the )?(?:test|exam)\b/,
+];
+
+/**
+ * Detect whether the user is asking to take a test.
+ */
+export function isTestRequest(message: string): boolean {
+  const normalized = message.toLowerCase().trim();
+  return TEST_TRIGGER_PATTERNS.some((p) => p.test(normalized));
+}
+
+/**
+ * Appended to the system prompt when a test is requested. Instructs the model
+ * to reply with ONLY minified JSON matching `testSchema` -- no prose, markdown,
+ * or code fences -- so the backend can parse it deterministically.
+ */
+export const TEST_SYSTEM_INSTRUCTION = `
+
+TEST MODE: The student has asked to take a test. Generate a test based on the course material and context above, mixing multiple-choice and open-ended (free-response) questions. Reply with ONLY a single minified JSON object and nothing else -- no prose, no markdown, no code fences, no explanation before or after.
+
+The JSON must match exactly this shape:
+{"test_title":"<short title>","questions":[{"type":"multiple_choice","question":"<q>","options":["<o1>","<o2>","<o3>","<o4>"],"correct_answer":"<one of options>","explanation":"<why>"},{"type":"open","question":"<q>","guidance":"<key points a strong written answer should cover>"}]}
+
+Rules:
+- Produce 8 to 15 questions total.
+- Every question MUST have a "type" of either "multiple_choice" or "open".
+- MOST questions should be "multiple_choice".
+- Include 1 to 3 "open" (free-response) questions where a short written answer (~50-80 words) suits the material better than fixed options.
+- For "multiple_choice" questions: provide 2 to 4 "options", and "correct_answer" must be an exact, character-for-character copy of one of the "options", plus an "explanation".
+- For "open" questions: provide "guidance" listing the key points a strong answer should cover.
+- Base questions on the provided course material when available; otherwise use general knowledge of the topic the student asked about.
+- Output valid JSON only.`;

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -26,6 +26,8 @@ import {
   publicChatRateLimit,
 } from "@/lib/rate-limit";
 import { buildRAGContext } from "../rag-context";
+import { detectMode } from "@/lib/modes/registry";
+import { detectModeEager } from "@/lib/modes/detection";
 import type { db as DbType } from "@teachanything/db";
 
 /**
@@ -42,6 +44,17 @@ function clampMaxTokens(maxTokens: number | null | undefined): number {
 
   return Math.max(MIN_TOKENS, Math.min(MAX_TOKENS, maxTokens));
 }
+
+/**
+ * Hard ceiling on the buffered response in a structured mode, measured in JS
+ * string length (UTF-16 code units, not bytes). Quiz/test/matching payloads are
+ * a few KB at most; if a model streams far past that it has gone off the rails
+ * (runaway repetition, never closing the JSON). Cap the buffer so a misbehaving
+ * stream can't accumulate unbounded memory -- once exceeded we stop buffering and
+ * let the normal parse-fail path emit the friendly fallback. 32k chars is a
+ * generous bound (true byte size is within a small multiple for any UTF-8 text).
+ */
+const MAX_STRUCTURED_BUFFER_CHARS = 32_000;
 
 /**
  * Cached token counter -- initialized once, reused across all requests.
@@ -74,9 +87,49 @@ async function* processMessage(params: {
   sessionId: string | undefined;
   db: typeof DbType;
   eventType: "message_sent" | "shared_message_sent";
+  /** Yes-from-confirm: skip the confirm gate and strict-detect for generation. */
+  skipConfirm?: boolean;
+  /** No-from-confirm: bypass detection entirely and answer as normal chat. */
+  forceNormalChat?: boolean;
 }) {
-  const { chatbot, message, db: database, eventType } = params;
+  const {
+    chatbot,
+    message,
+    db: database,
+    eventType,
+    skipConfirm,
+    forceNormalChat,
+  } = params;
   const sessionId = params.sessionId || nanoid();
+
+  // Two-phase structured-mode flow:
+  //  - Phase 1 (default): eager-detect a study-tool request and, instead of
+  //    generating, emit a `confirm` event so the client can show a Yes/No card.
+  //    No LLM call, no persistence -- the confirm is ephemeral.
+  //  - Phase 2 Yes (skipConfirm): the client re-sends a canonical trigger phrase;
+  //    strict `detectMode` matches it and the normal generation pipeline runs.
+  //  - Phase 2 No (forceNormalChat): detection is bypassed; answer as plain chat.
+  if (!skipConfirm && !forceNormalChat) {
+    const eager = detectModeEager(message);
+    if (eager) {
+      // Ephemeral confirmation: announce the session, ask, and close the stream.
+      // Nothing is persisted and no analytics are written for a confirm turn.
+      yield { type: "metadata" as const, sessionId };
+      yield {
+        type: "confirm" as const,
+        mode: eager.mode.id,
+        label: eager.mode.label,
+        topic: eager.topic,
+        originalMessage: message,
+      };
+      yield { type: "done" as const, responseTime: 0, truncated: false };
+      return;
+    }
+  }
+
+  // Strict detection drives actual generation. On a phase-2 Yes the canonical
+  // trigger guarantees a match; on forceNormalChat we skip it for a plain reply.
+  const mode = forceNormalChat ? undefined : detectMode(message);
 
   // Get or create conversation
   const existingConversation = await database
@@ -211,11 +264,13 @@ async function* processMessage(params: {
   }));
 
   // ragFailureNote + systemPrompt + fileManifest + contextText
+  // In a structured mode, append the mode instruction so the model returns strict JSON.
   const systemPrompt =
     ragResult.ragFailureNote +
     chatbot.systemPrompt +
     ragResult.fileManifest +
-    ragResult.contextText;
+    ragResult.contextText +
+    (mode ? mode.instruction : "");
 
   // Kick off the user-message insert alongside the streamText handshake
   // instead of blocking on it first. We await it before saving the assistant
@@ -250,7 +305,11 @@ async function* processMessage(params: {
       ...conversationHistory,
       { role: "user", content: message },
     ],
-    temperature: (chatbot.temperature ?? 70) / 100,
+    // Lower temperature in a structured mode for more reliable, parseable JSON.
+    temperature:
+      mode != null
+        ? Math.min((chatbot.temperature ?? 70) / 100, 0.3)
+        : (chatbot.temperature ?? 70) / 100,
     maxTokens: maxOutputTokens,
   });
 
@@ -261,15 +320,30 @@ async function* processMessage(params: {
   // Emit at most one `thinking` event per reasoning phase: reasoning-delta
   // fires for every token and would spam the subscription otherwise.
   let thinkingEmitted = false;
-  for await (const part of result.fullStream) {
+  streamLoop: for await (const part of result.fullStream) {
     switch (part.type) {
       case "text-delta": {
         fullResponse += part.text;
         thinkingEmitted = false;
-        yield {
-          type: "text" as const,
-          content: part.text,
-        };
+        // In a structured mode, buffer the JSON silently -- we emit a single
+        // structured event once parsing succeeds rather than streaming raw JSON.
+        if (!mode) {
+          yield {
+            type: "text" as const,
+            content: part.text,
+          };
+        } else if (fullResponse.length > MAX_STRUCTURED_BUFFER_CHARS) {
+          // Runaway structured stream: stop reading and abandon the buffer. The
+          // post-loop parse will fail on the (truncated) JSON and emit the
+          // mode's fallback message, the desired user-facing outcome. Labeled
+          // break exits the for-await loop, not just the switch.
+          logWarn("Structured-mode buffer exceeded cap, aborting buffering", {
+            chatbotId: chatbot.id,
+            modeId: mode.id,
+            chars: fullResponse.length,
+          });
+          break streamLoop;
+        }
         break;
       }
       case "reasoning-start":
@@ -324,19 +398,60 @@ async function* processMessage(params: {
     });
   }
 
-  // Wait for the user message insert (fired in parallel with streamText) so
-  // subsequent turns see the full conversation and the ordering is correct.
+  // Parse the buffered JSON for the detected mode. On success, emit a single
+  // structured event carrying the mode id + validated payload. On failure, fall
+  // back to a friendly text message rather than dumping malformed JSON.
+  let structured: unknown;
+  if (mode) {
+    try {
+      structured = mode.schema.parse(JSON.parse(fullResponse));
+    } catch (err) {
+      logError(err, `Failed to parse ${mode.id} JSON, falling back to text`, {
+        chatbotId: chatbot.id,
+        sessionId,
+      });
+    }
+
+    if (structured !== undefined) {
+      yield { type: "structured" as const, mode: mode.id, payload: structured };
+    } else {
+      fullResponse = mode.fallbackMessage;
+      yield { type: "text" as const, content: fullResponse };
+    }
+  }
+
+  // The user message, assistant message, and analytics below are intentionally
+  // three separate inserts rather than one transaction:
+  //   - The user insert is fired in parallel *before* streaming (latency win)
+  //     and is awaited here so ordering/history stay correct.
+  //   - Analytics is best-effort telemetry; it must never roll back a real
+  //     conversation message, so it stays decoupled.
+  // A user turn with no assistant reply (if the assistant insert fails) is
+  // harmless and still useful for debugging, so atomicity isn't required here.
   await userMessageInsert;
 
-  // Save assistant response
+  // Save assistant response. Quiz messages store a human-readable fallback in
+  // `content` (so export/history isn't empty) plus the structured quiz.
   await database.insert(messages).values({
     conversationId: conversation.id,
     role: "assistant",
-    content: fullResponse,
+    content:
+      mode && structured !== undefined
+        ? mode.summarize(structured)
+        : fullResponse,
     metadata: {
       sources: ragResult.sources,
       responseTime,
       ragUsed: ragResult.ragUsed,
+      ...(mode && structured !== undefined
+        ? {
+            // mode.id is typed StructuredModeId, which matches the schema's
+            // messageType column union -- no cast needed, and a renamed/added
+            // mode id now fails to compile here instead of drifting silently.
+            messageType: mode.id,
+            structured,
+          }
+        : {}),
     },
   });
 
@@ -383,6 +498,10 @@ export const chatRouter = router({
           .max(30)
           .regex(/^[a-zA-Z0-9_-]+$/)
           .optional(),
+        // Confirm-gate flags: skipConfirm = the user clicked "Yes" (run
+        // generation); forceNormalChat = clicked "No" (answer as plain chat).
+        skipConfirm: z.boolean().optional(),
+        forceNormalChat: z.boolean().optional(),
       }),
     )
     .subscription(async function* ({ ctx, input }) {
@@ -424,6 +543,8 @@ export const chatRouter = router({
           sessionId: input.sessionId,
           db: ctx.db,
           eventType: "message_sent",
+          skipConfirm: input.skipConfirm,
+          forceNormalChat: input.forceNormalChat,
         });
       } catch (error) {
         if (error instanceof TRPCError) throw error;
@@ -454,6 +575,10 @@ export const chatRouter = router({
           .max(30)
           .regex(/^[a-zA-Z0-9_-]+$/)
           .optional(),
+        // Confirm-gate flags: skipConfirm = "Yes" (generate); forceNormalChat =
+        // "No" (plain chat).
+        skipConfirm: z.boolean().optional(),
+        forceNormalChat: z.boolean().optional(),
       }),
     )
     .subscription(async function* ({ ctx, input }) {
@@ -498,6 +623,8 @@ export const chatRouter = router({
           sessionId: input.sessionId,
           db: ctx.db,
           eventType: "shared_message_sent",
+          skipConfirm: input.skipConfirm,
+          forceNormalChat: input.forceNormalChat,
         });
       } catch (error) {
         if (error instanceof TRPCError) throw error;

--- a/apps/web/src/types/database.ts
+++ b/apps/web/src/types/database.ts
@@ -1,4 +1,9 @@
 import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
+import type { Quiz } from "@/lib/quiz";
+import type { Flashcards } from "@/lib/flashcards";
+import type { Test } from "@/lib/test-mode";
+import type { MindMap } from "@/lib/mindmap";
+import type { Matching } from "@/lib/matching";
 import {
   user,
   chatbots,
@@ -41,6 +46,18 @@ export type NewApprovedDomain = InferInsertModel<typeof approvedDomains>;
 // Client-side types (for UI/chat components)
 // ============================================
 
+/**
+ * Structured-mode payload carried on an assistant message. The `messageType`
+ * discriminates which interactive widget renders and narrows `structured`.
+ * Modes: quiz, flashcards, test, mindmap (see lib/modes/registry.ts).
+ */
+export type StructuredMessage =
+  | { messageType: "quiz"; structured: Quiz }
+  | { messageType: "flashcards"; structured: Flashcards }
+  | { messageType: "test"; structured: Test }
+  | { messageType: "mindmap"; structured: MindMap }
+  | { messageType: "matching"; structured: Matching };
+
 // Chat message type (used in frontend chat interfaces)
 export interface ChatMessage {
   role: "user" | "assistant";
@@ -52,6 +69,22 @@ export interface ChatMessage {
   }>;
   cancelled?: boolean;
   truncated?: boolean;
+  // Structured Mode: when present, the message renders as an interactive widget
+  // (quiz/flashcards/test/mindmap) instead of markdown text. messageType
+  // discriminates which; `structured` is its validated payload.
+  messageType?: StructuredMessage["messageType"];
+  structured?: Quiz | Flashcards | Test | MindMap | Matching;
+  // Confirm gate: an ephemeral assistant message that renders a Yes/No card
+  // asking whether to generate a study tool. Not persisted server-side -- it
+  // exists only for the current turn. `mode` is the structured mode to run on
+  // Yes; `topic` seeds the canonical trigger; `originalMessage` is re-sent as
+  // normal chat on No.
+  confirm?: {
+    mode: StructuredMessage["messageType"];
+    label: string;
+    topic: string;
+    originalMessage: string;
+  };
 }
 
 // Message source type

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -330,6 +330,15 @@ export const messages = pgTable(
         responseTime?: number;
         model?: string;
         ragUsed?: boolean;
+        // Structured Mode: when the assistant reply is an interactive widget
+        // (quiz/flashcards/test/mindmap/matching), the mode id and its validated payload
+        // are stored here so the message is structurally reconstructable. The
+        // payload shape is per-mode (see lib/modes/registry.ts); kept as unknown
+        // here since this JSONB column is mode-agnostic storage.
+        // Keep this union in sync with StructuredModeId (apps/web/src/lib/modes/
+        // types.ts) -- this package can't import app code, so it's mirrored.
+        messageType?: "quiz" | "flashcards" | "test" | "mindmap" | "matching";
+        structured?: unknown;
       }>()
       .default({}),
     createdAt: timestamp("created_at").defaultNow().notNull(),


### PR DESCRIPTION
## Summary

Adds **structured study modes** to the chatbot: when a student asks for a study tool, the bot returns validated JSON the client renders as an interactive widget instead of plain prose.

Modes included:
- **Quiz** — multiple-choice, scored
- **Flashcards** — flip-through study deck
- **Test** — longer graded test with a timer, now supporting **free-response (open-ended) questions** graded by the AI as a chat follow-up
- **Mind map** — collapsible hierarchical concept map
- **Matching pairs** — Duolingo-style two-column matching game with first-try accuracy

It also replaces silent keyword triggering with a **Yes/No confirmation step**, so the bot never generates the wrong format ("don't make flashcards" no longer makes flashcards) and no longer misses casual phrasings ("i want u to make flashcards…").

## How it works

Each mode is a `StructuredMode` descriptor (`detect`, `instruction`, `schema`, `summarize`, `fallback`) driven by an ordered registry. The streaming pipeline:

1. **Eager-detect** a study-tool request → emit an ephemeral `confirm` event (no LLM call) → render a Yes/No card.
2. **Yes** → send a canonical trigger phrase (guaranteed to pass the strict detector) → the model returns strict JSON, which the server buffers (capped to guard runaway streams), validates, and emits as a single structured event.
3. **No** → answer the original message as normal chat.
4. The client re-validates the payload and renders the matching widget. Payloads persist in the `messages` JSONB metadata, typed by a single `StructuredModeId` source of truth.

## Notable details

- **Back-compat**: legacy persisted tests (multiple-choice questions without a `type` field) still parse — the schema defaults `type` to `"multiple_choice"`.
- **Confirmation gate** handles intent that regex can't: leading negations and "what is…" questions are excluded; the canonical-trigger round-trip is unit-tested for every mode.
- Hardening: structured-buffer size cap, matching-pair uniqueness validation, duplicate-option React keys, and failure toasts.

## Testing

- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test` ✅ — **411 tests pass**, including new coverage for each mode's schema/triggers, eager detection + negation guards, canonical-trigger round-trips, and grading helpers.

Verified to build and pass off a clean `main` (no dependency on unrelated in-flight work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
