### PR TITLE
fix(analytics): correct common-questions counts and paginate the card

### DIFF
--- a/apps/web/src/components/chatbot/analytics-tab.tsx
+++ b/apps/web/src/components/chatbot/analytics-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Bar,
   BarChart,
@@ -11,6 +12,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { keepPreviousData } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertCircle,
@@ -27,8 +29,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { trpc } from "@/lib/trpc";
+
+const COMMON_QUESTIONS_PAGE_SIZE = 5;
 
 interface ChatbotAnalyticsTabProps {
   chatbotId: string;
@@ -141,9 +146,14 @@ export function ChatbotAnalyticsTab({ chatbotId }: ChatbotAnalyticsTabProps) {
       { chatbotId },
       { enabled: !!chatbotId },
     );
+  const [questionsOffset, setQuestionsOffset] = useState(0);
   const commonQuestionsQuery = trpc.analytics.getCommonQuestions.useQuery(
-    { chatbotId, limit: 10, offset: 0 },
-    { enabled: !!chatbotId },
+    {
+      chatbotId,
+      limit: COMMON_QUESTIONS_PAGE_SIZE,
+      offset: questionsOffset,
+    },
+    { enabled: !!chatbotId, placeholderData: keepPreviousData },
   );
   const lowConfidenceQuery = trpc.analytics.getLowConfidenceQueries.useQuery(
     { chatbotId, limit: 5, offset: 0 },
@@ -343,7 +353,7 @@ export function ChatbotAnalyticsTab({ chatbotId }: ChatbotAnalyticsTabProps) {
           </CardContent>
         </Card>
 
-        <Card className="border border-border/60 shadow-xs">
+        <Card className="border border-border/60 shadow-xs xl:col-span-2">
           <CardHeader>
             <CardTitle>Session Lengths</CardTitle>
             <CardDescription>Sessions grouped by message count</CardDescription>
@@ -422,19 +432,68 @@ export function ChatbotAnalyticsTab({ chatbotId }: ChatbotAnalyticsTabProps) {
               </div>
             ) : (
               <div className="space-y-3">
-                {commonQuestionsQuery.data.questions.map((question, index) => (
-                  <div
-                    key={`${question.question}-${index}`}
-                    className="flex items-start gap-3 rounded-lg border p-3"
-                  >
-                    <div className="h-8 w-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold shrink-0">
-                      {question.count}
+                <div className="space-y-3">
+                  {commonQuestionsQuery.data.questions.map(
+                    (question, index) => (
+                      <div
+                        key={`${question.question}-${index}`}
+                        className="flex items-start gap-3 rounded-lg border p-3"
+                      >
+                        <div className="h-8 w-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold shrink-0">
+                          {question.count}
+                        </div>
+                        <p className="text-sm leading-6 break-words">
+                          {question.question}
+                        </p>
+                      </div>
+                    ),
+                  )}
+                </div>
+                {commonQuestionsQuery.data.totalCount >
+                  COMMON_QUESTIONS_PAGE_SIZE && (
+                  <div className="flex items-center justify-between pt-3 border-t">
+                    <span className="text-xs text-muted-foreground">
+                      Showing {questionsOffset + 1}-
+                      {Math.min(
+                        questionsOffset + COMMON_QUESTIONS_PAGE_SIZE,
+                        commonQuestionsQuery.data.totalCount,
+                      )}{" "}
+                      of {commonQuestionsQuery.data.totalCount}
+                    </span>
+                    <div className="flex gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          setQuestionsOffset(
+                            Math.max(
+                              0,
+                              questionsOffset - COMMON_QUESTIONS_PAGE_SIZE,
+                            ),
+                          )
+                        }
+                        disabled={questionsOffset === 0}
+                      >
+                        Previous
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          setQuestionsOffset(
+                            questionsOffset + COMMON_QUESTIONS_PAGE_SIZE,
+                          )
+                        }
+                        disabled={
+                          questionsOffset + COMMON_QUESTIONS_PAGE_SIZE >=
+                          commonQuestionsQuery.data.totalCount
+                        }
+                      >
+                        Next
+                      </Button>
                     </div>
-                    <p className="text-sm leading-6 break-words">
-                      {question.question}
-                    </p>
                   </div>
-                ))}
+                )}
               </div>
             )}
           </CardContent>

