### PR TITLE
docs(agents): clarify AGENTS.md applies to all contributors, AI optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ It applies to **every** contribution, regardless of how the code was written.
 
 The file is named `AGENTS.md` and formatted so AI coding agents can read and
 follow it directly, but using an AI coding agent is entirely optional. For a
-human contributor, treat this as the project's style guide; "follow AGENTS.md"
+human contributor, treat this as the project's style guide; "follow `AGENTS.md`"
 means "follow our coding standards," not "you must use AI."
 
 ## 1. Repository Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # AGENTS.md
 
-This is the project's coding-standards and architecture reference: repository
-structure, tech stack, TypeScript and API conventions, testing, and workflow
-rules. It applies to **every** contribution, regardless of how the code was
-written.
+This is the project's coding standards and architecture reference. It documents repository
+structure, tech stack, TypeScript and API conventions, testing, and workflow rules.
+It applies to **every** contribution, regardless of how the code was written.
 
 The file is named `AGENTS.md` and formatted so AI coding agents can read and
 follow it directly, but using an AI coding agent is entirely optional. For a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,14 @@
 # AGENTS.md
 
-Comprehensive guidance for AI coding agents working in this repository.
+This is the project's coding-standards and architecture reference: repository
+structure, tech stack, TypeScript and API conventions, testing, and workflow
+rules. It applies to **every** contribution, regardless of how the code was
+written.
+
+The file is named `AGENTS.md` and formatted so AI coding agents can read and
+follow it directly, but using an AI coding agent is entirely optional. For a
+human contributor, treat this as the project's style guide; "follow AGENTS.md"
+means "follow our coding standards," not "you must use AI."
 
 ## 1. Repository Structure
 


### PR DESCRIPTION
A contributor read the AGENTS.md name as 'you must use an AI agent.' Clarify at the top that it's the project's coding-standards/architecture reference for every contribution, and that using an AI agent is optional (the file is just also formatted for agents to consume). Docs-only.