### PR TITLE
feat(web-sources): list view for attaching existing web sources

### DIFF
--- a/apps/web/src/__tests__/lib/crawler-metadata.test.ts
+++ b/apps/web/src/__tests__/lib/crawler-metadata.test.ts
@@ -4,9 +4,36 @@ import {
   getSourceDisplayName,
   getSourceErrorCount,
   getSourcePageCount,
+  resolveSourceDisplayName,
 } from "@/lib/crawler-metadata";
 
 describe("crawler metadata helpers", () => {
+  describe("resolveSourceDisplayName", () => {
+    it("uses the trimmed display name when present", () => {
+      expect(
+        resolveSourceDisplayName("  Course Site  ", "https://example.edu"),
+      ).toBe("Course Site");
+    });
+
+    it("falls back to the root URL when display name is null", () => {
+      expect(resolveSourceDisplayName(null, "https://example.edu")).toBe(
+        "https://example.edu",
+      );
+    });
+
+    it("falls back to the root URL when display name is undefined", () => {
+      expect(resolveSourceDisplayName(undefined, "https://example.edu")).toBe(
+        "https://example.edu",
+      );
+    });
+
+    it("falls back to the root URL when display name is whitespace only", () => {
+      expect(resolveSourceDisplayName("   ", "https://example.edu")).toBe(
+        "https://example.edu",
+      );
+    });
+  });
+
   describe("getSourceDisplayName", () => {
     it("uses the trimmed custom source display name", () => {
       expect(

--- a/apps/web/src/components/chatbot/WebSourcesTab.tsx
+++ b/apps/web/src/components/chatbot/WebSourcesTab.tsx
@@ -226,7 +226,9 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
           onAttach={(crawlSourceId) =>
             attach.mutate({ crawlSourceId, chatbotId })
           }
-          attachingId={attach.variables?.crawlSourceId ?? null}
+          attachingId={
+            attach.isPending ? (attach.variables?.crawlSourceId ?? null) : null
+          }
           isAttaching={attach.isPending}
         />
 

--- a/apps/web/src/components/chatbot/WebSourcesTab.tsx
+++ b/apps/web/src/components/chatbot/WebSourcesTab.tsx
@@ -11,16 +11,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { CrawlSourceCard } from "./web-sources/CrawlSourceCard";
+import { AttachExistingSources } from "./web-sources/AttachExistingSources";
 import {
   AddFullWebSourceDialog,
   EmptyWebSourcesState,
@@ -49,7 +41,6 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
   const [expandedSources, setExpandedSources] = useState<Set<string>>(
     new Set(),
   );
-  const [selectedSourceId, setSelectedSourceId] = useState("");
 
   const {
     data: sources,
@@ -230,42 +221,14 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
           onSubmit={handleAddManualUrl}
         />
 
-        {unattached.length > 0 && (
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-            <div className="flex-1 space-y-1.5">
-              <Label htmlFor="attach-existing">
-                Attach an existing web source
-              </Label>
-              <Select
-                value={selectedSourceId}
-                onValueChange={setSelectedSourceId}
-              >
-                <SelectTrigger id="attach-existing">
-                  <SelectValue placeholder="Choose a web source..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {unattached.map((s) => (
-                    <SelectItem key={s.id} value={s.id}>
-                      {s.rootUrl}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={!selectedSourceId || attach.isPending}
-              onClick={() => {
-                if (!selectedSourceId) return;
-                attach.mutate({ crawlSourceId: selectedSourceId, chatbotId });
-                setSelectedSourceId("");
-              }}
-            >
-              Attach
-            </Button>
-          </div>
-        )}
+        <AttachExistingSources
+          sources={unattached}
+          onAttach={(crawlSourceId) =>
+            attach.mutate({ crawlSourceId, chatbotId })
+          }
+          attachingId={attach.variables?.crawlSourceId ?? null}
+          isAttaching={attach.isPending}
+        />
 
         {sourcesLoading ? (
           <WebSourcesSkeleton />

--- a/apps/web/src/components/chatbot/web-sources/AttachExistingSources.tsx
+++ b/apps/web/src/components/chatbot/web-sources/AttachExistingSources.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Globe, Plus } from "lucide-react";
+import { type RouterOutputs } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { getSourceDisplayName } from "@/lib/crawler-metadata";
+import { SourceStatusBadge } from "./status-badges";
+
+type AttachableSource =
+  RouterOutputs["crawler"]["getAttachableSources"][number];
+
+export function AttachExistingSources({
+  sources,
+  onAttach,
+  attachingId,
+  isAttaching,
+}: {
+  sources: AttachableSource[];
+  onAttach: (crawlSourceId: string) => void;
+  attachingId: string | null;
+  isAttaching: boolean;
+}) {
+  if (sources.length === 0) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <Label>Attach an existing web source</Label>
+      <div className="divide-y rounded-md border">
+        {sources.map((source) => {
+          const displayName = getSourceDisplayName(source);
+          return (
+            <div
+              key={source.id}
+              className="flex items-center gap-3 px-3 py-2.5"
+            >
+              <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{displayName}</p>
+                {displayName !== source.rootUrl && (
+                  <p className="truncate text-xs text-muted-foreground">
+                    {source.rootUrl}
+                  </p>
+                )}
+              </div>
+              <SourceStatusBadge status={source.status} />
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={isAttaching}
+                onClick={() => onAttach(source.id)}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                {attachingId === source.id ? "Attaching..." : "Attach"}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chatbot/web-sources/AttachExistingSources.tsx
+++ b/apps/web/src/components/chatbot/web-sources/AttachExistingSources.tsx
@@ -4,7 +4,7 @@ import { Globe, Plus } from "lucide-react";
 import { type RouterOutputs } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { getSourceDisplayName } from "@/lib/crawler-metadata";
+import { resolveSourceDisplayName } from "@/lib/crawler-metadata";
 import { SourceStatusBadge } from "./status-badges";
 
 type AttachableSource =
@@ -28,7 +28,10 @@ export function AttachExistingSources({
       <Label>Attach an existing web source</Label>
       <div className="divide-y rounded-md border">
         {sources.map((source) => {
-          const displayName = getSourceDisplayName(source);
+          const displayName = resolveSourceDisplayName(
+            source.displayName,
+            source.rootUrl,
+          );
           return (
             <div
               key={source.id}

--- a/apps/web/src/lib/crawler-metadata.ts
+++ b/apps/web/src/lib/crawler-metadata.ts
@@ -5,11 +5,21 @@ import type {
 
 export type { CrawledPageMetadata, CrawlSourceMetadata };
 
+// Resolves the label to show for a crawl source: the user-set display name
+// when present, otherwise the root URL. Shared by the full source list and
+// the attach picker (which only fetches displayName, not full metadata).
+export function resolveSourceDisplayName(
+  displayName: string | null | undefined,
+  rootUrl: string,
+): string {
+  return displayName?.trim() || rootUrl;
+}
+
 export function getSourceDisplayName(source: {
   rootUrl: string;
   metadata: CrawlSourceMetadata | null;
 }): string {
-  return source.metadata?.displayName?.trim() || source.rootUrl;
+  return resolveSourceDisplayName(source.metadata?.displayName, source.rootUrl);
 }
 
 export function getSourcePageCount(source: {

--- a/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
@@ -21,11 +21,17 @@ export const getAttachableSourcesProcedure = protectedProcedure
         AND ${chatbotCrawlSourceAssociations.chatbotId} = ${input.chatbotId}
     )`;
 
+    // Pull only the renamed display name out of metadata rather than the
+    // whole JSONB blob (which can carry large robotsText/errors fields).
+    const displayNameExpr = sql<
+      string | null
+    >`${crawlSources.metadata} ->> 'displayName'`;
+
     const rows = await ctx.db
       .select({
         id: crawlSources.id,
         rootUrl: crawlSources.rootUrl,
-        metadata: crawlSources.metadata,
+        displayName: displayNameExpr,
         status: crawlSources.status,
         createdAt: crawlSources.createdAt,
         isAttached: attachedExpr,

--- a/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-attachable-sources.ts
@@ -25,6 +25,7 @@ export const getAttachableSourcesProcedure = protectedProcedure
       .select({
         id: crawlSources.id,
         rootUrl: crawlSources.rootUrl,
+        metadata: crawlSources.metadata,
         status: crawlSources.status,
         createdAt: crawlSources.createdAt,
         isAttached: attachedExpr,


### PR DESCRIPTION
## What

Replaces the clunky "Attach an existing web source" dropdown on a chatbot's **Web Sources** tab with a row list, mirroring the **Associated Files** layout.

Requested by Professor Joubin: the dropdown was hard to use and showed full root URLs instead of her renamed (shortened) source names.

## Changes

- **New `web-sources/AttachExistingSources.tsx`** — row list replacing the `Select` dropdown. Each row shows:
  - the renamed display name (via `getSourceDisplayName`), falling back to the URL
  - the full root URL as subtext (only when a custom name is set)
  - a status badge + per-row **Attach** button (with in-flight "Attaching..." state)
- **`get-attachable-sources.ts`** — now returns `metadata` so the renamed `displayName` resolves client-side.
- **`WebSourcesTab.tsx`** — wires in the new component; drops the dropdown block, dead `selectedSourceId` state, and now-unused `Select`/`Label`/`Button` imports.

## Notes

- No schema change; display name already lives in `crawlSources.metadata.displayName`.
- `check-types` and `lint` pass.
- Not yet eyeballed in the running app.