### PR TITLE
feat(web-sources): make chatbot attachment optional

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -1,0 +1,169 @@
+name: Migrate Database
+
+# Applies pending Drizzle migrations to the production database after CI
+# passes on main. Modeled on the tambo migrate-db workflow. Runs only when
+# packages/db changed, only for trusted pushes to main, and never from fork
+# PRs or dependabot. Requires a DATABASE_URL repo secret (prod connection).
+#
+# NOTE: this runs in parallel with the Vercel production deploy, so there is a
+# brief window where new code may serve against the pre-migration schema (and,
+# because preview deploys share the production DATABASE_URL, previews of a
+# schema-changing PR run new code against the old schema until this lands).
+# Migrations are written non-destructively (backfill before drop) to tolerate
+# that window.
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    branches: [main]
+    types:
+      - completed
+  workflow_dispatch:
+
+concurrency:
+  group: migrate-db
+  cancel-in-progress: false
+
+jobs:
+  deploy-migrations:
+    name: Deploy Database Migrations
+    # Only trusted pushes from this repo (never fork PRs / dependabot).
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_repository.full_name == github.repository &&
+          github.event.workflow_run.head_branch == 'main' &&
+          github.event.workflow_run.conclusion == 'success'
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # For workflow_run events, check out the commit that triggered the
+          # upstream workflow. For manual dispatch, use the workflow's own SHA.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Check for changes in packages/db
+        id: check-changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WORKFLOW_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow_id || '' }}
+          WORKFLOW_RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || '' }}
+          HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -u
+
+          DB_PATH="packages/db"
+
+          if [ ! -d "$DB_PATH" ]; then
+            echo "Directory $DB_PATH does not exist; skipping migrations."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE_SHA=""
+
+          # When triggered by workflow_run, find the previous run of the
+          # upstream workflow on main and use its head_sha as the diff base.
+          if [ -n "${WORKFLOW_ID:-}" ] && [ -n "${WORKFLOW_RUN_ID:-}" ]; then
+            echo "Resolving previous workflow run for diff base..."
+
+            API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs?branch=main&per_page=20"
+
+            set -eo pipefail
+
+            if ! runs_json="$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" "$API_URL")"; then
+              set +e
+              echo "Warning: failed to fetch workflow runs; defaulting to changed=true" >&2
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if ! BASE_SHA="$(echo "$runs_json" | jq -r --arg current_id "$WORKFLOW_RUN_ID" '
+              if (.workflow_runs | type) != "array" then
+                ""
+              else
+                .workflow_runs
+                | sort_by(.run_started_at)
+                | to_entries
+                | (map(select(.value.id == ($current_id | tonumber)) | .key) | .[0]) as $idx
+                | if $idx == null or $idx == 0 then
+                    ""
+                  else
+                    .[$idx - 1].value.head_sha
+                  end
+              end
+            ')"; then
+              set +e
+              echo "Warning: failed to resolve BASE_SHA; defaulting to changed=true" >&2
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            set +e
+          fi
+
+          if [ -z "$BASE_SHA" ]; then
+            echo "No previous workflow run found; treating as initial run for diff."
+            if git ls-tree -r --name-only "$HEAD_SHA" "$DB_PATH" | grep -q . 2>/dev/null; then
+              echo "Initial run with database files present; running migrations."
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              status=$?
+              if [ "$status" -eq 1 ]; then
+                echo "Initial run without database files; skipping migrations."
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "Warning: git ls-tree/grep failed (status $status); defaulting to changed=true" >&2
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+              fi
+            fi
+            exit 0
+          fi
+
+          echo "Comparing $BASE_SHA..$HEAD_SHA for changes under $DB_PATH"
+
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "$DB_PATH"; then
+            echo "No changes detected in $DB_PATH between $BASE_SHA and $HEAD_SHA"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [ "$status" -eq 1 ]; then
+              echo "Changes detected in $DB_PATH"
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DB_PATH" || true
+            else
+              echo "Warning: git diff failed (status $status); defaulting to changed=true" >&2
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Setup Node
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.check-changes.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Run database migrations
+        if: steps.check-changes.outputs.changed == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npm run db:migrate
+        working-directory: packages/db

--- a/apps/web/src/__tests__/server/crawler-attach.test.ts
+++ b/apps/web/src/__tests__/server/crawler-attach.test.ts
@@ -1,8 +1,5 @@
 import { jest, describe, it, expect } from "@jest/globals";
-import {
-  deleteCrawlFileIds,
-  deleteAllCrawlFileIds,
-} from "@/server/routers/crawler/helpers";
+import { deleteAllCrawlFileIds } from "@/server/routers/crawler/helpers";
 
 function makeTx() {
   const whereStub = jest.fn(() => Promise.resolve(undefined));
@@ -11,22 +8,6 @@ function makeTx() {
   };
   return { tx, whereStub };
 }