--- a/apps/web/src/server/routers/analytics.ts
+++ b/apps/web/src/server/routers/analytics.ts
@@ -133,7 +133,7 @@ export const analyticsRouter = router({
 
       const [analyticsSummary] = await ctx.db
         .select({
-          eventCount: sql<number>`count(*)::int`,
+          ragEventCount: sql<number>`COALESCE(SUM(CASE WHEN (${analytics.eventData}->>'ragUsed') IS NOT NULL THEN 1 ELSE 0 END), 0)::int`,
           avgResponseTime: sql<number>`COALESCE(ROUND(AVG((${analytics.eventData}->>'responseTime')::double precision)), 0)::int`,
           ragHits: sql<number>`COALESCE(SUM(CASE WHEN ${analytics.eventData}->>'ragUsed' = 'true' THEN 1 ELSE 0 END), 0)::int`,
         })
@@ -145,10 +145,10 @@ export const analyticsRouter = router({
           ),
         );
 
-      const eventCount = analyticsSummary?.eventCount ?? 0;
+      const ragEventCount = analyticsSummary?.ragEventCount ?? 0;
       const ragHits = analyticsSummary?.ragHits ?? 0;
       const ragUsagePercentage =
-        eventCount > 0 ? Math.round((ragHits / eventCount) * 100) : 0;
+        ragEventCount > 0 ? Math.round((ragHits / ragEventCount) * 100) : 0;
 
       return {
         totalConversations,
@@ -393,7 +393,6 @@ export const analyticsRouter = router({
             "question",
           ),
           count: sql<number>`count(*)::int`.as("count"),
-          totalCount: sql<number>`count(*) OVER()::int`.as("total_count"),
         })
         .from(firstUserMessages)
         .where(
@@ -404,6 +403,10 @@ export const analyticsRouter = router({
         )
         .groupBy(firstUserMessages.normalizedQuestion)
         .as("grouped_questions");
+
+      const [total] = await ctx.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(groupedQuestions);
 
       const questions = await ctx.db
         .select()
@@ -417,7 +420,7 @@ export const analyticsRouter = router({
           question: q.question,
           count: q.count,
         })),
-        totalCount: questions[0]?.totalCount ?? 0,
+        totalCount: total?.count ?? 0,
       };
     }),
 


### PR DESCRIPTION
## Summary

Follow-up fixes and UI polish on the session-insights analytics feature merged in #305. Single commit on top of current `main`.

## What changed

**Backend (`apps/web/src/server/routers/analytics.ts`)**
- `getCommonQuestions`: return a real distinct-question total via a separate count, instead of the windowed `count(*) OVER()` read from `questions[0]`. The old value dropped to `0` on out-of-range offsets, breaking pagination totals.
- `getChatbotStats`: compute `ragUsagePercentage` over events that actually recorded `ragUsed`, so legacy rows without the field stop diluting the percentage.

**Frontend (`apps/web/src/components/chatbot/analytics-tab.tsx`)**
- Paginate the Common Questions card (5 per page, Previous/Next, `keepPreviousData` to avoid skeleton flicker). It was rendering 10 in one card and running long.
- Span Session Lengths full width (`xl:col-span-2`) to remove the empty grid column beside it.

## Reviewer notes (intentionally not addressed here)

From the Copilot pass on #305:
- **Timezone day/week keys** — no-op on our stack (`created_at` stores UTC wall-clock under Supabase UTC, so DB date keys already match the UTC gap-fill). A permanent fix means a `timestamptz` migration; out of scope.
- **`CREATE INDEX` not `CONCURRENTLY`** — Drizzle runs migrations in a transaction and `CONCURRENTLY` can't; the `analytics` table is new/small, so the lock is a non-issue at current scale.
- **Storing the raw `question` excerpt (PII)** — kept; the full text already lives in `messages.content`, and the analytics copy powers the low-confidence-queries view.

## Follow-up

Semantic grouping of common questions tracked in #315 (current grouping is exact-match on normalized text).

## Test plan

- `npm run check-types` — pass
- `npm run lint` — pass
- `npm run test` — 331 web + 40 ai pass
- Manual: paginate Common Questions, confirm totals correct past the last page; Session Lengths fills the row.
