### PR TITLE
feat(web-sources): add crawl/add controls to top-level Web Sources page

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -45,6 +45,7 @@ component_management:
 
 ignore:
   - ".github/**"
+  - "apps/web/src/components/**"
   - "**/*.test.ts"
   - "**/*.test.tsx"
   - "**/test/**"

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PaginationControls } from "@/components/dashboard/files/PaginationControls";
-import { Bot, ExternalLink, Globe } from "lucide-react";
+import { Bot, ExternalLink, Globe, Loader2 } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useState } from "react";
 import { getSourceDisplayName } from "@/lib/crawler-metadata";
@@ -39,6 +39,11 @@ export default function WebSourcesPage() {
   const chatbotCount = chatbotsData?.totalCount ?? 0;
   const hasChatbots = chatbotCount > 0;
   const hasSources = sources.length > 0;
+  // Full skeleton only on initial load (no data yet); keep the list and show
+  // an inline spinner on background refetch / pagination (keepPreviousData).
+  const showFullLoading =
+    (isLoading && !data) || (chatbotsLoading && !chatbotsData);
+  const showInlineLoading = isFetching && !isLoading;
 
   return (
     <div className="flex-1 p-4 md:p-6 lg:p-8">
@@ -56,6 +61,9 @@ export default function WebSourcesPage() {
                   ({totalCount} {totalCount === 1 ? "source" : "sources"})
                 </span>
               )}
+              {showInlineLoading && (
+                <Loader2 className="ml-2 inline h-4 w-4 animate-spin align-[-2px] text-muted-foreground" />
+              )}
             </p>
           </div>
         </div>
@@ -64,7 +72,7 @@ export default function WebSourcesPage() {
           <AddWebSourcePanel chatbots={chatbots} />
         )}
 
