### PR TITLE
fix(db): restrict setup-extensions env fallback to ENOENT

### DIFF
--- a/packages/db/scripts/setup-extensions.ts
+++ b/packages/db/scripts/setup-extensions.ts
@@ -20,16 +20,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Load environment variables from apps/web/.env when present. In CI (e.g. the
-// migrate-db workflow) that file doesn't exist; fall back to the ambient
-// environment, which is only an error if DATABASE_URL also isn't set.
+// release deploy) that file doesn't exist and DATABASE_URL comes from the
+// ambient environment. A missing file (ENOENT) is therefore expected and
+// tolerated, but any other load error (permissions, malformed file) is a real
+// problem and still fails fast.
 const envPath = resolve(__dirname, "../../../apps/web/.env");
 const result = config({ path: envPath });
 
-if (result.error && !process.env.DATABASE_URL) {
-  console.error(
-    "❌ Could not load apps/web/.env and DATABASE_URL is not set:",
-    result.error,
-  );
+if (result.error && (result.error as NodeJS.ErrnoException).code !== "ENOENT") {
+  console.error("❌ Error loading .env file:", result.error);
   process.exit(1);
 }
 


### PR DESCRIPTION
Addresses Copilot review on #335: the env-load fallback tolerated *any* dotenv error when DATABASE_URL was set, masking real issues (permissions, malformed .env). Now only a missing file (ENOENT) is tolerated; other errors fail fast. The existing DATABASE_URL-unset check still handles the missing-file-in-CI path.

- [x] check-types / lint / test green