### PR TITLE
docs: make CONTRIBUTING.md the front door for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report something that isn't working as expected.
 title: ""
-labels: bug
+labels: "type: bug"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report something that isn't working as expected.
+title: ""
+labels: bug
+assignees: ""
+---
+
+<!--
+See CONTRIBUTING.md for the workflow:
+https://github.com/akhileshrangani4/teachanything/blob/main/CONTRIBUTING.md
+-->
+
+## What happened
+
+A clear description of the bug.
+
+## Expected behavior
+
+What you expected to happen instead.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Environment
+
+- Where it happened (local / preview / production):
+- Browser / OS (if relevant):
+
+## Additional context
+
+Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/akhileshrangani4/teachanything/blob/main/CONTRIBUTING.md
+    about: Read this first. It covers the workflow, coding standards (AGENTS.md), and how to open an issue and PR.
+  - name: Ask a question / discuss before building
+    url: https://avi.mn/calendar
+    about: Want to talk through a feature, idea, or bug before starting work? Schedule a quick chat.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Propose a new feature or change. Open this and agree on direction BEFORE building.
 title: ""
-labels: enhancement
+labels: "type: enhancement"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Propose a new feature or change. Open this and agree on direction BEFORE building.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+<!--
+Per CONTRIBUTING.md, start from an issue so we can agree on direction before
+any code is written. The PR should then link back with "Closes #<this issue>".
+https://github.com/akhileshrangani4/teachanything/blob/main/CONTRIBUTING.md
+-->
+
+## Problem / motivation
+
+What problem does this solve, and for whom? Why now?
+
+## Proposed direction
+
+What you're thinking of building, at a high level. Not the full implementation.
+
+## Implementation notes / open questions
+
+Anything you'd want to align on before starting (approach, affected areas,
+trade-offs). For non-trivial work, let's agree on the technical approach here
+first.
+
+## Alternatives considered
+
+Other approaches you weighed, if any.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Before opening a PR, please read CONTRIBUTING.md:
+https://github.com/akhileshrangani4/teachanything/blob/main/CONTRIBUTING.md
+Every PR should trace back to an issue you've agreed on first.
+-->
+
+## Summary
+
+Brief description of what this PR does and why.
+
+- Bullet points for key changes
+- Reference the issue: Closes #123
+
+## Changes
+
+- What was added/modified/removed
+- Any architectural decisions made and why
+
+## Library Choices (if applicable)
+
+If you introduced new dependencies, briefly explain:
+
+- What you chose and why
+- What alternatives you considered
+- Maintenance status of the chosen library
+
+## Screenshots (if visual changes)
+
+Before/after screenshots or screen recordings for UI changes.
+
+## Test Plan
+
+- [ ] How to test the changes
+- [ ] Edge cases considered
+- [ ] What was manually verified
+
+## Checklist
+
+- [ ] PR title follows Conventional Commit format
+- [ ] Linked to an issue (or context provided)
+- [ ] `npm run lint` passes
+- [ ] `npm run check-types` passes
+- [ ] `npm run test` passes
+- [ ] No `console.log` statements
+- [ ] Zod validation on all new tRPC inputs
+- [ ] Ownership checks on protected resources
+- [ ] Screenshots attached for visual changes
+- [ ] New dependencies justified in PR description
+- [ ] Tests added for new utility/validation logic
+- [ ] Database migrations generated (`npm run db:generate`) if schema changed
+- [ ] I understand and can stand behind every change in this PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,7 @@ teachanything/
 
 - Find an open issue or file a new one
 - Comment on the issue to indicate you're working on it
+- Agree on the direction in the issue **before** building. For non-trivial work, discuss the technical approach with a maintainer first so we avoid duplicate or off-direction PRs
 - Branch from `main`
 
 ### 2. Branch Naming
@@ -124,6 +125,14 @@ refactor/analytics-queries
 - Add Zod validation on all tRPC inputs
 - Add ownership checks on protected resources
 - Add tests for new utility/validation logic (see [Testing in AGENTS.md](./AGENTS.md#12-testing))
+
+#### Own what you submit
+
+Using an AI coding assistant (Claude Code, etc.) is encouraged. The expectation
+is that you understand and can stand behind every line you submit, and that it
+follows [AGENTS.md](./AGENTS.md). Use the assistant's planning mode to agree on
+a plan before code is written, and give reviewers enough context in the PR
+description to see what the change does and why.
 
 ### Writing Tests
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
   <a href="https://github.com/akhileshrangani4/teachanything/commits/main"><img src="https://img.shields.io/github/last-commit/akhileshrangani4/teachanything" alt="Last Commit" /></a>
 </p>
 
+<p align="center">
+  <strong>New here?</strong> Start with <a href="./CONTRIBUTING.md">CONTRIBUTING.md</a> before opening an issue or PR. Using an AI coding assistant? Read <a href="./AGENTS.md">AGENTS.md</a>.
+</p>
+
 ---
 
 ## What is Teach Anything?


### PR DESCRIPTION
## Summary
Make the contribution path obvious and issue-first, so new contributors land on CONTRIBUTING.md before opening issues/PRs.

- README: prominent "New here? Start with CONTRIBUTING.md" pointer at the top (it was only linked in a section near the bottom).
- `.github/PULL_REQUEST_TEMPLATE.md`: a real PR template (previously the template only existed as markdown inside CONTRIBUTING.md), prompting for the issue link, context, and ownership.
- `.github/ISSUE_TEMPLATE/`: feature + bug templates and a `config.yml` that disables blank issues and links CONTRIBUTING.md + the office-hours calendar, nudging "open an issue and agree on direction first."
- CONTRIBUTING.md: agree on direction/approach before building; new "Own what you submit" note on AI-assisted work.

Docs/templates only, no code changes.

## Test Plan
- [x] lint / check-types / test green (no code touched)
- [ ] After merge: opening a new issue shows the templates; opening a PR pre-fills the template