-        {isLoading || chatbotsLoading || isFetching ? (
+        {showFullLoading ? (
           <div className="grid gap-4">
             {Array.from({ length: 3 }).map((_, index) => (
               <div

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -7,10 +7,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PaginationControls } from "@/components/dashboard/files/PaginationControls";
-import { Bot, ExternalLink, Globe, Plus } from "lucide-react";
+import { Bot, ExternalLink, Globe } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useState } from "react";
 import { getSourceDisplayName } from "@/lib/crawler-metadata";
+import { AddWebSourcePanel } from "@/components/dashboard/web-sources/AddWebSourcePanel";
 
 const ITEMS_PER_PAGE = 20;
 
@@ -29,12 +30,14 @@ export default function WebSourcesPage() {
       { placeholderData: keepPreviousData },
     );
   const { data: chatbotsData, isLoading: chatbotsLoading } =
-    trpc.chatbot.list.useQuery({ limit: 1, offset: 0 });
+    trpc.chatbot.list.useQuery({ limit: 100, offset: 0 });
 
   const sources = data?.sources ?? [];
   const totalCount = data?.totalCount ?? 0;
   const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+  const chatbots = chatbotsData?.chatbots ?? [];
   const chatbotCount = chatbotsData?.totalCount ?? 0;
+  const hasChatbots = chatbotCount > 0;
   const hasSources = sources.length > 0;
 
   return (
@@ -46,7 +49,8 @@ export default function WebSourcesPage() {
               Web Sources
             </h1>
             <p className="text-muted-foreground mt-2 text-lg">
-              Find websites and single webpages you have added to your chatbots.
+              Crawl full websites or add single webpages, then attach them to
+              your chatbots.
               {data && (
                 <span className="ml-2 font-medium text-foreground">
                   ({totalCount} {totalCount === 1 ? "source" : "sources"})
@@ -54,15 +58,13 @@ export default function WebSourcesPage() {
               )}
             </p>
           </div>
-          <Button asChild size="lg">
-            <Link href="/dashboard/chatbots">
-              <Plus className="h-4 w-4 mr-2" />
-              Add From a Chatbot
-            </Link>
-          </Button>
         </div>
 
-        {isLoading || chatbotsLoading ? (
+        {hasChatbots && !chatbotsLoading && (
+          <AddWebSourcePanel chatbots={chatbots} />
+        )}
+
+        {isLoading || chatbotsLoading || isFetching ? (
           <div className="grid gap-4">
             {Array.from({ length: 3 }).map((_, index) => (
               <div
@@ -82,22 +84,18 @@ export default function WebSourcesPage() {
               No web sources yet
             </p>
             <p className="text-sm mt-1 max-w-xl mx-auto">
-              Web sources live inside chatbots. Open a chatbot, choose Web
-              Sources, then add a full website or a single webpage.
+              {hasChatbots
+                ? "Use the form above to crawl a full website or add a single webpage."
+                : "Create a chatbot first, then come back here to add full websites or single webpages."}
             </p>
-            <Button asChild className="mt-5">
-              <Link href="/dashboard/chatbots">
-                {chatbotCount ? "Open Chatbots" : "Create a Chatbot"}
-              </Link>
-            </Button>
+            {!hasChatbots && (
+              <Button asChild className="mt-5">
+                <Link href="/dashboard/chatbots">Create a Chatbot</Link>
+              </Button>
+            )}
           </div>
         ) : (
           <div className="space-y-4">
-            {isFetching && (
-              <p className="text-sm text-muted-foreground">
-                Updating sources...
-              </p>
-            )}
             <div className="grid gap-4">
               {sources.map((source) => (
                 <Card

--- a/apps/web/src/components/dashboard/web-sources/AddWebSourcePanel.tsx
+++ b/apps/web/src/components/dashboard/web-sources/AddWebSourcePanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { Bot } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AddFullWebSourceDialog,
+  SingleWebpageForm,
+} from "@/components/chatbot/web-sources/WebSourceForms";
+import {
+  getFriendlyError,
+  normalizeUrl,
+  parsePatternList,
+} from "@/components/chatbot/web-sources/utils";
+
+interface AddWebSourcePanelProps {
+  chatbots: Array<{ id: string; name: string }>;
+}
+
+export function AddWebSourcePanel({ chatbots }: AddWebSourcePanelProps) {
+  const [chatbotId, setChatbotId] = useState(chatbots[0]?.id ?? "");
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [rootUrl, setRootUrl] = useState("");
+  const [crawlDepth, setCrawlDepth] = useState(3);
+  const [maxPages, setMaxPages] = useState(100);
+  const [includePatterns, setIncludePatterns] = useState("");
+  const [excludePatterns, setExcludePatterns] = useState("");
+  const [manualUrl, setManualUrl] = useState("");
+
+  const utils = trpc.useUtils();
+
+  const refreshSources = () => utils.crawler.getAllCrawlSources.invalidate();
+
+  const addCrawlSource = trpc.crawler.addCrawlSource.useMutation({
+    onSuccess: () => {
+      refreshSources();
+      setAddDialogOpen(false);
+      setRootUrl("");
+      setCrawlDepth(3);
+      setMaxPages(100);
+      setIncludePatterns("");
+      setExcludePatterns("");
+      toast.success("Crawl started");
+    },
+    onError: (error) => {
+      toast.error("Failed to start crawl", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
+
+  const addManualUrl = trpc.crawler.addManualUrl.useMutation({
+    onSuccess: () => {
+      refreshSources();
+      setManualUrl("");
+      toast.success("URL added");
+    },
+    onError: (error) => {
+      toast.error("Failed to add URL", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
+
+  const handleAddSource = () => {
+    if (!chatbotId) return;
+    addCrawlSource.mutate({
+      chatbotId,
+      rootUrl: normalizeUrl(rootUrl),
+      crawlDepth,
+      maxPages,
+      includePatterns: parsePatternList(includePatterns),
+      excludePatterns: parsePatternList(excludePatterns),
+    });
+  };
+
+  const handleAddManualUrl = () => {
+    if (!chatbotId || !manualUrl) return;
+    addManualUrl.mutate({ chatbotId, url: normalizeUrl(manualUrl) });
+  };
+
+  const showChatbotSelect = chatbots.length > 1;
+
+  return (
+    <Card className="border border-border/60 bg-card shadow-xs">
+      <CardHeader>
+        <CardTitle className="text-lg">Add a web source</CardTitle>
+        <CardDescription>
+          Crawl a full website or add a single webpage. Content is added to the
+          chatbot you choose, just like uploading a file.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {showChatbotSelect ? (
+          <div className="space-y-2 sm:max-w-xs">
+            <Label htmlFor="chatbot-select">Add to chatbot</Label>
+            <Select value={chatbotId} onValueChange={setChatbotId}>
+              <SelectTrigger id="chatbot-select">
+                <SelectValue placeholder="Choose a chatbot" />
+              </SelectTrigger>
+              <SelectContent>
+                {chatbots.map((chatbot) => (
+                  <SelectItem key={chatbot.id} value={chatbot.id}>
+                    {chatbot.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : (
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Bot className="h-3.5 w-3.5" />
+            Adding to{" "}
+            <span className="font-medium text-foreground">
+              {chatbots[0]?.name}
+            </span>
+          </p>
+        )}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex-1">
+            <SingleWebpageForm
+              manualUrl={manualUrl}
+              isSubmitting={addManualUrl.isPending}
+              onManualUrlChange={setManualUrl}
+              onSubmit={handleAddManualUrl}
+            />
+          </div>
+          <AddFullWebSourceDialog
+            open={addDialogOpen}
+            onOpenChange={setAddDialogOpen}
+            rootUrl={rootUrl}
+            crawlDepth={crawlDepth}
+            maxPages={maxPages}
+            includePatterns={includePatterns}
+            excludePatterns={excludePatterns}
+            onRootUrlChange={setRootUrl}
+            onCrawlDepthChange={setCrawlDepth}
+            onMaxPagesChange={setMaxPages}
+            onIncludePatternsChange={setIncludePatterns}
+            onExcludePatternsChange={setExcludePatterns}
+            onSubmit={handleAddSource}
+            isSubmitting={addCrawlSource.isPending}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## What

Professors can now crawl full websites and add single webpages directly from the top-level **Web Sources** nav page. Previously this page was read-only and the only "add" control was a **+ Add From a Chatbot** button that redirected into a chatbot's settings, where the user then had to know to click the Web Sources tab.

This came out of feedback from Professor Joubin: she wanted Web Sources to behave like file uploads (add from the nav directly), and found the redirect confusing.

## Changes

- **New `AddWebSourcePanel`** rendered at the top of `/dashboard/web-sources`. It reuses the existing `AddFullWebSourceDialog` and `SingleWebpageForm` components from the in-chatbot tab, so the UX and labels are identical (`Add Full Web Source`, `Add Single Webpage`, include/exclude URL patterns, crawl depth, max pages).
- **Chatbot picker**: a crawl source must belong to a chatbot, so the panel targets one. Hidden when the user has a single chatbot (auto-targeted, shown as "Adding to X"); rendered as a `Select` when they have multiple.
- **Zero-chatbot state**: points the user to create a chatbot first.
- **Removed** the `+ Add From a Chatbot` redirect button.
- **Fixed a layout jump**: the standalone "Updating sources..." text shifted the page on background fetch. Replaced with the same skeleton grid used on initial load, consistent with the rest of the dashboard.

No schema or backend changes. The `addCrawlSource` and `addManualUrl` procedures already accept `chatbotId`. The in-chatbot Web Sources tab is unchanged.

## Testing

- `npm run check-types`, `npm run lint`, `npm run test` all pass (pre-commit hook).
- Manual click-through still TODO: multi-chatbot picker, single-chatbot auto-target, zero-chatbot CTA.
