### PR TITLE
feat(auth): add approval email whitelist note to signup screen

### DIFF
--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -273,7 +273,17 @@ export default function RegisterPage() {
           <Alert className="mb-4">
             <AlertDescription>
               All accounts require admin approval before you can log in.
-              You&apos;ll receive an email once your account is approved.
+              You&apos;ll receive an email once your account is approved. After
+              signing up, please check your inbox and spam folder for approval
+              emails from{" "}
+              <a
+                href="mailto:admin@teachanything.ai"
+                className="text-primary hover:underline"
+              >
+                admin@teachanything.ai
+              </a>
+              . To make sure you receive updates, please add this address to
+              your contacts.
               {process.env.NEXT_PUBLIC_CONTACT_EMAIL && (
                 <>
                   {" "}


### PR DESCRIPTION
## Summary
Adds a visible note to the signup screen telling users to watch for approval emails from admin@teachanything.ai and add that address to their contacts.

Professor Joubin reported users often miss the auto-generated Resend approval email when it lands in spam/promotions. This makes the expectation explicit on the register page.

## Changes
- Extended the existing approval-notice `Alert` on the register page with copy from the issue: check inbox + spam folder, approval emails come from admin@teachanything.ai (rendered as a `mailto:` link), and add the address to contacts.

## Acceptance criteria
- [x] Signup screen includes a visible note (top of the register card, before the form).
- [x] Note mentions admin@teachanything.ai explicitly.
- [x] Note asks users to check spam/junk and add the address to contacts.
- [x] Copy fits cleanly on mobile and desktop (inline text inside existing Alert, wraps naturally).

Closes #300