-
-describe("deleteCrawlFileIds", () => {
-  it("no-ops on empty fileIds", async () => {
-    const { tx } = makeTx();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await deleteCrawlFileIds(tx as any, "chatbot-1", []);
-    expect(tx.delete).not.toHaveBeenCalled();
-  });
-
-  it("issues an association delete then an orphan-cleanup delete", async () => {
-    const { tx } = makeTx();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await deleteCrawlFileIds(tx as any, "chatbot-1", ["f1", "f2"]);
-    expect(tx.delete).toHaveBeenCalledTimes(2);
-  });
-});
 
 describe("deleteAllCrawlFileIds", () => {
   it("no-ops on empty fileIds", async () => {

--- a/apps/web/src/__tests__/server/crawler-attach.test.ts
+++ b/apps/web/src/__tests__/server/crawler-attach.test.ts
@@ -1,0 +1,47 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+jest.mock("@teachanything/db", () => ({ db: {} }));
+
+const { deleteCrawlFileIds, deleteAllCrawlFileIds } = await import(
+  "@/server/routers/crawler/helpers"
+);
+
+function makeTx() {
+  const whereStub = jest.fn(() => Promise.resolve(undefined));
+  const tx = {
+    delete: jest.fn(() => ({ where: whereStub })),
+  };
+  return { tx, whereStub };
+}
+
+describe("deleteCrawlFileIds", () => {
+  it("no-ops on empty fileIds", async () => {
+    const { tx } = makeTx();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await deleteCrawlFileIds(tx as any, "chatbot-1", []);
+    expect(tx.delete).not.toHaveBeenCalled();
+  });
+
+  it("issues an association delete then an orphan-cleanup delete", async () => {
+    const { tx } = makeTx();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await deleteCrawlFileIds(tx as any, "chatbot-1", ["f1", "f2"]);
+    expect(tx.delete).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("deleteAllCrawlFileIds", () => {
+  it("no-ops on empty fileIds", async () => {
+    const { tx } = makeTx();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await deleteAllCrawlFileIds(tx as any, []);
+    expect(tx.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes all associations then userFiles", async () => {
+    const { tx } = makeTx();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await deleteAllCrawlFileIds(tx as any, ["f1"]);
+    expect(tx.delete).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/__tests__/server/crawler-attach.test.ts
+++ b/apps/web/src/__tests__/server/crawler-attach.test.ts
@@ -1,10 +1,8 @@
 import { jest, describe, it, expect } from "@jest/globals";
-
-jest.mock("@teachanything/db", () => ({ db: {} }));
-
-const { deleteCrawlFileIds, deleteAllCrawlFileIds } = await import(
-  "@/server/routers/crawler/helpers"
-);
+import {
+  deleteCrawlFileIds,
+  deleteAllCrawlFileIds,
+} from "@/server/routers/crawler/helpers";
 
 function makeTx() {
   const whereStub = jest.fn(() => Promise.resolve(undefined));

--- a/apps/web/src/__tests__/server/crawler-validation.test.ts
+++ b/apps/web/src/__tests__/server/crawler-validation.test.ts
@@ -1,44 +1,112 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 import {
+  allCrawlSourcesInput,
   crawlSourceInput,
   manualUrlInput,
+  renameCrawledPageInput,
+  renameCrawlSourceInput,
 } from "@/server/routers/crawler/validation";
 
-describe("crawlSourceInput", () => {
-  it("accepts input with no chatbotId (unattached source)", () => {
-    const parsed = crawlSourceInput.parse({ rootUrl: "https://example.com" });
-    expect(parsed.chatbotId).toBeUndefined();
-    expect(parsed.crawlDepth).toBe(3);
-  });
-
-  it("accepts a valid chatbotId", () => {
-    const id = "11111111-1111-4111-8111-111111111111";
-    const parsed = crawlSourceInput.parse({
-      rootUrl: "https://example.com",
-      chatbotId: id,
+describe("crawler validation schemas", () => {
+  describe("renameCrawlSourceInput", () => {
+    it("accepts and trims valid source names", () => {
+      const result = renameCrawlSourceInput.parse({
+        crawlSourceId: "00000000-0000-4000-8000-000000000001",
+        name: "  Winter's Tale Folger  ",
+      });
+      expect(result.name).toBe("Winter's Tale Folger");
     });
-    expect(parsed.chatbotId).toBe(id);
+
+    it("rejects empty source names", () => {
+      expect(() =>
+        renameCrawlSourceInput.parse({
+          crawlSourceId: "00000000-0000-4000-8000-000000000001",
+          name: "   ",
+        }),
+      ).toThrow();
+    });
   });
 
-  it("rejects a malformed chatbotId", () => {
-    expect(() =>
-      crawlSourceInput.parse({
+  describe("renameCrawledPageInput", () => {
+    it("accepts and trims valid page titles", () => {
+      const result = renameCrawledPageInput.parse({
+        crawledPageId: "00000000-0000-4000-8000-000000000002",
+        title: "  Winter's Tale full text  ",
+      });
+      expect(result.title).toBe("Winter's Tale full text");
+    });
+
+    it("rejects empty page titles", () => {
+      expect(() =>
+        renameCrawledPageInput.parse({
+          crawledPageId: "00000000-0000-4000-8000-000000000002",
+          title: "   ",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("allCrawlSourcesInput", () => {
+    it("defaults pagination parameters", () => {
+      expect(allCrawlSourcesInput.parse({})).toEqual({
+        limit: 20,
+        offset: 0,
+      });
+    });
+
+    it("accepts valid pagination parameters", () => {
+      expect(allCrawlSourcesInput.parse({ limit: 50, offset: 100 })).toEqual({
+        limit: 50,
+        offset: 100,
+      });
+    });
+
+    it("rejects limits above the endpoint cap", () => {
+      expect(() =>
+        allCrawlSourcesInput.parse({ limit: 101, offset: 0 }),
+      ).toThrow();
+    });
+  });
+
+  describe("crawlSourceInput", () => {
+    it("accepts input with no chatbotId (unattached source)", () => {
+      const parsed = crawlSourceInput.parse({ rootUrl: "https://example.com" });
+      expect(parsed.chatbotId).toBeUndefined();
+      expect(parsed.crawlDepth).toBe(3);
+    });
+
+    it("accepts a valid chatbotId", () => {
+      const id = "11111111-1111-4111-8111-111111111111";
+      const parsed = crawlSourceInput.parse({
         rootUrl: "https://example.com",
-        chatbotId: "not-a-uuid",
-      }),
-    ).toThrow();
-  });
-});
+        chatbotId: id,
+      });
+      expect(parsed.chatbotId).toBe(id);
+    });
 
-describe("manualUrlInput", () => {
-  it("accepts input with no chatbotId", () => {
-    const parsed = manualUrlInput.parse({ url: "https://example.com/page" });
-    expect(parsed.chatbotId).toBeUndefined();
+    it("rejects a malformed chatbotId", () => {
+      expect(() =>
+        crawlSourceInput.parse({
+          rootUrl: "https://example.com",
+          chatbotId: "not-a-uuid",
+        }),
+      ).toThrow();
+    });
   });
 
-  it("rejects a malformed chatbotId", () => {
-    expect(() =>
-      manualUrlInput.parse({ url: "https://example.com/page", chatbotId: "x" }),
-    ).toThrow();
+  describe("manualUrlInput", () => {
+    it("accepts input with no chatbotId", () => {
+      const parsed = manualUrlInput.parse({ url: "https://example.com/page" });
+      expect(parsed.chatbotId).toBeUndefined();
+    });
+
+    it("rejects a malformed chatbotId", () => {
+      expect(() =>
+        manualUrlInput.parse({
+          url: "https://example.com/page",
+          chatbotId: "x",
+        }),
+      ).toThrow();
+    });
   });
 });

--- a/apps/web/src/__tests__/server/crawler-validation.test.ts
+++ b/apps/web/src/__tests__/server/crawler-validation.test.ts
@@ -1,68 +1,44 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 import {
-  allCrawlSourcesInput,
-  renameCrawledPageInput,
-  renameCrawlSourceInput,
+  crawlSourceInput,
+  manualUrlInput,
 } from "@/server/routers/crawler/validation";
 
-describe("crawler validation schemas", () => {
-  describe("renameCrawlSourceInput", () => {
-    it("accepts and trims valid source names", () => {
-      const result = renameCrawlSourceInput.parse({
-        crawlSourceId: "00000000-0000-4000-8000-000000000001",
-        name: "  Winter's Tale Folger  ",
-      });
-      expect(result.name).toBe("Winter's Tale Folger");
-    });
-
-    it("rejects empty source names", () => {
-      expect(() =>
-        renameCrawlSourceInput.parse({
-          crawlSourceId: "00000000-0000-4000-8000-000000000001",
-          name: "   ",
-        }),
-      ).toThrow();
-    });
+describe("crawlSourceInput", () => {
+  it("accepts input with no chatbotId (unattached source)", () => {
+    const parsed = crawlSourceInput.parse({ rootUrl: "https://example.com" });
+    expect(parsed.chatbotId).toBeUndefined();
+    expect(parsed.crawlDepth).toBe(3);
   });
 
-  describe("renameCrawledPageInput", () => {
-    it("accepts and trims valid page titles", () => {
-      const result = renameCrawledPageInput.parse({
-        crawledPageId: "00000000-0000-4000-8000-000000000002",
-        title: "  Winter's Tale full text  ",
-      });
-      expect(result.title).toBe("Winter's Tale full text");
+  it("accepts a valid chatbotId", () => {
+    const id = "11111111-1111-4111-8111-111111111111";
+    const parsed = crawlSourceInput.parse({
+      rootUrl: "https://example.com",
+      chatbotId: id,
     });
-
-    it("rejects empty page titles", () => {
-      expect(() =>
-        renameCrawledPageInput.parse({
-          crawledPageId: "00000000-0000-4000-8000-000000000002",
-          title: "   ",
-        }),
-      ).toThrow();
-    });
+    expect(parsed.chatbotId).toBe(id);
   });
 
-  describe("allCrawlSourcesInput", () => {
-    it("defaults pagination parameters", () => {
-      expect(allCrawlSourcesInput.parse({})).toEqual({
-        limit: 20,
-        offset: 0,
-      });
-    });
+  it("rejects a malformed chatbotId", () => {
+    expect(() =>
+      crawlSourceInput.parse({
+        rootUrl: "https://example.com",
+        chatbotId: "not-a-uuid",
+      }),
+    ).toThrow();
+  });
+});
 
-    it("accepts valid pagination parameters", () => {
-      expect(allCrawlSourcesInput.parse({ limit: 50, offset: 100 })).toEqual({
-        limit: 50,
-        offset: 100,
-      });
-    });
+describe("manualUrlInput", () => {
+  it("accepts input with no chatbotId", () => {
+    const parsed = manualUrlInput.parse({ url: "https://example.com/page" });
+    expect(parsed.chatbotId).toBeUndefined();
+  });
 
-    it("rejects limits above the endpoint cap", () => {
-      expect(() =>
-        allCrawlSourcesInput.parse({ limit: 101, offset: 0 }),
-      ).toThrow();
-    });
+  it("rejects a malformed chatbotId", () => {
+    expect(() =>
+      manualUrlInput.parse({ url: "https://example.com/page", chatbotId: "x" }),
+    ).toThrow();
   });
 });

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -7,9 +7,18 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PaginationControls } from "@/components/dashboard/files/PaginationControls";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu";
 import { Bot, ExternalLink, Globe, Loader2 } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useState } from "react";
+import { toast } from "sonner";
 import { getSourceDisplayName } from "@/lib/crawler-metadata";
 import { AddWebSourcePanel } from "@/components/dashboard/web-sources/AddWebSourcePanel";
 
@@ -37,6 +46,17 @@ export default function WebSourcesPage() {
   const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
   const chatbots = chatbotsData?.chatbots ?? [];
   const chatbotCount = chatbotsData?.totalCount ?? 0;
+
+  const utils = trpc.useUtils();
+  const attach = trpc.crawler.attachToChatbot.useMutation({
+    onSuccess: () => utils.crawler.getAllCrawlSources.invalidate(),
+    onError: (e) => toast.error("Failed to attach", { description: e.message }),
+  });
+  const detach = trpc.crawler.detachFromChatbot.useMutation({
+    onSuccess: () => utils.crawler.getAllCrawlSources.invalidate(),
+    onError: (e) =>
+      toast.error("Failed to remove", { description: e.message }),
+  });
   const hasChatbots = chatbotCount > 0;
   const hasSources = sources.length > 0;
   // Full skeleton only on initial load (no data yet); keep the list and show
@@ -145,10 +165,20 @@ export default function WebSourcesPage() {
                             {source.pageCount}{" "}
                             {source.pageCount === 1 ? "page" : "pages"}
                           </Badge>
-                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Bot className="h-3.5 w-3.5" />
-                            {source.chatbotName}
-                          </span>
+                          {source.chatbots.length === 0 ? (
+                            <Badge variant="outline">Not attached</Badge>
+                          ) : (
+                            source.chatbots.map((c) => (
+                              <Badge
+                                key={c.id}
+                                variant="secondary"
+                                className="gap-1"
+                              >
+                                <Bot className="h-3 w-3" />
+                                {c.name}
+                              </Badge>
+                            ))
+                          )}
                           {source.lastCrawledAt && (
                             <span className="text-xs text-muted-foreground">
                               Last crawled{" "}
@@ -159,13 +189,58 @@ export default function WebSourcesPage() {
                           )}
                         </div>
                       </div>
-                      <Button asChild variant="outline" className="shrink-0">
-                        <Link
-                          href={`/chatbot/${source.chatbotId}?tab=web-sources`}
-                        >
-                          Manage Source
-                        </Link>
-                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="outline" className="shrink-0">
+                            <Bot className="mr-2 h-4 w-4" />
+                            Chatbots
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-56">
+                          <DropdownMenuLabel>
+                            Attach to chatbots
+                          </DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          {chatbots.length === 0 ? (
+                            <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                              No chatbots yet. Create one to attach this source.
+                            </div>
+                          ) : (
+                            chatbots.map((chatbot) => {
+                              const attached = source.chatbots.some(
+                                (c) => c.id === chatbot.id,
+                              );
+                              return (
+                                <DropdownMenuCheckboxItem
+                                  key={chatbot.id}
+                                  checked={attached}
+                                  disabled={
+                                    attach.isPending || detach.isPending
+                                  }
+                                  onSelect={(e) => e.preventDefault()}
+                                  onCheckedChange={(checked) => {
+                                    if (checked) {
+                                      attach.mutate({
+                                        crawlSourceId: source.id,
+                                        chatbotId: chatbot.id,
+                                      });
+                                    } else {
+                                      detach.mutate({
+                                        crawlSourceId: source.id,
+                                        chatbotId: chatbot.id,
+                                      });
+                                    }
+                                  }}
+                                >
+                                  <span className="truncate">
+                                    {chatbot.name}
+                                  </span>
+                                </DropdownMenuCheckboxItem>
+                              );
+                            })
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </div>
                   </CardContent>
                 </Card>

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -54,8 +54,7 @@ export default function WebSourcesPage() {
   });
   const detach = trpc.crawler.detachFromChatbot.useMutation({
     onSuccess: () => utils.crawler.getAllCrawlSources.invalidate(),
-    onError: (e) =>
-      toast.error("Failed to remove", { description: e.message }),
+    onError: (e) => toast.error("Failed to remove", { description: e.message }),
   });
   const hasChatbots = chatbotCount > 0;
   const hasSources = sources.length > 0;

--- a/apps/web/src/components/chatbot/WebSourcesTab.tsx
+++ b/apps/web/src/components/chatbot/WebSourcesTab.tsx
@@ -11,6 +11,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { CrawlSourceCard } from "./web-sources/CrawlSourceCard";
 import {
   AddFullWebSourceDialog,
@@ -40,6 +49,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
   const [expandedSources, setExpandedSources] = useState<Set<string>>(
     new Set(),
   );
+  const [selectedSourceId, setSelectedSourceId] = useState("");
 
   const {
     data: sources,
@@ -53,6 +63,34 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     },
   );
   const utils = trpc.useUtils();
+
+  const { data: attachable } = trpc.crawler.getAttachableSources.useQuery({
+    chatbotId,
+  });
+
+  const attach = trpc.crawler.attachToChatbot.useMutation({
+    onSuccess: () => {
+      refetchSources();
+      utils.crawler.getAttachableSources.invalidate();
+      toast.success("Web source attached");
+    },
+    onError: (error) => {
+      toast.error("Failed to attach", { description: getFriendlyError(error) });
+    },
+  });
+
+  const detach = trpc.crawler.detachFromChatbot.useMutation({
+    onSuccess: () => {
+      refetchSources();
+      utils.crawler.getAttachableSources.invalidate();
+      toast.success("Removed from this chatbot");
+    },
+    onError: (error) => {
+      toast.error("Failed to remove", { description: getFriendlyError(error) });
+    },
+  });
+
+  const unattached = (attachable ?? []).filter((s) => !s.isAttached);
 
   const addCrawlSource = trpc.crawler.addCrawlSource.useMutation({
     onSuccess: () => {
@@ -80,18 +118,6 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     },
     onError: (error) => {
       toast.error("Failed to add URL", {
-        description: getFriendlyError(error),
-      });
-    },
-  });
-
-  const removeCrawlSource = trpc.crawler.removeCrawlSource.useMutation({
-    onSuccess: () => {
-      refetchSources();
-      toast.success("Web source removed");
-    },
-    onError: (error) => {
-      toast.error("Failed to remove source", {
         description: getFriendlyError(error),
       });
     },
@@ -204,6 +230,43 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
           onSubmit={handleAddManualUrl}
         />
 
+        {unattached.length > 0 && (
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="attach-existing">
+                Attach an existing web source
+              </Label>
+              <Select
+                value={selectedSourceId}
+                onValueChange={setSelectedSourceId}
+              >
+                <SelectTrigger id="attach-existing">
+                  <SelectValue placeholder="Choose a web source..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {unattached.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.rootUrl}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!selectedSourceId || attach.isPending}
+              onClick={() => {
+                if (!selectedSourceId) return;
+                attach.mutate({ crawlSourceId: selectedSourceId, chatbotId });
+                setSelectedSourceId("");
+              }}
+            >
+              Attach
+            </Button>
+          </div>
+        )}
+
         {sourcesLoading ? (
           <WebSourcesSkeleton />
         ) : !sources || sources.length === 0 ? (
@@ -218,7 +281,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
                 onToggleExpand={() => toggleExpanded(source.id)}
                 onRecrawl={() => recrawl.mutate({ crawlSourceId: source.id })}
                 onRemove={() =>
-                  removeCrawlSource.mutate({ crawlSourceId: source.id })
+                  detach.mutate({ crawlSourceId: source.id, chatbotId })
                 }
                 onToggleEnabled={(enabled) =>
                   toggleCrawlSource.mutate({
@@ -233,7 +296,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
                   })
                 }
                 isRecrawling={recrawl.isPending}
-                isRemoving={removeCrawlSource.isPending}
+                isRemoving={detach.isPending}
                 isTogglingEnabled={toggleCrawlSource.isPending}
                 isRenaming={renameCrawlSource.isPending}
               />

--- a/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
+++ b/apps/web/src/components/chatbot/web-sources/CrawlSourceCard.tsx
@@ -164,7 +164,6 @@ export function CrawlSourceCard({
             </div>
             <CrawlSourceActions
               source={source}
-              pageCount={pageCount}
               isActive={isActive}
               isRecrawling={isRecrawling}
               isRemoving={isRemoving}
@@ -192,7 +191,6 @@ export function CrawlSourceCard({
 
 function CrawlSourceActions({
   source,
-  pageCount,
   isActive,
   isRecrawling,
   isRemoving,
@@ -201,7 +199,6 @@ function CrawlSourceActions({
   onRemove,
 }: {
   source: CrawlSource;
-  pageCount: number;
   isActive: boolean;
   isRecrawling: boolean;
   isRemoving: boolean;
@@ -239,20 +236,16 @@ function CrawlSourceActions({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove Web Source</AlertDialogTitle>
+            <AlertDialogTitle>Remove from chatbot</AlertDialogTitle>
             <AlertDialogDescription>
-              This will remove the crawl source, all {pageCount} crawled page
-              {pageCount !== 1 ? "s" : ""}, and their embeddings. This action
-              cannot be undone.
+              Remove this web source from this chatbot? Its content stays
+              available to attach again.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={onRemove}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Remove
+            <AlertDialogAction onClick={onRemove}>
+              Remove from chatbot
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/components/dashboard/web-sources/AddWebSourcePanel.tsx
+++ b/apps/web/src/components/dashboard/web-sources/AddWebSourcePanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Bot } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { Label } from "@/components/ui/label";
@@ -29,12 +28,14 @@ import {
   parsePatternList,
 } from "@/components/chatbot/web-sources/utils";
 
+const NO_CHATBOT = "__none__";
+
 interface AddWebSourcePanelProps {
   chatbots: Array<{ id: string; name: string }>;
 }
 
 export function AddWebSourcePanel({ chatbots }: AddWebSourcePanelProps) {
-  const [chatbotId, setChatbotId] = useState(chatbots[0]?.id ?? "");
+  const [chatbotId, setChatbotId] = useState("");
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [rootUrl, setRootUrl] = useState("");
   const [crawlDepth, setCrawlDepth] = useState(3);
@@ -79,9 +80,8 @@ export function AddWebSourcePanel({ chatbots }: AddWebSourcePanelProps) {
   });
 
   const handleAddSource = () => {
-    if (!chatbotId) return;
     addCrawlSource.mutate({
-      chatbotId,
+      ...(chatbotId ? { chatbotId } : {}),
       rootUrl: normalizeUrl(rootUrl),
       crawlDepth,
       maxPages,
@@ -91,47 +91,42 @@ export function AddWebSourcePanel({ chatbots }: AddWebSourcePanelProps) {
   };
 
   const handleAddManualUrl = () => {
-    if (!chatbotId || !manualUrl) return;
-    addManualUrl.mutate({ chatbotId, url: normalizeUrl(manualUrl) });
+    if (!manualUrl) return;
+    addManualUrl.mutate({
+      ...(chatbotId ? { chatbotId } : {}),
+      url: normalizeUrl(manualUrl),
+    });
   };
-
-  const showChatbotSelect = chatbots.length > 1;
 
   return (
     <Card className="border border-border/60 bg-card shadow-xs">
       <CardHeader>
         <CardTitle className="text-lg">Add a web source</CardTitle>
         <CardDescription>
-          Crawl a full website or add a single webpage. Content is added to the
-          chatbot you choose, just like uploading a file.
+          Crawl a website or add a single page. Attach it to chatbots anytime,
+          just like uploading a file.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {showChatbotSelect ? (
-          <div className="space-y-2 sm:max-w-xs">
-            <Label htmlFor="chatbot-select">Add to chatbot</Label>
-            <Select value={chatbotId} onValueChange={setChatbotId}>
-              <SelectTrigger id="chatbot-select">
-                <SelectValue placeholder="Choose a chatbot" />
-              </SelectTrigger>
-              <SelectContent>
-                {chatbots.map((chatbot) => (
-                  <SelectItem key={chatbot.id} value={chatbot.id}>
-                    {chatbot.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        ) : (
-          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Bot className="h-3.5 w-3.5" />
-            Adding to{" "}
-            <span className="font-medium text-foreground">
-              {chatbots[0]?.name}
-            </span>
-          </p>
-        )}
+        <div className="space-y-2 sm:max-w-xs">
+          <Label htmlFor="chatbot-select">Add to chatbot (optional)</Label>
+          <Select
+            value={chatbotId || NO_CHATBOT}
+            onValueChange={(v) => setChatbotId(v === NO_CHATBOT ? "" : v)}
+          >
+            <SelectTrigger id="chatbot-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_CHATBOT}>No chatbot (add later)</SelectItem>
+              {chatbots.map((chatbot) => (
+                <SelectItem key={chatbot.id} value={chatbot.id}>
+                  {chatbot.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex-1">

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -5,7 +5,7 @@ import {
   userFiles,
   fileChunks,
   chatbotFileAssociations,
-  chatbots,
+  chatbotCrawlSourceAssociations,
 } from "@teachanything/db/schema";
 import { eq, inArray, sql } from "drizzle-orm";
 import {
@@ -297,16 +297,14 @@ export async function processCrawlPage(params: {
       return;
     }
 
-    const [chatbot] = await db
-      .select()
-      .from(chatbots)
-      .where(eq(chatbots.id, source.chatbotId))
-      .limit(1);
-
-    if (!chatbot) {
-      logInfo("Chatbot not found, skipping", { crawledPageId });
-      return;
-    }
+    // Chatbots this source is currently attached to. May be empty: the page
+    // is still crawled, embedded, and stored as a userFile, just not wired
+    // into any chatbot's RAG context until the source is attached.
+    const attachedChatbots = await db
+      .select({ chatbotId: chatbotCrawlSourceAssociations.chatbotId })
+      .from(chatbotCrawlSourceAssociations)
+      .where(eq(chatbotCrawlSourceAssociations.crawlSourceId, source.id));
+    const attachedChatbotIds = attachedChatbots.map((r) => r.chatbotId);
 
     if (!(await isUrlSafeWithDns(page.url))) {
       await db
@@ -395,7 +393,7 @@ export async function processCrawlPage(params: {
         const [file] = await tx
           .insert(userFiles)
           .values({
-            userId: chatbot.userId,
+            userId: source.userId,
             fileName: displayTitle,
             fileType: "text/html",
             fileSize: Buffer.byteLength(pageContent.content, "utf-8"),
@@ -407,13 +405,17 @@ export async function processCrawlPage(params: {
         if (!file) throw new Error("Failed to create user file");
         userFileId = file.id;
 
-        await tx
-          .insert(chatbotFileAssociations)
-          .values({
-            chatbotId: source.chatbotId,
-            fileId: userFileId,
-          })
-          .onConflictDoNothing();
+        if (attachedChatbotIds.length > 0) {
+          await tx
+            .insert(chatbotFileAssociations)
+            .values(
+              attachedChatbotIds.map((chatbotId) => ({
+                chatbotId,
+                fileId: userFileId as string,
+              })),
+            )
+            .onConflictDoNothing();
+        }
 
         await tx
           .update(crawledPages)

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -297,15 +297,6 @@ export async function processCrawlPage(params: {
       return;
     }
 
-    // Chatbots this source is currently attached to. May be empty: the page
-    // is still crawled, embedded, and stored as a userFile, just not wired
-    // into any chatbot's RAG context until the source is attached.
-    const attachedChatbots = await db
-      .select({ chatbotId: chatbotCrawlSourceAssociations.chatbotId })
-      .from(chatbotCrawlSourceAssociations)
-      .where(eq(chatbotCrawlSourceAssociations.crawlSourceId, source.id));
-    const attachedChatbotIds = attachedChatbots.map((r) => r.chatbotId);
-
     if (!(await isUrlSafeWithDns(page.url))) {
       await db
         .update(crawledPages)
@@ -421,15 +412,20 @@ export async function processCrawlPage(params: {
       }
 
       // Sync file associations to every chatbot the source is currently
-      // attached to. Runs for both new and re-crawled pages (idempotent via
-      // onConflictDoNothing) so a re-crawl self-heals any association gap --
-      // e.g. a chatbot attached while this page was mid-crawl.
-      if (attachedChatbotIds.length > 0) {
+      // attached to. Read attachments INSIDE the transaction so we reflect the
+      // freshest committed attach/detach state, and run for both new and
+      // re-crawled pages (idempotent via onConflictDoNothing) so a re-crawl
+      // self-heals any association gap from an attach during this crawl.
+      const attachedChatbots = await tx
+        .select({ chatbotId: chatbotCrawlSourceAssociations.chatbotId })
+        .from(chatbotCrawlSourceAssociations)
+        .where(eq(chatbotCrawlSourceAssociations.crawlSourceId, source.id));
+      if (attachedChatbots.length > 0) {
         await tx
           .insert(chatbotFileAssociations)
           .values(
-            attachedChatbotIds.map((chatbotId) => ({
-              chatbotId,
+            attachedChatbots.map((r) => ({
+              chatbotId: r.chatbotId,
               fileId: userFileId as string,
             })),
           )

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -405,18 +405,6 @@ export async function processCrawlPage(params: {
         if (!file) throw new Error("Failed to create user file");
         userFileId = file.id;
 
-        if (attachedChatbotIds.length > 0) {
-          await tx
-            .insert(chatbotFileAssociations)
-            .values(
-              attachedChatbotIds.map((chatbotId) => ({
-                chatbotId,
-                fileId: userFileId as string,
-              })),
-            )
-            .onConflictDoNothing();
-        }
-
         await tx
           .update(crawledPages)
           .set({ userFileId })
@@ -430,6 +418,22 @@ export async function processCrawlPage(params: {
             processingStatus: "processing",
           })
           .where(eq(userFiles.id, userFileId));
+      }
+
+      // Sync file associations to every chatbot the source is currently
+      // attached to. Runs for both new and re-crawled pages (idempotent via
+      // onConflictDoNothing) so a re-crawl self-heals any association gap --
+      // e.g. a chatbot attached while this page was mid-crawl.
+      if (attachedChatbotIds.length > 0) {
+        await tx
+          .insert(chatbotFileAssociations)
+          .values(
+            attachedChatbotIds.map((chatbotId) => ({
+              chatbotId,
+              fileId: userFileId as string,
+            })),
+          )
+          .onConflictDoNothing();
       }
 
       // Delete old chunks before inserting new ones (atomic within transaction)

--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -2,6 +2,7 @@ import { eq, and, sql, inArray, isNotNull } from "drizzle-orm";
 import {
   fileChunks,
   chatbotFileAssociations,
+  chatbotCrawlSourceAssociations,
   userFiles,
   crawledPages,
   crawlSources,
@@ -76,11 +77,18 @@ export async function buildRAGContext(
   if (fileIds.length > 0) {
     const disabledCrawledFiles = await params.db
       .select({ userFileId: crawledPages.userFileId })
-      .from(crawlSources)
-      .innerJoin(crawledPages, eq(crawledPages.crawlSourceId, crawlSources.id))
+      .from(chatbotCrawlSourceAssociations)
+      .innerJoin(
+        crawlSources,
+        eq(crawlSources.id, chatbotCrawlSourceAssociations.crawlSourceId),
+      )
+      .innerJoin(
+        crawledPages,
+        eq(crawledPages.crawlSourceId, crawlSources.id),
+      )
       .where(
         and(
-          eq(crawlSources.chatbotId, params.chatbotId),
+          eq(chatbotCrawlSourceAssociations.chatbotId, params.chatbotId),
           eq(crawlSources.enabled, false),
           isNotNull(crawledPages.userFileId),
         ),

--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -82,10 +82,7 @@ export async function buildRAGContext(
         crawlSources,
         eq(crawlSources.id, chatbotCrawlSourceAssociations.crawlSourceId),
       )
-      .innerJoin(
-        crawledPages,
-        eq(crawledPages.crawlSourceId, crawlSources.id),
-      )
+      .innerJoin(crawledPages, eq(crawledPages.crawlSourceId, crawlSources.id))
       .where(
         and(
           eq(chatbotCrawlSourceAssociations.chatbotId, params.chatbotId),

--- a/apps/web/src/server/routers/crawler/helpers.ts
+++ b/apps/web/src/server/routers/crawler/helpers.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, sql } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import {
   chatbots,
@@ -101,45 +101,6 @@ export async function assertOwnedChatbot(
   }
 
   return chatbot;
-}
-
-/**
- * Delete chatbot-scoped crawler userFiles safely.
- *
- * Removes this chatbot's associations to the given fileIds and deletes any
- * resulting orphans (userFiles with no remaining associations). Does NOT
- * delete files that are still linked to other chatbots.
- *
- * Must be run inside a transaction (pass the tx handle).
- */
-export async function deleteCrawlFileIds(
-  tx: Parameters<Parameters<typeof dbType.transaction>[0]>[0],
-  chatbotId: string,
-  fileIds: string[],
-): Promise<void> {
-  if (fileIds.length === 0) return;
-
-  // Step 1: remove this chatbot's associations to the target files.
-  await tx
-    .delete(chatbotFileAssociations)
-    .where(
-      and(
-        eq(chatbotFileAssociations.chatbotId, chatbotId),
-        inArray(chatbotFileAssociations.fileId, fileIds),
-      ),
-    );
-
-  // Step 2: delete userFiles that are now fully orphaned (no remaining
-  // associations to any chatbot). Uses NOT EXISTS in one round-trip
-  // instead of a SELECT + client-side diff + DELETE.
-  await tx
-    .delete(userFiles)
-    .where(
-      and(
-        inArray(userFiles.id, fileIds),
-        sql`NOT EXISTS (SELECT 1 FROM ${chatbotFileAssociations} WHERE ${chatbotFileAssociations.fileId} = ${userFiles.id})`,
-      ),
-    );
 }
 
 /**

--- a/apps/web/src/server/routers/crawler/helpers.ts
+++ b/apps/web/src/server/routers/crawler/helpers.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and, inArray, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import {
   chatbots,
@@ -130,18 +130,16 @@ export async function deleteCrawlFileIds(
     );
 
   // Step 2: delete userFiles that are now fully orphaned (no remaining
-  // associations to any chatbot).
-  const remaining = await tx
-    .select({ fileId: chatbotFileAssociations.fileId })
-    .from(chatbotFileAssociations)
-    .where(inArray(chatbotFileAssociations.fileId, fileIds));
-
-  const stillLinked = new Set(remaining.map((r) => r.fileId));
-  const toDelete = fileIds.filter((id) => !stillLinked.has(id));
-
-  if (toDelete.length > 0) {
-    await tx.delete(userFiles).where(inArray(userFiles.id, toDelete));
-  }
+  // associations to any chatbot). Uses NOT EXISTS in one round-trip
+  // instead of a SELECT + client-side diff + DELETE.
+  await tx
+    .delete(userFiles)
+    .where(
+      and(
+        inArray(userFiles.id, fileIds),
+        sql`NOT EXISTS (SELECT 1 FROM ${chatbotFileAssociations} WHERE ${chatbotFileAssociations.fileId} = ${userFiles.id})`,
+      ),
+    );
 }
 
 /**

--- a/apps/web/src/server/routers/crawler/helpers.ts
+++ b/apps/web/src/server/routers/crawler/helpers.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, sql } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import {
   chatbots,
@@ -16,39 +16,38 @@ import type { Context } from "@/server/trpc";
 type AuthedContext = Context & { session: { user: { id: string } } };
 
 /**
- * Fetch a crawl source and verify the caller owns its parent chatbot.
- * Single query (source JOIN chatbot) instead of two sequential selects.
+ * Fetch a crawl source and verify the caller owns it via userId.
  * Throws NOT_FOUND if the source doesn't exist or the user doesn't own it.
  */
 export async function assertOwnedCrawlSource(
   ctx: AuthedContext,
   crawlSourceId: string,
 ): Promise<typeof crawlSources.$inferSelect> {
-  const [row] = await ctx.db
-    .select({ source: crawlSources })
+  const [source] = await ctx.db
+    .select()
     .from(crawlSources)
-    .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
     .where(
       and(
         eq(crawlSources.id, crawlSourceId),
-        eq(chatbots.userId, ctx.session.user.id),
+        eq(crawlSources.userId, ctx.session.user.id),
       ),
     )
     .limit(1);
 
-  if (!row) {
+  if (!source) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Crawl source not found",
     });
   }
 
-  return row.source;
+  return source;
 }
 
 /**
- * Same as above but for a specific crawled page: verifies the caller owns
- * the chatbot that owns the parent crawl source.
+ * Fetch a crawled page and verify the caller owns the parent crawl source
+ * via userId (crawledPages -> crawlSources.userId).
+ * Throws NOT_FOUND if the page doesn't exist or the user doesn't own it.
  */
 export async function assertOwnedCrawledPage(
   ctx: AuthedContext,
@@ -61,11 +60,10 @@ export async function assertOwnedCrawledPage(
     .select({ page: crawledPages, source: crawlSources })
     .from(crawledPages)
     .innerJoin(crawlSources, eq(crawlSources.id, crawledPages.crawlSourceId))
-    .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
     .where(
       and(
         eq(crawledPages.id, crawledPageId),
-        eq(chatbots.userId, ctx.session.user.id),
+        eq(crawlSources.userId, ctx.session.user.id),
       ),
     )
     .limit(1);
@@ -132,14 +130,38 @@ export async function deleteCrawlFileIds(
     );
 
   // Step 2: delete userFiles that are now fully orphaned (no remaining
-  // associations to any chatbot). Uses NOT EXISTS in one round-trip
-  // instead of a SELECT + client-side diff + DELETE.
+  // associations to any chatbot).
+  const remaining = await tx
+    .select({ fileId: chatbotFileAssociations.fileId })
+    .from(chatbotFileAssociations)
+    .where(inArray(chatbotFileAssociations.fileId, fileIds));
+
+  const stillLinked = new Set(remaining.map((r) => r.fileId));
+  const toDelete = fileIds.filter((id) => !stillLinked.has(id));
+
+  if (toDelete.length > 0) {
+    await tx.delete(userFiles).where(inArray(userFiles.id, toDelete));
+  }
+}
+
+/**
+ * Delete crawler userFiles regardless of which chatbots they're attached to.
+ * Removes ALL associations for the given fileIds, then deletes the userFiles
+ * (they are exclusively owned by crawled pages). Use when removing a whole
+ * crawl source or an individual page, where the page should disappear from
+ * every chatbot it was attached to.
+ *
+ * Must be run inside a transaction (pass the tx handle).
+ */
+export async function deleteAllCrawlFileIds(
+  tx: Parameters<Parameters<typeof dbType.transaction>[0]>[0],
+  fileIds: string[],
+): Promise<void> {
+  if (fileIds.length === 0) return;
+
   await tx
-    .delete(userFiles)
-    .where(
-      and(
-        inArray(userFiles.id, fileIds),
-        sql`NOT EXISTS (SELECT 1 FROM ${chatbotFileAssociations} WHERE ${chatbotFileAssociations.fileId} = ${userFiles.id})`,
-      ),
-    );
+    .delete(chatbotFileAssociations)
+    .where(inArray(chatbotFileAssociations.fileId, fileIds));
+
+  await tx.delete(userFiles).where(inArray(userFiles.id, fileIds));
 }

--- a/apps/web/src/server/routers/crawler/index.ts
+++ b/apps/web/src/server/routers/crawler/index.ts
@@ -11,6 +11,9 @@ import { toggleCrawlSourceProcedure } from "./procedures/toggle-crawl-source";
 import { renameCrawlSourceProcedure } from "./procedures/rename-crawl-source";
 import { renameCrawledPageProcedure } from "./procedures/rename-crawled-page";
 import { getAllCrawlSourcesProcedure } from "./procedures/get-all-crawl-sources";
+import { attachToChatbotProcedure } from "./procedures/attach-to-chatbot";
+import { detachFromChatbotProcedure } from "./procedures/detach-from-chatbot";
+import { getAttachableSourcesProcedure } from "./procedures/get-attachable-sources";
 
 export const crawlerRouter = router({
   addCrawlSource: addCrawlSourceProcedure,
@@ -25,4 +28,7 @@ export const crawlerRouter = router({
   recrawl: recrawlProcedure,
   exportJson: exportJsonProcedure,
   toggleCrawlSource: toggleCrawlSourceProcedure,
+  attachToChatbot: attachToChatbotProcedure,
+  detachFromChatbot: detachFromChatbotProcedure,
+  getAttachableSources: getAttachableSourcesProcedure,
 });

--- a/apps/web/src/server/routers/crawler/procedures/add-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/add-crawl-source.ts
@@ -1,31 +1,21 @@
 import { protectedProcedure } from "@/server/trpc";
 import { eq, and } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { chatbots, crawlSources } from "@teachanything/db/schema";
+import {
+  crawlSources,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
 import { verifyUrlReachable } from "@teachanything/ai/crawler";
 import { dispatchCrawlJob, processCrawlDiscovery } from "@/lib/crawl-processor";
 import { checkRateLimit, crawlSourceRateLimit } from "@/lib/rate-limit";
+import { assertOwnedChatbot } from "../helpers";
 import { crawlSourceInput } from "../validation";
 
 export const addCrawlSourceProcedure = protectedProcedure
   .input(crawlSourceInput)
   .mutation(async ({ ctx, input }) => {
-    const [chatbot] = await ctx.db
-      .select()
-      .from(chatbots)
-      .where(
-        and(
-          eq(chatbots.id, input.chatbotId),
-          eq(chatbots.userId, ctx.session.user.id),
-        ),
-      )
-      .limit(1);
-
-    if (!chatbot) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Chatbot not found",
-      });
+    if (input.chatbotId) {
+      await assertOwnedChatbot(ctx, input.chatbotId);
     }
 
     const { success } = await checkRateLimit(
@@ -57,7 +47,7 @@ export const addCrawlSourceProcedure = protectedProcedure
       .from(crawlSources)
       .where(
         and(
-          eq(crawlSources.chatbotId, input.chatbotId),
+          eq(crawlSources.userId, ctx.session.user.id),
           eq(crawlSources.rootUrl, input.rootUrl),
         ),
       )
@@ -66,30 +56,41 @@ export const addCrawlSourceProcedure = protectedProcedure
     if (existing) {
       throw new TRPCError({
         code: "CONFLICT",
-        message: "A crawl source with this URL already exists for this chatbot",
+        message: "You've already added this URL as a web source",
       });
     }
 
-    const [source] = await ctx.db
-      .insert(crawlSources)
-      .values({
-        chatbotId: input.chatbotId,
-        rootUrl: input.rootUrl,
-        crawlDepth: input.crawlDepth,
-        maxPages: input.maxPages,
-        includePatterns: input.includePatterns,
-        excludePatterns: input.excludePatterns,
-        status: "pending",
-        metadata: {},
-      })
-      .returning();
+    const source = await ctx.db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(crawlSources)
+        .values({
+          userId: ctx.session.user.id,
+          rootUrl: input.rootUrl,
+          crawlDepth: input.crawlDepth,
+          maxPages: input.maxPages,
+          includePatterns: input.includePatterns,
+          excludePatterns: input.excludePatterns,
+          status: "pending",
+          metadata: {},
+        })
+        .returning();
 
-    if (!source) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to create crawl source",
-      });
-    }
+      if (!created) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create crawl source",
+        });
+      }
+
+      if (input.chatbotId) {
+        await tx
+          .insert(chatbotCrawlSourceAssociations)
+          .values({ chatbotId: input.chatbotId, crawlSourceId: created.id })
+          .onConflictDoNothing();
+      }
+
+      return created;
+    });
 
     await dispatchCrawlJob({
       jobPath: "/api/jobs/crawl-discover",

--- a/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
+++ b/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
@@ -90,7 +90,10 @@ export const addManualUrlProcedure = protectedProcedure
       if (input.chatbotId) {
         await tx
           .insert(chatbotCrawlSourceAssociations)
-          .values({ chatbotId: input.chatbotId, crawlSourceId: createdSource.id })
+          .values({
+            chatbotId: input.chatbotId,
+            crawlSourceId: createdSource.id,
+          })
           .onConflictDoNothing();
       }
 

--- a/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
+++ b/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
@@ -1,7 +1,11 @@
 import { protectedProcedure } from "@/server/trpc";
 import { eq, and } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { chatbots, crawlSources, crawledPages } from "@teachanything/db/schema";
+import {
+  crawlSources,
+  crawledPages,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
 import { verifyUrlReachable } from "@teachanything/ai/crawler";
 import {
   dispatchCrawlJob,
@@ -9,27 +13,14 @@ import {
   finalizeCrawlSource,
 } from "@/lib/crawl-processor";
 import { checkRateLimit, manualUrlRateLimit } from "@/lib/rate-limit";
+import { assertOwnedChatbot } from "../helpers";
 import { manualUrlInput } from "../validation";
 
 export const addManualUrlProcedure = protectedProcedure
   .input(manualUrlInput)
   .mutation(async ({ ctx, input }) => {
-    const [chatbot] = await ctx.db
-      .select()
-      .from(chatbots)
-      .where(
-        and(
-          eq(chatbots.id, input.chatbotId),
-          eq(chatbots.userId, ctx.session.user.id),
-        ),
-      )
-      .limit(1);
-
-    if (!chatbot) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Chatbot not found",
-      });
+    if (input.chatbotId) {
+      await assertOwnedChatbot(ctx, input.chatbotId);
     }
 
     const { success } = await checkRateLimit(
@@ -49,7 +40,7 @@ export const addManualUrlProcedure = protectedProcedure
       .from(crawlSources)
       .where(
         and(
-          eq(crawlSources.chatbotId, input.chatbotId),
+          eq(crawlSources.userId, ctx.session.user.id),
           eq(crawlSources.rootUrl, input.url),
         ),
       )
@@ -58,7 +49,7 @@ export const addManualUrlProcedure = protectedProcedure
     if (existingSource) {
       throw new TRPCError({
         code: "CONFLICT",
-        message: "This URL has already been added to this chatbot",
+        message: "You've already added this URL as a web source",
       });
     }
 
@@ -74,44 +65,55 @@ export const addManualUrlProcedure = protectedProcedure
       });
     }
 
-    const [source] = await ctx.db
-      .insert(crawlSources)
-      .values({
-        chatbotId: input.chatbotId,
-        rootUrl: input.url,
-        crawlDepth: 0,
-        maxPages: 1,
-        includePatterns: [],
-        excludePatterns: [],
-        status: "crawling",
-        metadata: {},
-      })
-      .returning();
+    const { source, page } = await ctx.db.transaction(async (tx) => {
+      const [createdSource] = await tx
+        .insert(crawlSources)
+        .values({
+          userId: ctx.session.user.id,
+          rootUrl: input.url,
+          crawlDepth: 0,
+          maxPages: 1,
+          includePatterns: [],
+          excludePatterns: [],
+          status: "crawling",
+          metadata: {},
+        })
+        .returning();
 
-    if (!source) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to create crawl source",
-      });
-    }
+      if (!createdSource) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create crawl source",
+        });
+      }
 
-    const [page] = await ctx.db
-      .insert(crawledPages)
-      .values({
-        crawlSourceId: source.id,
-        url: input.url,
-        depth: 0,
-        status: "pending",
-        metadata: {},
-      })
-      .returning();
+      if (input.chatbotId) {
+        await tx
+          .insert(chatbotCrawlSourceAssociations)
+          .values({ chatbotId: input.chatbotId, crawlSourceId: createdSource.id })
+          .onConflictDoNothing();
+      }
 
-    if (!page) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to create crawled page record",
-      });
-    }
+      const [createdPage] = await tx
+        .insert(crawledPages)
+        .values({
+          crawlSourceId: createdSource.id,
+          url: input.url,
+          depth: 0,
+          status: "pending",
+          metadata: {},
+        })
+        .returning();
+
+      if (!createdPage) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create crawled page record",
+        });
+      }
+
+      return { source: createdSource, page: createdPage };
+    });
 
     await dispatchCrawlJob({
       jobPath: "/api/jobs/crawl-process-page",

--- a/apps/web/src/server/routers/crawler/procedures/attach-to-chatbot.ts
+++ b/apps/web/src/server/routers/crawler/procedures/attach-to-chatbot.ts
@@ -1,0 +1,64 @@
+import { protectedProcedure } from "@/server/trpc";
+import { z } from "zod";
+import { eq, and, isNotNull } from "drizzle-orm";
+import {
+  crawledPages,
+  chatbotFileAssociations,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
+import { assertOwnedCrawlSource, assertOwnedChatbot } from "../helpers";
+import { logInfo } from "@/lib/logger";
+
+export const attachToChatbotProcedure = protectedProcedure
+  .input(
+    z.object({
+      crawlSourceId: z.string().uuid(),
+      chatbotId: z.string().uuid(),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    await assertOwnedCrawlSource(ctx, input.crawlSourceId);
+    await assertOwnedChatbot(ctx, input.chatbotId);
+
+    await ctx.db.transaction(async (tx) => {
+      await tx
+        .insert(chatbotCrawlSourceAssociations)
+        .values({
+          chatbotId: input.chatbotId,
+          crawlSourceId: input.crawlSourceId,
+        })
+        .onConflictDoNothing();
+
+      // Backfill file associations for every already-crawled page of this
+      // source so the chatbot's RAG context picks them up immediately.
+      const pages = await tx
+        .select({ userFileId: crawledPages.userFileId })
+        .from(crawledPages)
+        .where(
+          and(
+            eq(crawledPages.crawlSourceId, input.crawlSourceId),
+            isNotNull(crawledPages.userFileId),
+          ),
+        );
+
+      const fileIds = pages
+        .map((p) => p.userFileId)
+        .filter((id): id is string => id !== null);
+
+      if (fileIds.length > 0) {
+        await tx
+          .insert(chatbotFileAssociations)
+          .values(
+            fileIds.map((fileId) => ({ chatbotId: input.chatbotId, fileId })),
+          )
+          .onConflictDoNothing();
+      }
+    });
+
+    logInfo("Web source attached to chatbot", {
+      crawlSourceId: input.crawlSourceId,
+      chatbotId: input.chatbotId,
+    });
+
+    return { success: true };
+  });

--- a/apps/web/src/server/routers/crawler/procedures/detach-from-chatbot.ts
+++ b/apps/web/src/server/routers/crawler/procedures/detach-from-chatbot.ts
@@ -1,0 +1,62 @@
+import { protectedProcedure } from "@/server/trpc";
+import { z } from "zod";
+import { eq, and, isNotNull } from "drizzle-orm";
+import {
+  crawledPages,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
+import {
+  assertOwnedCrawlSource,
+  assertOwnedChatbot,
+  deleteCrawlFileIds,
+} from "../helpers";
+import { logInfo } from "@/lib/logger";
+
+export const detachFromChatbotProcedure = protectedProcedure
+  .input(
+    z.object({
+      crawlSourceId: z.string().uuid(),
+      chatbotId: z.string().uuid(),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    await assertOwnedCrawlSource(ctx, input.crawlSourceId);
+    await assertOwnedChatbot(ctx, input.chatbotId);
+
+    await ctx.db.transaction(async (tx) => {
+      await tx
+        .delete(chatbotCrawlSourceAssociations)
+        .where(
+          and(
+            eq(
+              chatbotCrawlSourceAssociations.crawlSourceId,
+              input.crawlSourceId,
+            ),
+            eq(chatbotCrawlSourceAssociations.chatbotId, input.chatbotId),
+          ),
+        );
+
+      const pages = await tx
+        .select({ userFileId: crawledPages.userFileId })
+        .from(crawledPages)
+        .where(
+          and(
+            eq(crawledPages.crawlSourceId, input.crawlSourceId),
+            isNotNull(crawledPages.userFileId),
+          ),
+        );
+
+      const fileIds = pages
+        .map((p) => p.userFileId)
+        .filter((id): id is string => id !== null);
+
+      await deleteCrawlFileIds(tx, input.chatbotId, fileIds);
+    });
+
+    logInfo("Web source detached from chatbot", {
+      crawlSourceId: input.crawlSourceId,
+      chatbotId: input.chatbotId,
+    });
+
+    return { success: true };
+  });

--- a/apps/web/src/server/routers/crawler/procedures/detach-from-chatbot.ts
+++ b/apps/web/src/server/routers/crawler/procedures/detach-from-chatbot.ts
@@ -1,15 +1,12 @@
 import { protectedProcedure } from "@/server/trpc";
 import { z } from "zod";
-import { eq, and, isNotNull } from "drizzle-orm";
+import { eq, and, inArray, isNotNull } from "drizzle-orm";
 import {
   crawledPages,
+  chatbotFileAssociations,
   chatbotCrawlSourceAssociations,
 } from "@teachanything/db/schema";
-import {
-  assertOwnedCrawlSource,
-  assertOwnedChatbot,
-  deleteCrawlFileIds,
-} from "../helpers";
+import { assertOwnedCrawlSource, assertOwnedChatbot } from "../helpers";
 import { logInfo } from "@/lib/logger";
 
 export const detachFromChatbotProcedure = protectedProcedure
@@ -50,7 +47,21 @@ export const detachFromChatbotProcedure = protectedProcedure
         .map((p) => p.userFileId)
         .filter((id): id is string => id !== null);
 
-      await deleteCrawlFileIds(tx, input.chatbotId, fileIds);
+      // Remove ONLY this chatbot's associations to the source's crawled
+      // files. The userFiles/chunks/pages are intentionally left intact so
+      // the source can be re-attached later without re-crawling or
+      // re-embedding. (Crawled files are deleted only when the source itself
+      // is removed.)
+      if (fileIds.length > 0) {
+        await tx
+          .delete(chatbotFileAssociations)
+          .where(
+            and(
+              eq(chatbotFileAssociations.chatbotId, input.chatbotId),
+              inArray(chatbotFileAssociations.fileId, fileIds),
+            ),
+          );
+      }
     });
 
     logInfo("Web source detached from chatbot", {

--- a/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
@@ -1,6 +1,11 @@
 import { protectedProcedure } from "@/server/trpc";
 import { eq, inArray, sql, desc } from "drizzle-orm";
-import { chatbots, crawlSources, crawledPages } from "@teachanything/db/schema";
+import {
+  chatbots,
+  crawlSources,
+  crawledPages,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
 import { allCrawlSourcesInput } from "../validation";
 
 export const getAllCrawlSourcesProcedure = protectedProcedure
@@ -9,15 +14,12 @@ export const getAllCrawlSourcesProcedure = protectedProcedure
     const [totalCountResult] = await ctx.db
       .select({ count: sql<number>`count(*)` })
       .from(crawlSources)
-      .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
-      .where(eq(chatbots.userId, ctx.session.user.id));
+      .where(eq(crawlSources.userId, ctx.session.user.id));
     const totalCount = Number(totalCountResult?.count ?? 0);
 
     const sources = await ctx.db
       .select({
         id: crawlSources.id,
-        chatbotId: crawlSources.chatbotId,
-        chatbotName: chatbots.name,
         rootUrl: crawlSources.rootUrl,
         status: crawlSources.status,
         enabled: crawlSources.enabled,
@@ -26,8 +28,7 @@ export const getAllCrawlSourcesProcedure = protectedProcedure
         createdAt: crawlSources.createdAt,
       })
       .from(crawlSources)
-      .innerJoin(chatbots, eq(chatbots.id, crawlSources.chatbotId))
-      .where(eq(chatbots.userId, ctx.session.user.id))
+      .where(eq(crawlSources.userId, ctx.session.user.id))
       .orderBy(desc(crawlSources.createdAt), desc(crawlSources.id))
       .limit(input.limit)
       .offset(input.offset);
@@ -35,6 +36,7 @@ export const getAllCrawlSourcesProcedure = protectedProcedure
     if (sources.length === 0) return { sources: [], totalCount };
 
     const sourceIds = sources.map((source) => source.id);
+
     const pageCounts = await ctx.db
       .select({
         crawlSourceId: crawledPages.crawlSourceId,
@@ -48,10 +50,32 @@ export const getAllCrawlSourcesProcedure = protectedProcedure
       pageCounts.map((row) => [row.crawlSourceId, Number(row.count)]),
     );
 
+    // Attached chatbots per source (array; may be empty = "Not attached").
+    const attachments = await ctx.db
+      .select({
+        crawlSourceId: chatbotCrawlSourceAssociations.crawlSourceId,
+        chatbotId: chatbots.id,
+        chatbotName: chatbots.name,
+      })
+      .from(chatbotCrawlSourceAssociations)
+      .innerJoin(
+        chatbots,
+        eq(chatbots.id, chatbotCrawlSourceAssociations.chatbotId),
+      )
+      .where(inArray(chatbotCrawlSourceAssociations.crawlSourceId, sourceIds));
+
+    const attachMap = new Map<string, { id: string; name: string }[]>();
+    for (const row of attachments) {
+      const list = attachMap.get(row.crawlSourceId) ?? [];
+      list.push({ id: row.chatbotId, name: row.chatbotName });
+      attachMap.set(row.crawlSourceId, list);
+    }
+
     return {
       sources: sources.map((source) => ({
         ...source,
         pageCount: countMap.get(source.id) ?? 0,
+        chatbots: attachMap.get(source.id) ?? [],
       })),
       totalCount,
     };

--- a/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
@@ -1,0 +1,37 @@
+import { protectedProcedure } from "@/server/trpc";
+import { z } from "zod";
+import { eq, sql, desc } from "drizzle-orm";
+import {
+  crawlSources,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
+import { assertOwnedChatbot } from "../helpers";
+
+// Lists the caller's web sources with a flag for whether each is already
+// attached to the given chatbot. Powers the "Attach existing web source"
+// picker on a chatbot's Web Sources tab.
+export const getAttachableSourcesProcedure = protectedProcedure
+  .input(z.object({ chatbotId: z.string().uuid() }))
+  .query(async ({ ctx, input }) => {
+    await assertOwnedChatbot(ctx, input.chatbotId);
+
+    const attachedExpr = sql<boolean>`EXISTS (
+      SELECT 1 FROM ${chatbotCrawlSourceAssociations}
+      WHERE ${chatbotCrawlSourceAssociations.crawlSourceId} = ${crawlSources.id}
+        AND ${chatbotCrawlSourceAssociations.chatbotId} = ${input.chatbotId}
+    )`;
+
+    const rows = await ctx.db
+      .select({
+        id: crawlSources.id,
+        rootUrl: crawlSources.rootUrl,
+        status: crawlSources.status,
+        createdAt: crawlSources.createdAt,
+        isAttached: attachedExpr,
+      })
+      .from(crawlSources)
+      .where(eq(crawlSources.userId, ctx.session.user.id))
+      .orderBy(desc(crawlSources.createdAt), desc(crawlSources.id));
+
+    return rows;
+  });

--- a/apps/web/src/server/routers/crawler/procedures/get-crawl-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-crawl-sources.ts
@@ -2,7 +2,12 @@ import { protectedProcedure } from "@/server/trpc";
 import { z } from "zod";
 import { eq, and, sql, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { chatbots, crawlSources, crawledPages } from "@teachanything/db/schema";
+import {
+  chatbots,
+  crawlSources,
+  crawledPages,
+  chatbotCrawlSourceAssociations,
+} from "@teachanything/db/schema";
 
 export const getCrawlSourcesProcedure = protectedProcedure
   .input(z.object({ chatbotId: z.string().uuid() }))
@@ -26,9 +31,27 @@ export const getCrawlSourcesProcedure = protectedProcedure
     }
 
     const sources = await ctx.db
-      .select()
-      .from(crawlSources)
-      .where(eq(crawlSources.chatbotId, input.chatbotId));
+      .select({
+        id: crawlSources.id,
+        userId: crawlSources.userId,
+        rootUrl: crawlSources.rootUrl,
+        status: crawlSources.status,
+        enabled: crawlSources.enabled,
+        crawlDepth: crawlSources.crawlDepth,
+        maxPages: crawlSources.maxPages,
+        includePatterns: crawlSources.includePatterns,
+        excludePatterns: crawlSources.excludePatterns,
+        lastCrawledAt: crawlSources.lastCrawledAt,
+        metadata: crawlSources.metadata,
+        createdAt: crawlSources.createdAt,
+        updatedAt: crawlSources.updatedAt,
+      })
+      .from(chatbotCrawlSourceAssociations)
+      .innerJoin(
+        crawlSources,
+        eq(crawlSources.id, chatbotCrawlSourceAssociations.crawlSourceId),
+      )
+      .where(eq(chatbotCrawlSourceAssociations.chatbotId, input.chatbotId));
 
     if (sources.length === 0) return [];
 

--- a/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
@@ -4,7 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { crawlSources, crawledPages } from "@teachanything/db/schema";
 import { logInfo, logError } from "@/lib/logger";
 import { crawlSourceIdInput } from "../validation";
-import { assertOwnedCrawlSource, deleteCrawlFileIds } from "../helpers";
+import { assertOwnedCrawlSource, deleteAllCrawlFileIds } from "../helpers";
 
 export const removeCrawlSourceProcedure = protectedProcedure
   .input(crawlSourceIdInput)
@@ -45,7 +45,7 @@ export const removeCrawlSourceProcedure = protectedProcedure
           ),
         ];
 
-        await deleteCrawlFileIds(tx, source.chatbotId, fileIds);
+        await deleteAllCrawlFileIds(tx, fileIds);
 
         await tx
           .delete(crawlSources)
@@ -53,8 +53,7 @@ export const removeCrawlSourceProcedure = protectedProcedure
       });
 
       logInfo("Crawl source removed", {
-        crawlSourceId: input.crawlSourceId,
-        chatbotId: source.chatbotId,
+        crawlSourceId: source.id,
       });
 
       return { success: true };

--- a/apps/web/src/server/routers/crawler/procedures/remove-crawled-page.ts
+++ b/apps/web/src/server/routers/crawler/procedures/remove-crawled-page.ts
@@ -4,7 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { crawledPages } from "@teachanything/db/schema";
 import { logInfo, logError } from "@/lib/logger";
 import { crawledPageIdInput } from "../validation";
-import { assertOwnedCrawledPage, deleteCrawlFileIds } from "../helpers";
+import { assertOwnedCrawledPage, deleteAllCrawlFileIds } from "../helpers";
 
 export const removeCrawledPageProcedure = protectedProcedure
   .input(crawledPageIdInput)
@@ -44,7 +44,7 @@ export const removeCrawledPageProcedure = protectedProcedure
         if (fresh.userFileId) {
           // Use the shared orphan-aware helper so a userFile shared with
           // another chatbot isn't deleted out from under it.
-          await deleteCrawlFileIds(tx, source.chatbotId, [fresh.userFileId]);
+          await deleteAllCrawlFileIds(tx, [fresh.userFileId]);
         }
 
         await tx

--- a/apps/web/src/server/routers/crawler/procedures/remove-crawled-page.ts
+++ b/apps/web/src/server/routers/crawler/procedures/remove-crawled-page.ts
@@ -42,8 +42,9 @@ export const removeCrawledPageProcedure = protectedProcedure
         if (!fresh) return; // already deleted concurrently
 
         if (fresh.userFileId) {
-          // Use the shared orphan-aware helper so a userFile shared with
-          // another chatbot isn't deleted out from under it.
+          // A crawled page owns its userFile 1:1, so deleting the page means
+          // deleting that file everywhere: remove its associations across all
+          // chatbots, then the userFile itself.
           await deleteAllCrawlFileIds(tx, [fresh.userFileId]);
         }
 

--- a/apps/web/src/server/routers/crawler/validation.ts
+++ b/apps/web/src/server/routers/crawler/validation.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const crawlSourceInput = z.object({
-  chatbotId: z.string().uuid(),
+  chatbotId: z.string().uuid().optional(),
   rootUrl: z.string().url(),
   crawlDepth: z.number().int().min(1).max(5).default(3),
   maxPages: z.number().int().min(1).max(500).default(100),
@@ -26,7 +26,7 @@ export const crawlSourceInput = z.object({
 });
 
 export const manualUrlInput = z.object({
-  chatbotId: z.string().uuid(),
+  chatbotId: z.string().uuid().optional(),
   url: z.string().url(),
 });
 

--- a/packages/db/drizzle/0015_faithful_midnight.sql
+++ b/packages/db/drizzle/0015_faithful_midnight.sql
@@ -1,0 +1,55 @@
+-- 1. Add user_id nullable so we can backfill before enforcing NOT NULL.
+ALTER TABLE "crawl_sources" ADD COLUMN "user_id" text;--> statement-breakpoint
+
+-- 2. Backfill ownership from the source's current chatbot.
+UPDATE "crawl_sources" cs
+SET "user_id" = c."user_id"
+FROM "chatbots" c
+WHERE c."id" = cs."chatbot_id";--> statement-breakpoint
+
+-- 3. Enforce ownership.
+ALTER TABLE "crawl_sources" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "crawl_sources" ADD CONSTRAINT "crawl_sources_user_id_user_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_crawl_sources_user_id" ON "crawl_sources" USING btree ("user_id");--> statement-breakpoint
+
+-- 4. Create the junction table.
+CREATE TABLE "chatbot_crawl_source_associations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chatbot_id" uuid NOT NULL,
+	"crawl_source_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);--> statement-breakpoint
+ALTER TABLE "chatbot_crawl_source_associations" ADD CONSTRAINT "chatbot_crawl_source_associations_chatbot_id_chatbots_id_fk"
+  FOREIGN KEY ("chatbot_id") REFERENCES "public"."chatbots"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chatbot_crawl_source_associations" ADD CONSTRAINT "chatbot_crawl_source_associations_crawl_source_id_crawl_sources_id_fk"
+  FOREIGN KEY ("crawl_source_id") REFERENCES "public"."crawl_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx"
+  ON "chatbot_crawl_source_associations" USING btree ("chatbot_id","crawl_source_id");--> statement-breakpoint
+
+-- 5. Backfill the junction from existing source->chatbot bindings.
+INSERT INTO "chatbot_crawl_source_associations" ("chatbot_id", "crawl_source_id")
+SELECT "chatbot_id", "id" FROM "crawl_sources";--> statement-breakpoint
+
+-- 6. Verify counts BEFORE dropping chatbot_id. Aborts the transaction if any
+--    source failed to backfill (NULL user_id) or junction count != source count.
+DO $$
+DECLARE
+  src_count int;
+  assoc_count int;
+  null_owner int;
+BEGIN
+  SELECT count(*) INTO src_count FROM "crawl_sources";
+  SELECT count(*) INTO assoc_count FROM "chatbot_crawl_source_associations";
+  SELECT count(*) INTO null_owner FROM "crawl_sources" WHERE "user_id" IS NULL;
+  IF null_owner > 0 THEN
+    RAISE EXCEPTION 'Backfill failed: % crawl_sources have NULL user_id', null_owner;
+  END IF;
+  IF src_count <> assoc_count THEN
+    RAISE EXCEPTION 'Backfill mismatch: % sources vs % associations', src_count, assoc_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- 7. Now safe to drop the old column + its index.
+DROP INDEX IF EXISTS "idx_crawl_sources_chatbot_id";--> statement-breakpoint
+ALTER TABLE "crawl_sources" DROP COLUMN "chatbot_id";

--- a/packages/db/drizzle/0016_dry_franklin_storm.sql
+++ b/packages/db/drizzle/0016_dry_franklin_storm.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "chatbot_file_associations_file_id_idx" ON "chatbot_file_associations" USING btree ("file_id");--> statement-breakpoint
+CREATE INDEX "idx_chatbot_crawl_source_assoc_crawl_source_id" ON "chatbot_crawl_source_associations" USING btree ("crawl_source_id");

--- a/packages/db/drizzle/meta/0015_snapshot.json
+++ b/packages/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1813 @@
+{
+  "id": "4b78c151-c7b6-488c-bb04-937675e3adb1",
+  "prevId": "a87abba1-b462-4f65-a4b1-f8bb762cd6cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics": {
+      "name": "analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_chatbot_event_type_created_at_idx": {
+          "name": "analytics_chatbot_event_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "analytics_chatbot_event_type_session_id_idx": {
+          "name": "analytics_chatbot_event_type_session_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "analytics_chatbot_event_type_rag_used_idx": {
+          "name": "analytics_chatbot_event_type_rag_used_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"event_data\"->>'ragUsed')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "analytics_chatbot_id_chatbots_id_fk": {
+          "name": "analytics_chatbot_id_chatbots_id_fk",
+          "tableFrom": "analytics",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "tableTo": "chatbots",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_domains": {
+      "name": "approved_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approved_domains_created_by_user_id_fk": {
+          "name": "approved_domains_created_by_user_id_fk",
+          "tableFrom": "approved_domains",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_domains_domain_unique": {
+          "name": "approved_domains_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_file_associations": {
+      "name": "chatbot_file_associations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatbot_file_associations_chatbot_id_file_id_idx": {
+          "name": "chatbot_file_associations_chatbot_id_file_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chatbot_file_associations_chatbot_id_chatbots_id_fk": {
+          "name": "chatbot_file_associations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "tableTo": "chatbots",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chatbot_file_associations_file_id_user_files_id_fk": {
+          "name": "chatbot_file_associations_file_id_user_files_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "tableTo": "user_files",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbots": {
+      "name": "chatbots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meta-llama/llama-3.3-70b-instruct'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 70
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2000
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_questions": {
+          "name": "suggested_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_sources": {
+          "name": "show_sources",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_author_name": {
+          "name": "custom_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_settings": {
+          "name": "embed_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"light\",\"position\":\"bottom-right\",\"buttonColor\":\"#000000\",\"chatColor\":\"#ffffff\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chatbots_user_id_user_id_fk": {
+          "name": "chatbots_user_id_user_id_fk",
+          "tableFrom": "chatbots",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chatbots_share_token_unique": {
+          "name": "chatbots_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_chatbot_id_created_at_idx": {
+          "name": "conversations_chatbot_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_chatbot_id_chatbots_id_fk": {
+          "name": "conversations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "conversations",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "tableTo": "chatbots",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_session_id_unique": {
+          "name": "conversations_session_id_unique",
+          "columns": [
+            "session_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawl_sources": {
+      "name": "crawl_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_url": {
+          "name": "root_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "crawl_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "include_patterns": {
+          "name": "include_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawl_sources_user_id": {
+          "name": "idx_crawl_sources_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "crawl_sources_user_id_user_id_fk": {
+          "name": "crawl_sources_user_id_user_id_fk",
+          "tableFrom": "crawl_sources",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawled_pages": {
+      "name": "crawled_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crawl_source_id": {
+          "name": "crawl_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_file_id": {
+          "name": "user_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "crawled_page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawled_pages_source_status": {
+          "name": "idx_crawled_pages_source_status",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_crawled_pages_source_url": {
+          "name": "idx_crawled_pages_source_url",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_crawled_pages_user_file_id": {
+          "name": "idx_crawled_pages_user_file_id",
+          "columns": [
+            {
+              "expression": "user_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "crawled_pages_crawl_source_id_crawl_sources_id_fk": {
+          "name": "crawled_pages_crawl_source_id_crawl_sources_id_fk",
+          "tableFrom": "crawled_pages",
+          "columnsFrom": [
+            "crawl_source_id"
+          ],
+          "tableTo": "crawl_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "crawled_pages_user_file_id_user_files_id_fk": {
+          "name": "crawled_pages_user_file_id_user_files_id_fk",
+          "tableFrom": "crawled_pages",
+          "columnsFrom": [
+            "user_file_id"
+          ],
+          "tableTo": "user_files",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_deliveries": {
+      "name": "email_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_message_id": {
+          "name": "resend_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_message_id": {
+          "name": "qstash_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "email_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_deliveries_resend_message_id_idx": {
+          "name": "email_deliveries_resend_message_id_idx",
+          "columns": [
+            {
+              "expression": "resend_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_deliveries_idempotency_key_unique": {
+          "name": "email_deliveries_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_chunks": {
+      "name": "file_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_chunks_embedding_idx": {
+          "name": "file_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "m": 24,
+            "ef_construction": 128
+          },
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "file_chunks_file_id_idx": {
+          "name": "file_chunks_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "file_chunks_file_id_user_files_id_fk": {
+          "name": "file_chunks_file_id_user_files_id_fk",
+          "tableFrom": "file_chunks",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "tableTo": "user_files",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_chunks_file_id_chunk_index_unique": {
+          "name": "file_chunks_file_id_chunk_index_unique",
+          "columns": [
+            "file_id",
+            "chunk_index"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "messages_content_trgm_idx": {
+          "name": "messages_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "conversations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_affiliation": {
+          "name": "institutional_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faculty_webpage": {
+          "name": "faculty_webpage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_files": {
+      "name": "user_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "processing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_files_user_id_user_id_fk": {
+          "name": "user_files_user_id_user_id_fk",
+          "tableFrom": "user_files",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_crawl_source_associations": {
+      "name": "chatbot_crawl_source_associations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_source_id": {
+          "name": "crawl_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx": {
+          "name": "chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chatbot_crawl_source_associations_chatbot_id_chatbots_id_fk": {
+          "name": "chatbot_crawl_source_associations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "chatbot_crawl_source_associations",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "tableTo": "chatbots",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chatbot_crawl_source_associations_crawl_source_id_crawl_sources_id_fk": {
+          "name": "chatbot_crawl_source_associations_crawl_source_id_crawl_sources_id_fk",
+          "tableFrom": "chatbot_crawl_source_associations",
+          "columnsFrom": [
+            "crawl_source_id"
+          ],
+          "tableTo": "crawl_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.crawl_status": {
+      "name": "crawl_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "discovering",
+        "crawling",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.crawled_page_status": {
+      "name": "crawled_page_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed",
+        "blocked",
+        "skipped"
+      ]
+    },
+    "public.email_delivery_status": {
+      "name": "email_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "delivered",
+        "delayed",
+        "bounced",
+        "complained",
+        "failed"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "admin_notification",
+        "approval",
+        "rejection",
+        "promote_admin",
+        "demote_admin",
+        "account_disabled",
+        "account_enabled",
+        "account_deleted",
+        "password_reset"
+      ]
+    },
+    "public.processing_status": {
+      "name": "processing_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0016_snapshot.json
+++ b/packages/db/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1843 @@
+{
+  "id": "e9578c54-ecbb-47ac-b0e6-070cfe95ed8a",
+  "prevId": "4b78c151-c7b6-488c-bb04-937675e3adb1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics": {
+      "name": "analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_chatbot_event_type_created_at_idx": {
+          "name": "analytics_chatbot_event_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_chatbot_event_type_session_id_idx": {
+          "name": "analytics_chatbot_event_type_session_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_chatbot_event_type_rag_used_idx": {
+          "name": "analytics_chatbot_event_type_rag_used_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"event_data\"->>'ragUsed')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_chatbot_id_chatbots_id_fk": {
+          "name": "analytics_chatbot_id_chatbots_id_fk",
+          "tableFrom": "analytics",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_domains": {
+      "name": "approved_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approved_domains_created_by_user_id_fk": {
+          "name": "approved_domains_created_by_user_id_fk",
+          "tableFrom": "approved_domains",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_domains_domain_unique": {
+          "name": "approved_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_crawl_source_associations": {
+      "name": "chatbot_crawl_source_associations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_source_id": {
+          "name": "crawl_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx": {
+          "name": "chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chatbot_crawl_source_assoc_crawl_source_id": {
+          "name": "idx_chatbot_crawl_source_assoc_crawl_source_id",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chatbot_crawl_source_associations_chatbot_id_chatbots_id_fk": {
+          "name": "chatbot_crawl_source_associations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "chatbot_crawl_source_associations",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chatbot_crawl_source_associations_crawl_source_id_crawl_sources_id_fk": {
+          "name": "chatbot_crawl_source_associations_crawl_source_id_crawl_sources_id_fk",
+          "tableFrom": "chatbot_crawl_source_associations",
+          "tableTo": "crawl_sources",
+          "columnsFrom": [
+            "crawl_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_file_associations": {
+      "name": "chatbot_file_associations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatbot_file_associations_chatbot_id_file_id_idx": {
+          "name": "chatbot_file_associations_chatbot_id_file_id_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chatbot_file_associations_file_id_idx": {
+          "name": "chatbot_file_associations_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chatbot_file_associations_chatbot_id_chatbots_id_fk": {
+          "name": "chatbot_file_associations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chatbot_file_associations_file_id_user_files_id_fk": {
+          "name": "chatbot_file_associations_file_id_user_files_id_fk",
+          "tableFrom": "chatbot_file_associations",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbots": {
+      "name": "chatbots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meta-llama/llama-3.3-70b-instruct'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 70
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2000
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_questions": {
+          "name": "suggested_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_sources": {
+          "name": "show_sources",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_author_name": {
+          "name": "custom_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_settings": {
+          "name": "embed_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"light\",\"position\":\"bottom-right\",\"buttonColor\":\"#000000\",\"chatColor\":\"#ffffff\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chatbots_user_id_user_id_fk": {
+          "name": "chatbots_user_id_user_id_fk",
+          "tableFrom": "chatbots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chatbots_share_token_unique": {
+          "name": "chatbots_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatbot_id": {
+          "name": "chatbot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_chatbot_id_created_at_idx": {
+          "name": "conversations_chatbot_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "chatbot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_chatbot_id_chatbots_id_fk": {
+          "name": "conversations_chatbot_id_chatbots_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "chatbots",
+          "columnsFrom": [
+            "chatbot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_session_id_unique": {
+          "name": "conversations_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawl_sources": {
+      "name": "crawl_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_url": {
+          "name": "root_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "crawl_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "include_patterns": {
+          "name": "include_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "last_crawled_at": {
+          "name": "last_crawled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawl_sources_user_id": {
+          "name": "idx_crawl_sources_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_sources_user_id_user_id_fk": {
+          "name": "crawl_sources_user_id_user_id_fk",
+          "tableFrom": "crawl_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawled_pages": {
+      "name": "crawled_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crawl_source_id": {
+          "name": "crawl_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_file_id": {
+          "name": "user_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "crawled_page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crawled_pages_source_status": {
+          "name": "idx_crawled_pages_source_status",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crawled_pages_source_url": {
+          "name": "idx_crawled_pages_source_url",
+          "columns": [
+            {
+              "expression": "crawl_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crawled_pages_user_file_id": {
+          "name": "idx_crawled_pages_user_file_id",
+          "columns": [
+            {
+              "expression": "user_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawled_pages_crawl_source_id_crawl_sources_id_fk": {
+          "name": "crawled_pages_crawl_source_id_crawl_sources_id_fk",
+          "tableFrom": "crawled_pages",
+          "tableTo": "crawl_sources",
+          "columnsFrom": [
+            "crawl_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawled_pages_user_file_id_user_files_id_fk": {
+          "name": "crawled_pages_user_file_id_user_files_id_fk",
+          "tableFrom": "crawled_pages",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "user_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_deliveries": {
+      "name": "email_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_message_id": {
+          "name": "resend_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_message_id": {
+          "name": "qstash_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "email_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_deliveries_resend_message_id_idx": {
+          "name": "email_deliveries_resend_message_id_idx",
+          "columns": [
+            {
+              "expression": "resend_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_deliveries_idempotency_key_unique": {
+          "name": "email_deliveries_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_chunks": {
+      "name": "file_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_chunks_embedding_idx": {
+          "name": "file_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 24,
+            "ef_construction": 128
+          }
+        },
+        "file_chunks_file_id_idx": {
+          "name": "file_chunks_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_chunks_file_id_user_files_id_fk": {
+          "name": "file_chunks_file_id_user_files_id_fk",
+          "tableFrom": "file_chunks",
+          "tableTo": "user_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_chunks_file_id_chunk_index_unique": {
+          "name": "file_chunks_file_id_chunk_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_content_trgm_idx": {
+          "name": "messages_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_affiliation": {
+          "name": "institutional_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faculty_webpage": {
+          "name": "faculty_webpage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_files": {
+      "name": "user_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "processing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_files_user_id_user_id_fk": {
+          "name": "user_files_user_id_user_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.crawl_status": {
+      "name": "crawl_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "discovering",
+        "crawling",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.crawled_page_status": {
+      "name": "crawled_page_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed",
+        "blocked",
+        "skipped"
+      ]
+    },
+    "public.email_delivery_status": {
+      "name": "email_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "delivered",
+        "delayed",
+        "bounced",
+        "complained",
+        "failed"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "admin_notification",
+        "approval",
+        "rejection",
+        "promote_admin",
+        "demote_admin",
+        "account_disabled",
+        "account_enabled",
+        "account_deleted",
+        "password_reset"
+      ]
+    },
+    "public.processing_status": {
+      "name": "processing_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1781141680232,
       "tag": "0015_faithful_midnight",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781144642063,
+      "tag": "0016_dry_franklin_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780082546786,
       "tag": "0014_certain_moon_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1781141680232,
+      "tag": "0015_faithful_midnight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -474,9 +474,7 @@ export const crawledPages = pgTable(
   ],
 );
 
-// Junction table: associates web sources (crawl sources) with chatbots
-// (many-to-many), mirroring chatbotFileAssociations. A source may be
-// attached to zero-or-more chatbots.
+// Junction table: Associates web sources (crawl sources) with chatbots (many-to-many)
 export const chatbotCrawlSourceAssociations = pgTable(
   "chatbot_crawl_source_associations",
   {
@@ -490,6 +488,7 @@ export const chatbotCrawlSourceAssociations = pgTable(
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [
+    // Composite uniqueIndex doubles as a B-tree on chatbotId (leading column) + unique constraint on (chatbotId, crawlSourceId). Name abbreviated ("assoc") to stay under Postgres's 63-char identifier limit.
     uniqueIndex("chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx").on(
       table.chatbotId,
       table.crawlSourceId,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -246,6 +246,10 @@ export const chatbotFileAssociations = pgTable(
       table.chatbotId,
       table.fileId,
     ),
+    // B-tree on fileId for bulk deletes/lookups keyed by file alone (e.g.
+    // deleting a crawled file across all chatbots). The composite above is
+    // chatbotId-leading and can't serve fileId-only predicates.
+    index("chatbot_file_associations_file_id_idx").on(table.fileId),
   ],
 );
 
@@ -491,6 +495,12 @@ export const chatbotCrawlSourceAssociations = pgTable(
     // Composite uniqueIndex doubles as a B-tree on chatbotId (leading column) + unique constraint on (chatbotId, crawlSourceId). Name abbreviated ("assoc") to stay under Postgres's 63-char identifier limit.
     uniqueIndex("chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx").on(
       table.chatbotId,
+      table.crawlSourceId,
+    ),
+    // B-tree on crawlSourceId for lookups keyed by source alone (crawl
+    // processor, attach/detach backfill, get-attachable). The composite above
+    // is chatbotId-leading and can't serve crawlSourceId-only predicates.
+    index("idx_chatbot_crawl_source_assoc_crawl_source_id").on(
       table.crawlSourceId,
     ),
   ],

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -421,8 +421,8 @@ export const crawlSources = pgTable(
   "crawl_sources",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    chatbotId: uuid("chatbot_id")
-      .references(() => chatbots.id, { onDelete: "cascade" })
+    userId: text("user_id")
+      .references(() => user.id, { onDelete: "cascade" })
       .notNull(),
     rootUrl: text("root_url").notNull(),
     status: crawlStatusEnum("status").default("pending").notNull(),
@@ -436,7 +436,7 @@ export const crawlSources = pgTable(
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
-  (table) => [index("idx_crawl_sources_chatbot_id").on(table.chatbotId)],
+  (table) => [index("idx_crawl_sources_user_id").on(table.userId)],
 );
 
 export const crawledPages = pgTable(
@@ -474,12 +474,36 @@ export const crawledPages = pgTable(
   ],
 );
 
+// Junction table: associates web sources (crawl sources) with chatbots
+// (many-to-many), mirroring chatbotFileAssociations. A source may be
+// attached to zero-or-more chatbots.
+export const chatbotCrawlSourceAssociations = pgTable(
+  "chatbot_crawl_source_associations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    chatbotId: uuid("chatbot_id")
+      .references(() => chatbots.id, { onDelete: "cascade" })
+      .notNull(),
+    crawlSourceId: uuid("crawl_source_id")
+      .references(() => crawlSources.id, { onDelete: "cascade" })
+      .notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("chatbot_crawl_source_assoc_chatbot_id_crawl_source_id_idx").on(
+      table.chatbotId,
+      table.crawlSourceId,
+    ),
+  ],
+);
+
 export const userRelations = relations(user, ({ many }) => ({
   chatbots: many(chatbots),
   sessions: many(session),
   accounts: many(account),
   approvedDomainsCreated: many(approvedDomains),
   files: many(userFiles),
+  crawlSources: many(crawlSources),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -514,7 +538,7 @@ export const chatbotsRelations = relations(chatbots, ({ one, many }) => ({
   fileAssociations: many(chatbotFileAssociations),
   conversations: many(conversations),
   analytics: many(analytics),
-  crawlSources: many(crawlSources),
+  crawlSourceAssociations: many(chatbotCrawlSourceAssociations),
 }));
 
 export const userFilesRelations = relations(userFiles, ({ one, many }) => ({
@@ -575,11 +599,26 @@ export const analyticsRelations = relations(analytics, ({ one }) => ({
 export const crawlSourcesRelations = relations(
   crawlSources,
   ({ one, many }) => ({
-    chatbot: one(chatbots, {
-      fields: [crawlSources.chatbotId],
-      references: [chatbots.id],
+    user: one(user, {
+      fields: [crawlSources.userId],
+      references: [user.id],
     }),
     pages: many(crawledPages),
+    chatbotAssociations: many(chatbotCrawlSourceAssociations),
+  }),
+);
+
+export const chatbotCrawlSourceAssociationsRelations = relations(
+  chatbotCrawlSourceAssociations,
+  ({ one }) => ({
+    chatbot: one(chatbots, {
+      fields: [chatbotCrawlSourceAssociations.chatbotId],
+      references: [chatbots.id],
+    }),
+    crawlSource: one(crawlSources, {
+      fields: [chatbotCrawlSourceAssociations.crawlSourceId],
+      references: [crawlSources.id],
+    }),
   }),
 );
 


### PR DESCRIPTION
## Summary

Web sources can now be added without a chatbot and attached/detached later, mirroring how file uploads work. Reported by Professor Joubin: with one chatbot the Add panel silently forced attachment to it.

**Model shift:** `crawlSources` is now user-owned (`userId`) instead of chatbot-owned (`chatbotId NOT NULL`). A new `chatbotCrawlSourceAssociations` junction maps source <-> chatbot (many-to-many), mirroring `chatbotFileAssociations`. Crawled pages still become `userFiles` + `fileChunks`; the crawl processor reads the junction and syncs page-level `chatbotFileAssociations`, so RAG retrieval is unchanged except its disabled-source filter.

### Backend
- Schema: drop `crawlSources.chatbotId`, add `userId` + `chatbotCrawlSourceAssociations`.
- `chatbotId` optional on `addCrawlSource` / `addManualUrl`; dedup now per `(userId, rootUrl)`.
- New procedures: `attachToChatbot`, `detachFromChatbot`, `getAttachableSources`.
- Crawl processor: owner from `source.userId`; fan out file associations to every attached chatbot, on **every** completed page (re-crawl self-heals any association gap).
- `getCrawlSources` / `getAllCrawlSources` query through the junction; global list returns attached chatbots as an array.
- RAG disabled-source filter rewired through the junction.
- Deleting a chatbot now detaches sources (they survive); per-chatbot "remove" detaches instead of deleting.

### UI
- Global Add panel: "No chatbot (add later)" default option.
- Global list: per-row dropdown to attach/detach chatbots; "Not attached" badge.
- Per-chatbot Web Sources tab: "Attach an existing web source" picker; per-source remove = detach.

### Migration (0015) — non-destructive, NOT yet applied
Ordered backfill before drop: add `user_id` (nullable) -> backfill from chatbots -> set NOT NULL -> create junction -> backfill junction -> **verify counts (aborts on mismatch/NULL)** -> drop `chatbot_id`. Existing `chatbotFileAssociations` untouched: no re-crawl / re-embedding.

## Test Plan
- [x] `check-types`, `lint`, `test` (340 web + 40 ai) green
- [x] New unit tests: validation (optional chatbotId), orphan-safe delete helpers
- [ ] **Run migration 0015 against a SCRATCH DB first**, confirm pre/post counts match, before deploy
- [ ] E2E smoke: add source with no chatbot -> "Not attached"; attach from global list + chatbot tab; verify RAG retrieval; detach; attach to two chatbots; full delete leaves no orphans

> Contains a schema migration affecting live data. Review the migration ordering + run the scratch-DB dry-run before merge/deploy.