### PR TITLE
feat(rag): agentic retrieval with hybrid search + page citations (#271)

### DIFF
--- a/apps/web/src/__tests__/lib/message-sources.test.ts
+++ b/apps/web/src/__tests__/lib/message-sources.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "@jest/globals";
+import { dedupeSourcesByFileName, describeSource } from "@/lib/message-sources";
+
+describe("dedupeSourcesByFileName", () => {
+  it("keeps the highest-similarity chunk per file", () => {
+    const result = dedupeSourcesByFileName([
+      { fileName: "a.pdf", chunkIndex: 0, similarity: 0.4 },
+      { fileName: "a.pdf", chunkIndex: 1, similarity: 0.9 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.similarity).toBe(0.9);
+  });
+
+  it("keeps two pages of the same file as separate badges", () => {
+    const result = dedupeSourcesByFileName([
+      { fileName: "a.pdf", chunkIndex: 0, similarity: 0.8, pageNumber: 3 },
+      { fileName: "a.pdf", chunkIndex: 1, similarity: 0.7, pageNumber: 14 },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(
+      result.map((s) => s.pageNumber).sort((a, b) => (a ?? 0) - (b ?? 0)),
+    ).toEqual([3, 14]);
+  });
+
+  it("collapses same file + same page, keeping highest similarity", () => {
+    const result = dedupeSourcesByFileName([
+      { fileName: "a.pdf", chunkIndex: 0, similarity: 0.5, pageNumber: 3 },
+      { fileName: "a.pdf", chunkIndex: 1, similarity: 0.95, pageNumber: 3 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.similarity).toBe(0.95);
+  });
+
+  it("treats missing pageNumber as its own key, distinct from a numbered page", () => {
+    const result = dedupeSourcesByFileName([
+      { fileName: "a.pdf", chunkIndex: 0, similarity: 0.5 },
+      { fileName: "a.pdf", chunkIndex: 1, similarity: 0.6, pageNumber: 2 },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns the input untouched when empty", () => {
+    expect(dedupeSourcesByFileName([])).toEqual([]);
+  });
+});
+
+describe("describeSource", () => {
+  it("strips the Web: prefix and flags web sources", () => {
+    expect(describeSource({ fileName: "Web: example.edu" })).toEqual({
+      isWeb: true,
+      label: "example.edu",
+    });
+  });
+
+  it("returns file sources as-is", () => {
+    expect(describeSource({ fileName: "syllabus.pdf" })).toEqual({
+      isWeb: false,
+      label: "syllabus.pdf",
+    });
+  });
+});

--- a/apps/web/src/__tests__/server/chat-helpers.test.ts
+++ b/apps/web/src/__tests__/server/chat-helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "@jest/globals";
+import { clampMaxTokens, describeToolActivity } from "@/server/chat-helpers";
+
+describe("clampMaxTokens", () => {
+  it("returns the default for null/undefined/NaN", () => {
+    expect(clampMaxTokens(null)).toBe(2000);
+    expect(clampMaxTokens(undefined)).toBe(2000);
+    expect(clampMaxTokens(NaN)).toBe(2000);
+  });
+  it("clamps below the minimum up to 100", () => {
+    expect(clampMaxTokens(0)).toBe(100);
+    expect(clampMaxTokens(50)).toBe(100);
+  });
+  it("clamps above the maximum down to 4000", () => {
+    expect(clampMaxTokens(10000)).toBe(4000);
+  });
+  it("passes through values in range", () => {
+    expect(clampMaxTokens(1500)).toBe(1500);
+  });
+});
+
+describe("describeToolActivity", () => {
+  it("includes the user query for search_documents", () => {
+    expect(describeToolActivity("search_documents", { query: "Berlin" })).toBe(
+      "Searching documents for “Berlin”",
+    );
+  });
+  it("falls back to a generic search label when query is missing/empty", () => {
+    expect(describeToolActivity("search_documents", {})).toBe(
+      "Searching documents…",
+    );
+    expect(describeToolActivity("search_documents", { query: "" })).toBe(
+      "Searching documents…",
+    );
+  });
+  it("labels page and neighbor lookups", () => {
+    expect(describeToolActivity("get_page", { pageNumber: 14 })).toBe(
+      "Reading page 14…",
+    );
+    expect(describeToolActivity("get_context_around", {})).toBe(
+      "Reading surrounding context…",
+    );
+    expect(describeToolActivity("list_documents", {})).toBe(
+      "Looking through your documents…",
+    );
+  });
+  it("never throws on missing input and uses a generic fallback", () => {
+    expect(describeToolActivity("done", undefined)).toBe("Working…");
+    expect(describeToolActivity("unknown_tool", null)).toBe("Working…");
+  });
+});

--- a/apps/web/src/__tests__/server/hybrid-search-helpers.test.ts
+++ b/apps/web/src/__tests__/server/hybrid-search-helpers.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "@jest/globals";
+import { hasQuotedPhrase } from "@/server/hybrid-search";
+
+describe("hasQuotedPhrase", () => {
+  it("detects a quoted phrase (triggers FTS boost)", () => {
+    expect(hasQuotedPhrase('did it mention "the Berlin airlift"?')).toBe(true);
+  });
+  it("is false for unquoted queries", () => {
+    expect(hasQuotedPhrase("does it mention the berlin airlift")).toBe(false);
+  });
+  it("ignores empty quotes", () => {
+    expect(hasQuotedPhrase('an empty "" pair')).toBe(false);
+  });
+});

--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -26,6 +26,7 @@ export default function SharedChatPage() {
     setCurrentMessage,
     isStreaming,
     isThinking,
+    statusLabel,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -83,6 +84,7 @@ export default function SharedChatPage() {
             messages={messages}
             isStreaming={isStreaming}
             isThinking={isThinking}
+            statusLabel={statusLabel}
             streamingContent={streamingContent}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -71,6 +71,7 @@ export default function ChatbotDetailPage() {
     setCurrentMessage,
     isStreaming,
     isThinking,
+    statusLabel,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -215,6 +216,7 @@ export default function ChatbotDetailPage() {
                 messages={messages}
                 isStreaming={isStreaming}
                 isThinking={isThinking}
+                statusLabel={statusLabel}
                 streamingContent={streamingContent}
                 currentMessage={currentMessage}
                 setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/app/embed/[shareToken]/window/page.tsx
+++ b/apps/web/src/app/embed/[shareToken]/window/page.tsx
@@ -22,6 +22,7 @@ export default function EmbedWindowPage() {
     setCurrentMessage,
     isStreaming,
     isThinking,
+    statusLabel,
     streamingContent,
     messagesEndRef,
     chatbot,
@@ -71,6 +72,7 @@ export default function EmbedWindowPage() {
             messages={messages}
             isStreaming={isStreaming}
             isThinking={isThinking}
+            statusLabel={statusLabel}
             streamingContent={streamingContent}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -15,6 +15,7 @@ interface ChatInterfaceProps {
   messages: MessageType[];
   isStreaming: boolean;
   isThinking?: boolean;
+  statusLabel?: string | null;
   streamingContent: string;
   currentMessage: string;
   setCurrentMessage: (message: string) => void;
@@ -35,6 +36,7 @@ export function ChatInterface({
   messages,
   isStreaming,
   isThinking = false,
+  statusLabel = null,
   streamingContent,
   currentMessage,
   setCurrentMessage,
@@ -136,6 +138,7 @@ export function ChatInterface({
                   <StreamingMessage
                     content={streamingContent}
                     isThinking={isThinking}
+                    statusLabel={statusLabel}
                   />
                 )}
               </div>

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -147,11 +147,13 @@ export function ChatMessage({
 interface StreamingMessageProps {
   content: string;
   isThinking?: boolean;
+  statusLabel?: string | null;
 }
 
 export function StreamingMessage({
   content,
   isThinking = false,
+  statusLabel = null,
 }: StreamingMessageProps) {
   const hasContent = content && content.trim().length > 0;
 
@@ -176,7 +178,7 @@ export function StreamingMessage({
               {isThinking && (
                 <div className="mt-1.5 md:mt-2 flex items-center gap-2 text-xs text-muted-foreground italic">
                   <TypingLoader size="sm" className="opacity-60" />
-                  <span>Thinking…</span>
+                  <span>{statusLabel ?? "Thinking…"}</span>
                 </div>
               )}
             </div>
@@ -204,7 +206,7 @@ export function StreamingMessage({
             {isThinking ? (
               <div className="flex items-center gap-2 text-xs text-muted-foreground italic">
                 <TypingLoader size="sm" className="opacity-60" />
-                <span>Thinking…</span>
+                <span>{statusLabel ?? "Thinking…"}</span>
               </div>
             ) : (
               <TypingLoader size="md" className="opacity-60" />

--- a/apps/web/src/components/chat/settings/ChatbotSettings.tsx
+++ b/apps/web/src/components/chat/settings/ChatbotSettings.tsx
@@ -23,6 +23,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import {
   MODEL_REGISTRY,
+  toolCapableModels,
   type SupportedModel,
   formatContextWindow,
 } from "@teachanything/ai/models";
@@ -34,13 +35,15 @@ import {
   VALIDATION_LIMITS,
 } from "@/lib/validation";
 
-// Group models by provider for the dropdown. Map preserves MODEL_REGISTRY insertion order.
-const modelsByProvider = Object.values(MODEL_REGISTRY).reduce((acc, model) => {
+// Group tool-capable models by provider for the dropdown. Agentic retrieval
+// requires tool calling, so non-tool models are not offered. Map preserves
+// MODEL_REGISTRY insertion order.
+const modelsByProvider = toolCapableModels().reduce((acc, model) => {
   const group = acc.get(model.provider) ?? [];
   group.push(model);
   acc.set(model.provider, group);
   return acc;
-}, new Map<string, (typeof MODEL_REGISTRY)[keyof typeof MODEL_REGISTRY][]>());
+}, new Map<string, ReturnType<typeof toolCapableModels>>());
 
 interface ChatbotSettingsProps {
   chatbot: {
@@ -77,6 +80,13 @@ export function ChatbotSettings({ chatbot }: ChatbotSettingsProps) {
     chatbot.maxTokens?.toString() ?? "2000",
   );
   const [showSources, setShowSources] = useState(chatbot.showSources ?? false);
+
+  // A legacy chatbot may be saved on a model that no longer supports document
+  // tools. When that happens we still render it as a selectable option so the
+  // form stays valid and editing does not silently change the saved model.
+  const savedModelIsNonTool =
+    !!model &&
+    !MODEL_REGISTRY[model as keyof typeof MODEL_REGISTRY]?.supportsTools;
 
   // Sync editable fields from server only when not actively editing
   useEffect(() => {
@@ -407,6 +417,16 @@ export function ChatbotSettings({ chatbot }: ChatbotSettingsProps) {
                       ))}
                     </SelectGroup>
                   ),
+                )}
+                {/* Legacy chatbots may have a saved model that no longer
+                    supports document tools. Keep it selectable so editing
+                    other fields does not silently change the saved model. */}
+                {savedModelIsNonTool && (
+                  <SelectItem value={model}>
+                    {MODEL_REGISTRY[model as keyof typeof MODEL_REGISTRY]
+                      ?.displayName ?? model}{" "}
+                    (no document tools)
+                  </SelectItem>
                 )}
               </SelectContent>
             </Select>

--- a/apps/web/src/components/chatbot/ConversationsTab.tsx
+++ b/apps/web/src/components/chatbot/ConversationsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Card,
   CardContent,
@@ -22,7 +22,18 @@ import {
 } from "@/components/ui/select";
 import { trpc, type RouterOutputs } from "@/lib/trpc";
 import { keepPreviousData } from "@tanstack/react-query";
-import { MessageSquare, Search, ArrowLeft, Clock } from "lucide-react";
+import { MessageSquare, Search, ArrowLeft, Clock, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { logError } from "@/lib/logger";
 import { formatDuration, formatTimestamp } from "@/lib/conversation-format";
 
@@ -70,17 +81,21 @@ export function ConversationsTab({ chatbotId }: ConversationsTabProps) {
   const [sortBy, setSortBy] = useState<SortBy>("recent");
   const [offset, setOffset] = useState(0);
   const [limit, setLimit] = useState(MIN_LIMIT);
-  const resultsRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
 
   // Measure the results area and fit as many rows as will fit so the panel
-  // doesn't leave whitespace. Re-runs when the viewport resizes. On resize,
-  // snap offset to the new page boundary that still contains the current
-  // top row instead of kicking the user back to page 1.
-  useLayoutEffect(() => {
-    const el = resultsRef.current;
+  // doesn't leave whitespace. A callback ref (not useLayoutEffect+useRef) is
+  // used so measurement re-attaches every time the list view re-mounts -- e.g.
+  // after returning from a conversation detail. The old approach left a stale
+  // ResizeObserver bound to the detached node, which fired with height 0 and
+  // reset the page size to the minimum (the "10 -> 5 after going back" bug).
+  const setResultsRef = useCallback((el: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
     if (!el) return;
     const update = () => {
       const rows = Math.floor(el.clientHeight / ROW_HEIGHT_PX);
+      if (rows <= 0) return; // ignore detached/zero-height measurements
       const clamped = Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, rows));
       setLimit((prev) => {
         if (prev === clamped) return prev;
@@ -91,7 +106,7 @@ export function ConversationsTab({ chatbotId }: ConversationsTabProps) {
     update();
     const observer = new ResizeObserver(update);
     observer.observe(el);
-    return () => observer.disconnect();
+    observerRef.current = observer;
   }, []);
 
   // Reset pagination when the effective query or sort changes.
@@ -150,7 +165,7 @@ export function ConversationsTab({ chatbotId }: ConversationsTabProps) {
           </Select>
         </div>
 
-        <div ref={resultsRef} className="flex flex-1 min-h-0 flex-col">
+        <div ref={setResultsRef} className="flex flex-1 min-h-0 flex-col">
           <ConversationsResults
             chatbotId={chatbotId}
             search={debouncedSearch}
@@ -260,6 +275,7 @@ function ConversationsResults({
 
   return (
     <ConversationListView
+      chatbotId={chatbotId}
       conversations={data.conversations}
       totalCount={data.totalCount}
       limit={limit}
@@ -271,6 +287,7 @@ function ConversationsResults({
 }
 
 function ConversationListView({
+  chatbotId,
   conversations,
   totalCount,
   limit,
@@ -278,6 +295,7 @@ function ConversationListView({
   onSelectConversation,
   onOffsetChange,
 }: {
+  chatbotId: string;
   conversations: ConversationRow[];
   totalCount: number;
   limit: number;
@@ -285,39 +303,174 @@ function ConversationListView({
   onSelectConversation: (id: string) => void;
   onOffsetChange: (offset: number) => void;
 }) {
+  const utils = trpc.useUtils();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Pending delete: a specific list of ids (single trash or bulk). null = closed.
+  const [pendingIds, setPendingIds] = useState<string[] | null>(null);
+
+  const deleteMutation = trpc.analytics.deleteConversations.useMutation({
+    onSuccess: async ({ deletedCount }) => {
+      toast.success(
+        `Deleted ${deletedCount} chat${deletedCount !== 1 ? "s" : ""}`,
+      );
+      setSelected(new Set());
+      setPendingIds(null);
+      // If the current page may now be empty, step back to the previous one.
+      if (offset > 0 && deletedCount >= conversations.length) {
+        onOffsetChange(Math.max(0, offset - limit));
+      }
+      await Promise.all([
+        utils.analytics.getConversationsList.invalidate({ chatbotId }),
+        utils.analytics.searchConversations.invalidate({ chatbotId }),
+      ]);
+    },
+    onError: (err) => {
+      logError(err, "[conversations] delete failed", { chatbotId });
+      toast.error("Failed to delete. Please try again.");
+      setPendingIds(null);
+    },
+  });
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const allVisibleSelected =
+    conversations.length > 0 && conversations.every((c) => selected.has(c.id));
+
+  const toggleAllVisible = () =>
+    setSelected((prev) => {
+      if (allVisibleSelected) {
+        const next = new Set(prev);
+        conversations.forEach((c) => next.delete(c.id));
+        return next;
+      }
+      return new Set([...prev, ...conversations.map((c) => c.id)]);
+    });
+
   return (
     <div className="flex flex-1 min-h-0 flex-col gap-2">
+      {/* Selection toolbar */}
+      <div className="flex items-center justify-between gap-2 px-1 shrink-0 h-7">
+        <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+          <input
+            type="checkbox"
+            className="h-3.5 w-3.5 cursor-pointer accent-primary"
+            checked={allVisibleSelected}
+            onChange={toggleAllVisible}
+            aria-label="Select all on this page"
+          />
+          {selected.size > 0 ? `${selected.size} selected` : "Select all"}
+        </label>
+        {selected.size > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-destructive hover:text-destructive"
+            onClick={() => setPendingIds([...selected])}
+          >
+            <Trash2 className="h-3.5 w-3.5 mr-1" />
+            Delete selected
+          </Button>
+        )}
+      </div>
       <div className="flex-1 min-h-0 overflow-y-auto divide-y rounded-lg border">
         {conversations.map((conversation) => (
-          <button
+          <div
             key={conversation.id}
-            type="button"
-            onClick={() => onSelectConversation(conversation.id)}
-            className="flex items-center justify-between w-full px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+            className="flex items-center gap-2 px-4 py-3 hover:bg-muted/50 transition-colors"
           >
-            <div className="min-w-0 flex-1 mr-3">
-              <p className="text-sm font-medium truncate">
-                {conversation.preview || "No messages"}
-              </p>
-              <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <MessageSquare className="h-3 w-3" />
-                  {conversation.messageCount} message
-                  {conversation.messageCount !== 1 ? "s" : ""}
-                </span>
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {formatDuration(
-                    conversation.firstMessageAt,
-                    conversation.lastMessageAt,
-                  )}
-                </span>
-                <span>{formatTimestamp(conversation.createdAt)}</span>
+            <input
+              type="checkbox"
+              className="h-4 w-4 shrink-0 cursor-pointer accent-primary"
+              checked={selected.has(conversation.id)}
+              onChange={() => toggle(conversation.id)}
+              aria-label="Select chat"
+            />
+            <button
+              type="button"
+              onClick={() => onSelectConversation(conversation.id)}
+              className="flex items-center justify-between min-w-0 flex-1 text-left"
+            >
+              <div className="min-w-0 flex-1 mr-3">
+                <p className="text-sm font-medium truncate">
+                  {conversation.preview || "No messages"}
+                </p>
+                <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <MessageSquare className="h-3 w-3" />
+                    {conversation.messageCount} message
+                    {conversation.messageCount !== 1 ? "s" : ""}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {formatDuration(
+                      conversation.firstMessageAt,
+                      conversation.lastMessageAt,
+                    )}
+                  </span>
+                  <span>{formatTimestamp(conversation.createdAt)}</span>
+                </div>
               </div>
-            </div>
-          </button>
+            </button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => setPendingIds([conversation.id])}
+              aria-label="Delete chat"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
         ))}
       </div>
+
+      <AlertDialog
+        open={pendingIds !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingIds(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {pendingIds?.length ?? 0} chat
+              {(pendingIds?.length ?? 0) !== 1 ? "s" : ""}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the selected student chat
+              {(pendingIds?.length ?? 0) !== 1 ? "s" : ""} and all their
+              messages. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteMutation.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                if (pendingIds && pendingIds.length > 0) {
+                  deleteMutation.mutate({
+                    chatbotId,
+                    conversationIds: pendingIds,
+                  });
+                }
+              }}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {totalCount > limit && (
         <div className="flex items-center justify-between px-1 shrink-0">
           <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/chatbot/ConversationsTab.tsx
+++ b/apps/web/src/components/chatbot/ConversationsTab.tsx
@@ -354,80 +354,83 @@ function ConversationListView({
 
   return (
     <div className="flex flex-1 min-h-0 flex-col gap-2">
-      {/* Selection toolbar */}
-      <div className="flex items-center justify-between gap-2 px-1 shrink-0 h-7">
-        <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
-          <input
-            type="checkbox"
-            className="h-3.5 w-3.5 cursor-pointer accent-primary"
-            checked={allVisibleSelected}
-            onChange={toggleAllVisible}
-            aria-label="Select all on this page"
-          />
-          {selected.size > 0 ? `${selected.size} selected` : "Select all"}
-        </label>
-        {selected.size > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-destructive hover:text-destructive"
-            onClick={() => setPendingIds([...selected])}
-          >
-            <Trash2 className="h-3.5 w-3.5 mr-1" />
-            Delete selected
-          </Button>
-        )}
-      </div>
-      <div className="flex-1 min-h-0 overflow-y-auto divide-y rounded-lg border">
-        {conversations.map((conversation) => (
-          <div
-            key={conversation.id}
-            className="flex items-center gap-2 px-4 py-3 hover:bg-muted/50 transition-colors"
-          >
+      <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border">
+        {/* Sticky selection header — px-4 + h-4 checkbox so it lines up
+            exactly above the per-row checkboxes. */}
+        <div className="sticky top-0 z-10 flex items-center justify-between gap-2 px-4 py-2 bg-background border-b">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
             <input
               type="checkbox"
-              className="h-4 w-4 shrink-0 cursor-pointer accent-primary"
-              checked={selected.has(conversation.id)}
-              onChange={() => toggle(conversation.id)}
-              aria-label="Select chat"
+              className="h-4 w-4 cursor-pointer accent-primary"
+              checked={allVisibleSelected}
+              onChange={toggleAllVisible}
+              aria-label="Select all on this page"
             />
-            <button
-              type="button"
-              onClick={() => onSelectConversation(conversation.id)}
-              className="flex items-center justify-between min-w-0 flex-1 text-left"
-            >
-              <div className="min-w-0 flex-1 mr-3">
-                <p className="text-sm font-medium truncate">
-                  {conversation.preview || "No messages"}
-                </p>
-                <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                  <span className="flex items-center gap-1">
-                    <MessageSquare className="h-3 w-3" />
-                    {conversation.messageCount} message
-                    {conversation.messageCount !== 1 ? "s" : ""}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <Clock className="h-3 w-3" />
-                    {formatDuration(
-                      conversation.firstMessageAt,
-                      conversation.lastMessageAt,
-                    )}
-                  </span>
-                  <span>{formatTimestamp(conversation.createdAt)}</span>
-                </div>
-              </div>
-            </button>
+            {selected.size > 0 ? `${selected.size} selected` : "Select all"}
+          </label>
+          {selected.size > 0 && (
             <Button
               variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-              onClick={() => setPendingIds([conversation.id])}
-              aria-label="Delete chat"
+              size="sm"
+              className="h-7 text-destructive hover:text-destructive"
+              onClick={() => setPendingIds([...selected])}
             >
-              <Trash2 className="h-4 w-4" />
+              <Trash2 className="h-3.5 w-3.5 mr-1" />
+              Delete selected
             </Button>
-          </div>
-        ))}
+          )}
+        </div>
+        <div className="divide-y">
+          {conversations.map((conversation) => (
+            <div
+              key={conversation.id}
+              className="flex items-center gap-2 px-4 py-3 hover:bg-muted/50 transition-colors"
+            >
+              <input
+                type="checkbox"
+                className="h-4 w-4 shrink-0 cursor-pointer accent-primary"
+                checked={selected.has(conversation.id)}
+                onChange={() => toggle(conversation.id)}
+                aria-label="Select chat"
+              />
+              <button
+                type="button"
+                onClick={() => onSelectConversation(conversation.id)}
+                className="flex items-center justify-between min-w-0 flex-1 text-left"
+              >
+                <div className="min-w-0 flex-1 mr-3">
+                  <p className="text-sm font-medium truncate">
+                    {conversation.preview || "No messages"}
+                  </p>
+                  <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <MessageSquare className="h-3 w-3" />
+                      {conversation.messageCount} message
+                      {conversation.messageCount !== 1 ? "s" : ""}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {formatDuration(
+                        conversation.firstMessageAt,
+                        conversation.lastMessageAt,
+                      )}
+                    </span>
+                    <span>{formatTimestamp(conversation.createdAt)}</span>
+                  </div>
+                </div>
+              </button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                onClick={() => setPendingIds([conversation.id])}
+                aria-label="Delete chat"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
       </div>
 
       <AlertDialog

--- a/apps/web/src/components/chatbot/ConversationsTab.tsx
+++ b/apps/web/src/components/chatbot/ConversationsTab.tsx
@@ -357,7 +357,7 @@ function ConversationListView({
       <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border">
         {/* Sticky selection header — px-4 + h-4 checkbox so it lines up
             exactly above the per-row checkboxes. */}
-        <div className="sticky top-0 z-10 flex items-center justify-between gap-2 px-4 py-2 bg-background border-b">
+        <div className="sticky top-0 z-10 flex h-11 items-center justify-between gap-2 px-4 bg-background border-b">
           <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
             <input
               type="checkbox"
@@ -384,11 +384,11 @@ function ConversationListView({
           {conversations.map((conversation) => (
             <div
               key={conversation.id}
-              className="flex items-center gap-2 px-4 py-3 hover:bg-muted/50 transition-colors"
+              className="flex items-start gap-2 px-4 py-3 hover:bg-muted/50 transition-colors"
             >
               <input
                 type="checkbox"
-                className="h-4 w-4 shrink-0 cursor-pointer accent-primary"
+                className="h-4 w-4 mt-0.5 shrink-0 cursor-pointer accent-primary"
                 checked={selected.has(conversation.id)}
                 onChange={() => toggle(conversation.id)}
                 aria-label="Select chat"
@@ -422,7 +422,7 @@ function ConversationListView({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                className="h-8 w-8 shrink-0 self-center text-muted-foreground hover:text-destructive"
                 onClick={() => setPendingIds([conversation.id])}
                 aria-label="Delete chat"
               >

--- a/apps/web/src/components/dashboard/chatbots/chatbot-constants.ts
+++ b/apps/web/src/components/dashboard/chatbots/chatbot-constants.ts
@@ -1,6 +1,11 @@
-import { MODEL_REGISTRY, type SupportedModel } from "@teachanything/ai/models";
+import {
+  toolCapableModels,
+  type SupportedModel,
+} from "@teachanything/ai/models";
 
-export const MODELS = Object.values(MODEL_REGISTRY).map((m) => ({
+// Agentic retrieval requires tool calling, so only tool-capable models are
+// offered when creating a chatbot.
+export const MODELS = toolCapableModels().map((m) => ({
   value: m.id as SupportedModel,
   label: m.displayName,
 }));

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -116,7 +116,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -39,7 +39,7 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-pointer items-center justify-center py-1",
       className,
     )}
     {...props}
@@ -56,7 +56,7 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-pointer items-center justify-center py-1",
       className,
     )}
     {...props}
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ui/source-badge.tsx
+++ b/apps/web/src/components/ui/source-badge.tsx
@@ -17,6 +17,11 @@ export function SourceBadge({
   className = "text-xs",
 }: SourceBadgeProps) {
   const { isWeb, label } = describeSource(source);
+  // Web sources have no page concept; only file sources get a page suffix.
+  const displayLabel =
+    !isWeb && source.pageNumber != null
+      ? `${label} · p.${source.pageNumber}`
+      : label;
   return (
     <Badge
       variant={variant}
@@ -32,7 +37,7 @@ export function SourceBadge({
       ) : (
         <FileText className="h-3 w-3 mr-1" />
       )}
-      {label}
+      {displayLabel}
     </Badge>
   );
 }

--- a/apps/web/src/components/ui/source-badge.tsx
+++ b/apps/web/src/components/ui/source-badge.tsx
@@ -20,7 +20,7 @@ export function SourceBadge({
   // Web sources have no page concept; only file sources get a page suffix.
   const displayLabel =
     !isWeb && source.pageNumber != null
-      ? `${label} · p.${source.pageNumber}`
+      ? `${label} · Page ${source.pageNumber}`
       : label;
   return (
     <Badge

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -64,6 +64,7 @@ export function useChat(shareToken: string) {
     setCurrentMessage: state.setCurrentMessage,
     isStreaming: state.isStreaming,
     isThinking: state.isThinking,
+    statusLabel: state.statusLabel,
     streamingContent: state.streamingContent,
     messagesEndRef: state.messagesEndRef,
     chatbot,

--- a/apps/web/src/hooks/useChatState.ts
+++ b/apps/web/src/hooks/useChatState.ts
@@ -161,15 +161,19 @@ export function useChatState() {
       setIsThinking(false);
       setStatusLabel(null);
 
-      // Guard: if streaming was already stopped (e.g., user cancelled), skip.
-      // Uses ref (not state) to avoid stale closure issues in subscription callbacks.
-      if (!streamingContentRef.current) return;
-
       const finalContent = streamingContentRef.current;
       const finalSources = [...sourcesRef.current];
 
+      // Always tear down the streaming UI on done -- even for an empty turn --
+      // so the loader never gets stuck. Only commit an assistant message when the
+      // model actually produced text: the model decides its own wording (the
+      // server falls back through the static RAG path), so a genuinely empty
+      // turn shows no bubble rather than a fabricated reply.
       updateStreamingContent("");
       setIsStreaming(false);
+      sourcesRef.current = [];
+
+      if (!finalContent) return;
 
       setMessages((prev) => [
         ...prev,
@@ -180,8 +184,6 @@ export function useChatState() {
           truncated: data.truncated || undefined,
         },
       ]);
-
-      sourcesRef.current = [];
     }
   };
 

--- a/apps/web/src/hooks/useChatState.ts
+++ b/apps/web/src/hooks/useChatState.ts
@@ -6,12 +6,14 @@ type StreamSource = {
   fileName: string;
   chunkIndex: number;
   similarity: number;
+  pageNumber?: number | null;
 };
 
 type StreamData =
   | { type: "metadata"; sessionId?: string; sources?: StreamSource[] }
   | { type: "text"; content: string }
   | { type: "thinking" }
+  | { type: "status"; label: string }
   | { type: "done"; truncated?: boolean; responseTime?: number };
 
 /**
@@ -28,6 +30,7 @@ export function useChatState() {
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState("");
   const [isThinking, setIsThinking] = useState(false);
+  const [statusLabel, setStatusLabel] = useState<string | null>(null);
   const streamingContentRef = useRef("");
   // Set when the user cancels mid-stream. Gates handleStreamData so any
   // chunks that arrive after cancellation don't resurrect the streaming UI.
@@ -45,7 +48,12 @@ export function useChatState() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const sourcesRef = useRef<
-    Array<{ fileName: string; chunkIndex: number; similarity: number }>
+    Array<{
+      fileName: string;
+      chunkIndex: number;
+      similarity: number;
+      pageNumber?: number | null;
+    }>
   >([]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -88,6 +96,7 @@ export function useChatState() {
     setSessionId("");
     setIsStreaming(false);
     setIsThinking(false);
+    setStatusLabel(null);
     setStreamingContent("");
     streamingContentRef.current = "";
     cancelledRef.current = false;
@@ -104,6 +113,7 @@ export function useChatState() {
     updateStreamingContent("");
     setIsStreaming(false);
     setIsThinking(false);
+    setStatusLabel(null);
     sourcesRef.current = [];
 
     setMessages((prev) => [
@@ -134,14 +144,22 @@ export function useChatState() {
       // First text chunk ends the thinking phase. React bails on identical
       // state so we call unconditionally to avoid a stale-closure trap.
       setIsThinking(false);
+      // The answer has started -- clear any tool-activity status line.
+      setStatusLabel(null);
       updateStreamingContent((prev) => prev + data.content);
     } else if (data.type === "thinking") {
       // Model is in a reasoning phase. Flip the indicator so the UI doesn't
       // look frozen during long pauses.
       setIsThinking(true);
+    } else if (data.type === "status") {
+      // Agentic tool activity (e.g. "Searching documents…"). Surface it as a
+      // richer thinking indicator while the model retrieves.
+      setStatusLabel(data.label);
+      setIsThinking(true);
     } else if (data.type === "done") {
       clearStreamingTimeout();
       setIsThinking(false);
+      setStatusLabel(null);
 
       // Guard: if streaming was already stopped (e.g., user cancelled), skip.
       // Uses ref (not state) to avoid stale closure issues in subscription callbacks.
@@ -173,6 +191,7 @@ export function useChatState() {
     toast.error("Failed to send message. Please try again.");
     setIsStreaming(false);
     setIsThinking(false);
+    setStatusLabel(null);
 
     // Preserve any partial content already received so the user can see what
     // the model produced before the stream failed. Prior behavior dropped it.
@@ -199,6 +218,7 @@ export function useChatState() {
   const startStreaming = () => {
     setIsStreaming(true);
     setIsThinking(false);
+    setStatusLabel(null);
     updateStreamingContent("");
     sourcesRef.current = [];
     cancelledRef.current = false;
@@ -227,6 +247,7 @@ export function useChatState() {
     sessionId,
     isStreaming,
     isThinking,
+    statusLabel,
     streamingContent,
     messagesEndRef,
     // Streaming orchestration

--- a/apps/web/src/hooks/useChatbot.ts
+++ b/apps/web/src/hooks/useChatbot.ts
@@ -61,6 +61,7 @@ export function useChatbot(
     setCurrentMessage: state.setCurrentMessage,
     isStreaming: state.isStreaming,
     isThinking: state.isThinking,
+    statusLabel: state.statusLabel,
     streamingContent: state.streamingContent,
     messagesEndRef: state.messagesEndRef,
     chatbot,

--- a/apps/web/src/lib/file-processor.ts
+++ b/apps/web/src/lib/file-processor.ts
@@ -11,6 +11,13 @@ import { logInfo, logError } from "./logger";
 const EXTRACTION_TIMEOUT_MS = 60_000;
 
 /**
+ * Bump when ingestion logic changes (chunking, page metadata, etc.). Files with
+ * userFiles.metadata.processingVersion < this are reprocessed lazily on access.
+ * v1 = pre-page flat chunks @2500; v2 = page-aware @1000 with pageNumber.
+ */
+export const CURRENT_PROCESSING_VERSION = 2;
+
+/**
  * Sanitize error messages before storing in metadata visible to users.
  * Prevents internal details (hostnames, connection strings, API keys) from leaking.
  */
@@ -204,8 +211,8 @@ export async function processFile(params: {
     // Stage 2: Extract text content (10-30%)
     await updateProgress(fileId, "extracting", 10);
     const ragService = createRAGService();
-    const content = await withTimeout(
-      ragService.extractContent(buffer, file.fileType),
+    const pagedChunks = await withTimeout(
+      ragService.extractAndChunk(buffer, file.fileType),
       EXTRACTION_TIMEOUT_MS,
       `File extraction timed out after ${EXTRACTION_TIMEOUT_MS / 1000}s`,
     );
@@ -213,8 +220,8 @@ export async function processFile(params: {
 
     // Stage 3: Chunk text (30-40%)
     await updateProgress(fileId, "chunking", 30);
-    const chunks = await ragService.chunkText(content);
-    await updateProgress(fileId, "chunking", 40, 0, chunks.length);
+    const chunks = pagedChunks.map((c) => c.content);
+    await updateProgress(fileId, "chunking", 40, 0, pagedChunks.length);
 
     // Stage 4: Generate embeddings (40-90%)
     // This is the slowest part, so batch process and report progress
@@ -296,6 +303,10 @@ export async function processFile(params: {
           content: chunk,
           embedding,
           tokenCount: await ragService.countTokens(chunk),
+          metadata:
+            pagedChunks[index]?.pageNumber != null
+              ? { pageNumber: pagedChunks[index]!.pageNumber }
+              : {},
         };
       }),
     );
@@ -311,6 +322,7 @@ export async function processFile(params: {
         metadata: {
           chunkCount: chunks.length,
           processedAt: new Date().toISOString(),
+          processingVersion: CURRENT_PROCESSING_VERSION,
           processingProgress: {
             stage: "storing",
             percentage: 100,

--- a/apps/web/src/lib/message-sources.ts
+++ b/apps/web/src/lib/message-sources.ts
@@ -7,21 +7,28 @@ export type SourceCitation = {
   fileName: string;
   chunkIndex: number;
   similarity: number;
+  pageNumber?: number | null;
 };
 
 /**
- * Dedupe citations by fileName, keeping the highest-similarity chunk per
- * file. O(n) via Map. Mirrors the historical behavior of ChatMessage.tsx.
+ * Dedupe citations by fileName + pageNumber, keeping the highest-similarity
+ * chunk per (file, page). O(n) via Map. The same file cited on different pages
+ * yields separate badges; chunks without a page collapse under one key.
  */
 export function dedupeSourcesByFileName<
-  T extends { fileName: string; similarity: number },
+  T extends {
+    fileName: string;
+    similarity: number;
+    pageNumber?: number | null;
+  },
 >(sources: T[]): T[] {
   if (sources.length === 0) return sources;
   const best = new Map<string, T>();
   for (const s of sources) {
-    const existing = best.get(s.fileName);
+    const key = `${s.fileName}::${s.pageNumber ?? ""}`;
+    const existing = best.get(key);
     if (!existing || s.similarity > existing.similarity) {
-      best.set(s.fileName, s);
+      best.set(key, s);
     }
   }
   return [...best.values()];

--- a/apps/web/src/server/__tests__/retrieval-tools.test.ts
+++ b/apps/web/src/server/__tests__/retrieval-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "@jest/globals";
 import { reciprocalRankFusion } from "@teachanything/ai/rrf";
+import {
+  searchDocumentsInput,
+  getPageInput,
+  getContextAroundInput,
+} from "../retrieval-tool-schemas";
 
 // Regression for issue #271: a close-reading detail question must surface the
 // exact-answer chunk even when dense vector search under-ranks it (semantic
@@ -23,5 +28,29 @@ describe("close-reading adjacency retrieval (fusion level)", () => {
     expect(fused[0]).toBe("chunkN");
     // The setup chunk is retrieved alongside the answer for adjacent context.
     expect(fused.slice(0, 3)).toContain("chunkN-1");
+  });
+});
+
+describe("retrieval tool input schemas", () => {
+  it("search_documents requires a query", () => {
+    expect(searchDocumentsInput.safeParse({}).success).toBe(false);
+    expect(searchDocumentsInput.safeParse({ query: "x" }).success).toBe(true);
+  });
+  it("get_page requires fileId + pageNumber", () => {
+    expect(getPageInput.safeParse({ fileId: "f" }).success).toBe(false);
+    expect(
+      getPageInput.safeParse({
+        fileId: "550e8400-e29b-41d4-a716-446655440000",
+        pageNumber: 3,
+      }).success,
+    ).toBe(true);
+  });
+  it("get_context_around requires fileId + chunkIndex", () => {
+    expect(
+      getContextAroundInput.safeParse({
+        fileId: "550e8400-e29b-41d4-a716-446655440000",
+        chunkIndex: 0,
+      }).success,
+    ).toBe(true);
   });
 });

--- a/apps/web/src/server/__tests__/retrieval-tools.test.ts
+++ b/apps/web/src/server/__tests__/retrieval-tools.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "@jest/globals";
+import { reciprocalRankFusion } from "@teachanything/ai/rrf";
+
+// Regression for issue #271: a close-reading detail question must surface the
+// exact-answer chunk even when dense vector search under-ranks it (semantic
+// dilution), because lexical (FTS + trigram) signals rank it highly. The setup
+// chunk (N-1) should also be retrieved for adjacent context.
+describe("close-reading adjacency retrieval (fusion level)", () => {
+  it("surfaces the exact-answer chunk even when vector under-ranks it", () => {
+    const vector = ["chunkN-1", "chunkX", "chunkY", "chunkN"]; // answer (N) ranked 4th
+    const fts = ["chunkN", "chunkN-1"]; // exact term -> N ranked 1st
+    const trgm = ["chunkN"]; // exact substring -> N ranked 1st
+
+    const fused = reciprocalRankFusion(
+      [
+        { items: vector, weight: 1 },
+        { items: fts, weight: 2 }, // quoted-phrase boost
+        { items: trgm, weight: 1 },
+      ],
+      { k: 60 },
+    );
+
+    expect(fused[0]).toBe("chunkN");
+    // The setup chunk is retrieved alongside the answer for adjacent context.
+    expect(fused.slice(0, 3)).toContain("chunkN-1");
+  });
+});

--- a/apps/web/src/server/chat-helpers.ts
+++ b/apps/web/src/server/chat-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure, dependency-free helpers for the chat router. Kept in their own module
+ * so they can be unit-tested without importing the streaming / AI-SDK chain
+ * that `chat.ts` pulls in.
+ */
+
+/** Clamp a requested max output token count to the supported range (100-4000). */
+export function clampMaxTokens(maxTokens: number | null | undefined): number {
+  const MIN_TOKENS = 100;
+  const MAX_TOKENS = 4000;
+  const DEFAULT_TOKENS = 2000;
+
+  if (maxTokens == null || isNaN(maxTokens)) {
+    return DEFAULT_TOKENS;
+  }
+
+  return Math.max(MIN_TOKENS, Math.min(MAX_TOKENS, maxTokens));
+}
+
+/**
+ * Map an agentic retrieval tool-call to a human-readable status label shown in
+ * the live status line while the model works. Only the action + the
+ * user-derived query are surfaced -- never tool RESULT content (which could
+ * contain document text on public shared bots).
+ */
+export function describeToolActivity(toolName: string, input: unknown): string {
+  const args = (input ?? {}) as {
+    query?: unknown;
+    pageNumber?: unknown;
+  };
+  switch (toolName) {
+    case "search_documents":
+      return typeof args.query === "string" && args.query.length > 0
+        ? `Searching documents for “${args.query}”`
+        : "Searching documents…";
+    case "get_page":
+      return `Reading page ${String(args.pageNumber)}…`;
+    case "get_context_around":
+      return "Reading surrounding context…";
+    case "list_documents":
+      return "Looking through your documents…";
+    default:
+      return "Working…";
+  }
+}

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -1,6 +1,6 @@
 import { eq, and, inArray, isNotNull, sql } from "drizzle-orm";
 import { fileChunks, userFiles } from "@teachanything/db/schema";
-import { reciprocalRankFusion } from "@teachanything/ai";
+import { reciprocalRankFusion } from "@teachanything/ai/rrf";
 import type { db as DbType } from "@teachanything/db";
 
 export interface HybridSearchParams {

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -45,7 +45,12 @@ export async function hybridSearch(
   params: HybridSearchParams,
 ): Promise<HybridChunk[]> {
   const { db, query, queryEmbedding, limit } = params;
-  const fileIds = params.fileId ? [params.fileId] : params.fileIds;
+  // Authorization: a single-file request must INTERSECT the chatbot-scoped set,
+  // never replace it. params.fileId originates from a model tool call, so a
+  // hallucinated/foreign UUID must not widen access beyond params.fileIds.
+  const fileIds = params.fileId
+    ? params.fileIds.filter((id) => id === params.fileId)
+    : params.fileIds;
   if (fileIds.length === 0) return [];
 
   const overfetch = Math.min(limit * 2, 60);

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -1,0 +1,138 @@
+import { eq, and, inArray, isNotNull, sql } from "drizzle-orm";
+import { fileChunks, userFiles } from "@teachanything/db/schema";
+import { reciprocalRankFusion } from "@teachanything/ai";
+import type { db as DbType } from "@teachanything/db";
+
+export interface HybridSearchParams {
+  db: typeof DbType;
+  fileIds: string[];
+  query: string;
+  queryEmbedding: number[];
+  limit: number;
+  /** Restrict to a single file (tool fileId arg). */
+  fileId?: string;
+}
+
+export interface HybridChunk {
+  chunkId: string;
+  fileId: string;
+  fileName: string;
+  chunkIndex: number;
+  pageNumber: number | null;
+  content: string;
+  vectorSimilarity: number | null;
+}
+
+/** Returns true when the query contains a "quoted phrase" — boosts FTS weight. */
+function hasQuotedPhrase(query: string): boolean {
+  return /"[^"]+"/.test(query);
+}
+
+/**
+ * Chatbot-scoped triple-fusion search over file chunks.
+ *
+ * Runs three independent retrievers — vector similarity (HNSW), Postgres
+ * full-text (tsvector), and trigram (pg_trgm) — over the same file scope, then
+ * fuses their rankings in TypeScript via Reciprocal Rank Fusion. FTS is weighted
+ * higher when the user quoted an exact phrase.
+ *
+ * MATCHES rag-context.ts vector patterns: cosine `1 - (embedding <=> :json)` in
+ * SELECT, raw distance `embedding <=> :json` in ORDER BY (HNSW index), the
+ * `JSON.stringify(queryEmbedding)` literal, the userFiles join, and the
+ * `processingStatus = 'completed'` + `isNotNull(embedding)` filters.
+ */
+export async function hybridSearch(
+  params: HybridSearchParams,
+): Promise<HybridChunk[]> {
+  const { db, query, queryEmbedding, limit } = params;
+  const fileIds = params.fileId ? [params.fileId] : params.fileIds;
+  if (fileIds.length === 0) return [];
+
+  const overfetch = Math.min(limit * 2, 60);
+  const embeddingLiteral = JSON.stringify(queryEmbedding);
+
+  const baseWhere = and(
+    inArray(fileChunks.fileId, fileIds),
+    eq(userFiles.processingStatus, "completed"),
+    isNotNull(fileChunks.embedding),
+  );
+
+  // 1. Vector candidates (HNSW, distance ascending)
+  const vectorRows = await db
+    .select({
+      chunkId: fileChunks.id,
+      similarity: sql<number>`1 - (${fileChunks.embedding} <=> ${embeddingLiteral})`,
+    })
+    .from(fileChunks)
+    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+    .where(baseWhere)
+    .orderBy(sql`${fileChunks.embedding} <=> ${embeddingLiteral}`)
+    .limit(overfetch);
+
+  // 2. Full-text candidates (websearch_to_tsquery + ts_rank_cd)
+  const ftsRows = await db
+    .select({ chunkId: fileChunks.id })
+    .from(fileChunks)
+    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+    .where(
+      and(
+        baseWhere,
+        sql`to_tsvector('english', ${fileChunks.content}) @@ websearch_to_tsquery('english', ${query})`,
+      ),
+    )
+    .orderBy(
+      sql`ts_rank_cd(to_tsvector('english', ${fileChunks.content}), websearch_to_tsquery('english', ${query})) DESC`,
+    )
+    .limit(overfetch);
+
+  // 3. Trigram candidates (similarity DESC). Uses pg_trgm % operator.
+  const trgmRows = await db
+    .select({ chunkId: fileChunks.id })
+    .from(fileChunks)
+    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+    .where(and(baseWhere, sql`${fileChunks.content} % ${query}`))
+    .orderBy(sql`similarity(${fileChunks.content}, ${query}) DESC`)
+    .limit(overfetch);
+
+  // Fuse via RRF. FTS weighted higher when the user quoted an exact phrase.
+  const ftsWeight = hasQuotedPhrase(query) ? 2 : 1;
+  const fusedIds = reciprocalRankFusion<string>(
+    [
+      { items: vectorRows.map((r) => r.chunkId), weight: 1 },
+      { items: ftsRows.map((r) => r.chunkId), weight: ftsWeight },
+      { items: trgmRows.map((r) => r.chunkId), weight: 1 },
+    ],
+    { k: 60 },
+  ).slice(0, limit);
+
+  if (fusedIds.length === 0) return [];
+
+  const simById = new Map(vectorRows.map((r) => [r.chunkId, r.similarity]));
+  const rows = await db
+    .select({
+      chunkId: fileChunks.id,
+      fileId: fileChunks.fileId,
+      fileName: userFiles.fileName,
+      chunkIndex: fileChunks.chunkIndex,
+      metadata: fileChunks.metadata,
+      content: fileChunks.content,
+    })
+    .from(fileChunks)
+    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+    .where(inArray(fileChunks.id, fusedIds));
+
+  const byId = new Map(rows.map((r) => [r.chunkId, r]));
+  return fusedIds
+    .map((id) => byId.get(id))
+    .filter((r): r is NonNullable<typeof r> => r != null)
+    .map((r) => ({
+      chunkId: r.chunkId,
+      fileId: r.fileId,
+      fileName: r.fileName,
+      chunkIndex: r.chunkIndex,
+      pageNumber:
+        (r.metadata as { pageNumber?: number } | null)?.pageNumber ?? null,
+      content: r.content,
+      vectorSimilarity: simById.get(r.chunkId) ?? null,
+    }));
+}

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -24,7 +24,7 @@ export interface HybridChunk {
 }
 
 /** Returns true when the query contains a "quoted phrase" — boosts FTS weight. */
-function hasQuotedPhrase(query: string): boolean {
+export function hasQuotedPhrase(query: string): boolean {
   return /"[^"]+"/.test(query);
 }
 

--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -33,10 +33,16 @@ export interface RAGContextResult {
     fileName: string;
     chunkIndex: number;
     similarity: number;
+    // Optional: only the agentic retrieval path supplies page numbers. The
+    // static path leaves it undefined so existing consumers keep validating.
+    pageNumber?: number | null;
   }>;
   ragUsed: boolean;
   fileManifest: string;
   ragFailureNote: string;
+  // File IDs the chat router needs to build retrieval tools for the agentic
+  // path. Empty when the chatbot has no completed (enabled) files.
+  fileIds: string[];
 }
 
 /**
@@ -114,6 +120,7 @@ export async function buildRAGContext(
       ragUsed: false,
       fileManifest,
       ragFailureNote: "",
+      fileIds: [],
     };
   }
 
@@ -149,6 +156,7 @@ export async function buildRAGContext(
       ragUsed: false,
       fileManifest,
       ragFailureNote,
+      fileIds,
     };
   }
 
@@ -168,6 +176,7 @@ export async function buildRAGContext(
       ragUsed: false,
       fileManifest,
       ragFailureNote: "",
+      fileIds,
     };
   }
 
@@ -209,6 +218,7 @@ export async function buildRAGContext(
       ragUsed: false,
       fileManifest,
       ragFailureNote: "",
+      fileIds,
     };
   }
 
@@ -250,5 +260,12 @@ export async function buildRAGContext(
   });
 
   // 8. Return result
-  return { contextText, sources, ragUsed, fileManifest, ragFailureNote: "" };
+  return {
+    contextText,
+    sources,
+    ragUsed,
+    fileManifest,
+    ragFailureNote: "",
+    fileIds,
+  };
 }

--- a/apps/web/src/server/reprocess.ts
+++ b/apps/web/src/server/reprocess.ts
@@ -1,0 +1,56 @@
+import { eq, and, or, isNull, sql } from "drizzle-orm";
+import { userFiles, chatbotFileAssociations } from "@teachanything/db/schema";
+import { CURRENT_PROCESSING_VERSION, processFile } from "@/lib/file-processor";
+import { isLocalStorageMode } from "@/lib/local-storage";
+import { publishQStashJob } from "@/lib/qstash";
+import { env } from "@/lib/env";
+import { logError, logInfo } from "@/lib/logger";
+import type { db as DbType } from "@teachanything/db";
+
+/**
+ * Lazily reprocess files ingested under an older processing version so they gain
+ * page-aware chunks + pageNumber metadata (issue #271). Non-blocking and
+ * best-effort: never throws into the chat path.
+ */
+export async function maybeEnqueueReprocess(
+  db: typeof DbType,
+  chatbotId: string,
+): Promise<void> {
+  try {
+    const stale = await db
+      .select({ fileId: userFiles.id })
+      .from(chatbotFileAssociations)
+      .innerJoin(userFiles, eq(chatbotFileAssociations.fileId, userFiles.id))
+      .where(
+        and(
+          eq(chatbotFileAssociations.chatbotId, chatbotId),
+          eq(userFiles.processingStatus, "completed"),
+          or(
+            isNull(sql`${userFiles.metadata} ->> 'processingVersion'`),
+            sql`(${userFiles.metadata} ->> 'processingVersion')::int < ${CURRENT_PROCESSING_VERSION}`,
+          ),
+        ),
+      );
+    if (stale.length === 0) return;
+    logInfo("Lazy reprocess: enqueuing stale files", {
+      chatbotId,
+      count: stale.length,
+    });
+    for (const { fileId } of stale) {
+      if (isLocalStorageMode()) {
+        void processFile({ fileId }).catch((e) =>
+          logError(e, "Inline reprocess failed", { fileId }),
+        );
+      } else {
+        // Enqueue via QStash — same helper, url, and body { fileId } as
+        // files/procedures/finalize-upload.ts.
+        await publishQStashJob({
+          url: `${env.NEXT_PUBLIC_APP_URL}/api/jobs/process-file`,
+          body: { fileId },
+        });
+      }
+    }
+  } catch (error) {
+    logError(error, "maybeEnqueueReprocess failed", { chatbotId });
+  }
+}

--- a/apps/web/src/server/reprocess.ts
+++ b/apps/web/src/server/reprocess.ts
@@ -1,7 +1,6 @@
 import { eq, and, or, isNull, sql } from "drizzle-orm";
 import { userFiles, chatbotFileAssociations } from "@teachanything/db/schema";
 import { CURRENT_PROCESSING_VERSION, processFile } from "@/lib/file-processor";
-import { isLocalStorageMode } from "@/lib/local-storage";
 import { publishQStashJob } from "@/lib/qstash";
 import { env } from "@/lib/env";
 import { logError, logInfo } from "@/lib/logger";
@@ -36,18 +35,24 @@ export async function maybeEnqueueReprocess(
       chatbotId,
       count: stale.length,
     });
+    // Match finalize-upload's gate: process inline in development (QStash can't
+    // deliver to localhost), publish to QStash in production. Each file is
+    // isolated so one failure doesn't abort the rest of the batch.
+    const inlineDev = env.NODE_ENV === "development";
     for (const { fileId } of stale) {
-      if (isLocalStorageMode()) {
+      if (inlineDev) {
         void processFile({ fileId }).catch((e) =>
           logError(e, "Inline reprocess failed", { fileId }),
         );
       } else {
-        // Enqueue via QStash — same helper, url, and body { fileId } as
-        // files/procedures/finalize-upload.ts.
-        await publishQStashJob({
-          url: `${env.NEXT_PUBLIC_APP_URL}/api/jobs/process-file`,
-          body: { fileId },
-        });
+        try {
+          await publishQStashJob({
+            url: `${env.NEXT_PUBLIC_APP_URL}/api/jobs/process-file`,
+            body: { fileId },
+          });
+        } catch (e) {
+          logError(e, "Failed to enqueue reprocess job", { fileId });
+        }
       }
     }
   } catch (error) {

--- a/apps/web/src/server/retrieval-tool-schemas.ts
+++ b/apps/web/src/server/retrieval-tool-schemas.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/**
+ * Zod input schemas for the agentic retrieval tools.
+ *
+ * Kept in a standalone module (no `ai` import) so they can be imported in unit
+ * tests without pulling the AI SDK runtime — which depends on Web APIs like
+ * `TransformStream` that are absent in the Jest/node test environment — into the
+ * test process.
+ */
+
+export const searchDocumentsInput = z.object({
+  query: z.string().min(1).describe("Search terms or an exact quoted phrase"),
+  fileId: z.string().uuid().optional().describe("Restrict to one document"),
+  limit: z.number().int().min(1).max(12).optional(),
+});
+
+export const getPageInput = z.object({
+  fileId: z.string().uuid(),
+  pageNumber: z.number().int().min(1),
+});
+
+export const getContextAroundInput = z.object({
+  fileId: z.string().uuid(),
+  chunkIndex: z.number().int().min(0),
+});

--- a/apps/web/src/server/retrieval-tools.ts
+++ b/apps/web/src/server/retrieval-tools.ts
@@ -49,6 +49,12 @@ export function createRetrievalTools(ctx: RetrievalToolContext) {
         "Search the attached documents for passages. Use the user's exact words or a quoted phrase for specific details. Returns passages with file name, page number, and chunk index. ALWAYS search before claiming something is or is not in the documents.",
       inputSchema: searchDocumentsInput,
       execute: async ({ query, fileId, limit }) => {
+        // Authorization: reject a model-supplied fileId outside this chatbot's
+        // scope, matching get_page / get_context_around (hybridSearch also
+        // intersects defensively).
+        if (fileId && !ctx.fileIds.includes(fileId)) {
+          return { error: "Unknown document" };
+        }
         const queryEmbedding = await ctx.aiClient.generateEmbedding(query);
         const results = await hybridSearch({
           db: ctx.db,

--- a/apps/web/src/server/retrieval-tools.ts
+++ b/apps/web/src/server/retrieval-tools.ts
@@ -1,0 +1,189 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { eq, and, inArray, asc, sql } from "drizzle-orm";
+import { fileChunks, userFiles } from "@teachanything/db/schema";
+import type { db as DbType } from "@teachanything/db";
+import type { OpenRouterClient } from "@teachanything/ai/openrouter";
+import { hybridSearch, type HybridChunk } from "./hybrid-search";
+import {
+  searchDocumentsInput,
+  getPageInput,
+  getContextAroundInput,
+} from "./retrieval-tool-schemas";
+
+export {
+  searchDocumentsInput,
+  getPageInput,
+  getContextAroundInput,
+} from "./retrieval-tool-schemas";
+
+export interface RetrievalToolContext {
+  db: typeof DbType;
+  fileIds: string[];
+  aiClient: OpenRouterClient;
+}
+
+export interface RetrievalSource {
+  fileName: string;
+  chunkIndex: number;
+  pageNumber: number | null;
+  similarity: number | null;
+}
+
+export function createRetrievalTools(ctx: RetrievalToolContext) {
+  const sources: RetrievalSource[] = [];
+  const record = (chunks: HybridChunk[]) => {
+    for (const c of chunks) {
+      sources.push({
+        fileName: c.fileName,
+        chunkIndex: c.chunkIndex,
+        pageNumber: c.pageNumber,
+        similarity: c.vectorSimilarity,
+      });
+    }
+  };
+
+  const tools = {
+    search_documents: tool({
+      description:
+        "Search the attached documents for passages. Use the user's exact words or a quoted phrase for specific details. Returns passages with file name, page number, and chunk index. ALWAYS search before claiming something is or is not in the documents.",
+      inputSchema: searchDocumentsInput,
+      execute: async ({ query, fileId, limit }) => {
+        const queryEmbedding = await ctx.aiClient.generateEmbedding(query);
+        const results = await hybridSearch({
+          db: ctx.db,
+          fileIds: ctx.fileIds,
+          query,
+          queryEmbedding,
+          limit: limit ?? 6,
+          fileId,
+        });
+        record(results);
+        return results.map((r) => ({
+          fileName: r.fileName,
+          pageNumber: r.pageNumber,
+          chunkIndex: r.chunkIndex,
+          content: r.content,
+        }));
+      },
+    }),
+
+    get_page: tool({
+      description:
+        "Return the full text of a specific page of a document. Use when the user asks about a page number or to verify a citation.",
+      inputSchema: getPageInput,
+      execute: async ({ fileId, pageNumber }) => {
+        if (!ctx.fileIds.includes(fileId)) return { error: "Unknown document" };
+        const rows = await ctx.db
+          .select({
+            content: fileChunks.content,
+            chunkIndex: fileChunks.chunkIndex,
+            fileName: userFiles.fileName,
+          })
+          .from(fileChunks)
+          .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+          .where(
+            and(
+              eq(fileChunks.fileId, fileId),
+              sql`(${fileChunks.metadata} ->> 'pageNumber')::int = ${pageNumber}`,
+            ),
+          )
+          .orderBy(asc(fileChunks.chunkIndex));
+        return {
+          pageNumber,
+          fileName: rows[0]?.fileName ?? null,
+          text: rows.map((r) => r.content).join("\n"),
+        };
+      },
+    }),
+
+    get_context_around: tool({
+      description:
+        "Return a chunk and its immediate neighbors (previous and next) in document order. Use to recover context when a search hit reads as if it starts mid-thought.",
+      inputSchema: getContextAroundInput,
+      execute: async ({ fileId, chunkIndex }) => {
+        if (!ctx.fileIds.includes(fileId)) return { error: "Unknown document" };
+        const rows = await ctx.db
+          .select({
+            content: fileChunks.content,
+            chunkIndex: fileChunks.chunkIndex,
+            metadata: fileChunks.metadata,
+            fileName: userFiles.fileName,
+          })
+          .from(fileChunks)
+          .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+          .where(
+            and(
+              eq(fileChunks.fileId, fileId),
+              inArray(fileChunks.chunkIndex, [
+                chunkIndex - 1,
+                chunkIndex,
+                chunkIndex + 1,
+              ]),
+            ),
+          )
+          .orderBy(asc(fileChunks.chunkIndex));
+        record(
+          rows.map((r) => ({
+            chunkId: "",
+            fileId,
+            fileName: r.fileName,
+            chunkIndex: r.chunkIndex,
+            pageNumber:
+              (r.metadata as { pageNumber?: number } | null)?.pageNumber ??
+              null,
+            content: r.content,
+            vectorSimilarity: null,
+          })),
+        );
+        return {
+          fileName: rows[0]?.fileName ?? null,
+          chunks: rows.map((r) => ({
+            chunkIndex: r.chunkIndex,
+            content: r.content,
+          })),
+        };
+      },
+    }),
+
+    list_documents: tool({
+      description:
+        "List the documents attached to this chatbot with their page counts.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        if (ctx.fileIds.length === 0) return { documents: [] };
+        const rows = await ctx.db
+          .select({
+            fileId: userFiles.id,
+            fileName: userFiles.fileName,
+            pageCount: sql<
+              number | null
+            >`max((${fileChunks.metadata} ->> 'pageNumber')::int)`,
+          })
+          .from(userFiles)
+          .leftJoin(fileChunks, eq(fileChunks.fileId, userFiles.id))
+          .where(inArray(userFiles.id, ctx.fileIds))
+          .groupBy(userFiles.id, userFiles.fileName);
+        return {
+          documents: rows.map((r) => ({
+            fileId: r.fileId,
+            fileName: r.fileName,
+            pageCount: r.pageCount ?? null,
+          })),
+        };
+      },
+    }),
+
+    done: tool({
+      description:
+        "Call this with your final answer once you have gathered enough evidence. Cite the file and page for each claim.",
+      inputSchema: z.object({
+        answer: z.string(),
+        sources: z.array(z.string()).optional(),
+      }),
+      // No execute: invoking `done` stops the loop (hasToolCall('done')).
+    }),
+  };
+
+  return { tools, sources };
+}

--- a/apps/web/src/server/routers/analytics.ts
+++ b/apps/web/src/server/routers/analytics.ts
@@ -827,4 +827,33 @@ export const analyticsRouter = router({
         totalCount,
       };
     }),
+
+  /**
+   * Delete one or more conversations (and their messages, via cascade) for a
+   * chatbot the caller owns. Used by the Student Chats tab to clear retry junk.
+   */
+  deleteConversations: protectedProcedure
+    .input(
+      z.object({
+        chatbotId: z.string().uuid(),
+        conversationIds: z.array(z.string().uuid()).min(1).max(100),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertOwnedChatbot(ctx, input.chatbotId);
+
+      // Scope the delete to this chatbot so a caller can't delete another
+      // chatbot's conversations by id. Messages cascade-delete via FK.
+      const deleted = await ctx.db
+        .delete(conversations)
+        .where(
+          and(
+            eq(conversations.chatbotId, input.chatbotId),
+            inArray(conversations.id, input.conversationIds),
+          ),
+        )
+        .returning({ id: conversations.id });
+
+      return { deletedCount: deleted.length };
+    }),
 });

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -547,14 +547,17 @@ async function* processMessage(params: {
   if (useTools) {
     const agentic = yield* streamAgentic();
 
-    // Zero-tool-call safety net: the model produced no tool calls AND no text.
-    // Fall back to the static injection path so the user still gets an answer.
-    if (!agentic.anyToolCall && !agentic.fullResponse) {
+    // Empty-response safety net: the agentic path produced no user-visible
+    // text (e.g. it only ran searches then hit the step cap, or called `done`
+    // with an empty answer). Fall back to the static injection path so the user
+    // always gets an answer instead of an empty, stuck-looking stream.
+    if (!agentic.fullResponse) {
       logWarn(
-        "Agentic path produced no tool calls; falling back to static RAG",
+        "Agentic path produced no text response; falling back to static RAG",
         {
           chatbotId: chatbot.id,
           modelId,
+          anyToolCall: agentic.anyToolCall,
         },
       );
       // Emit RAG sources for the fallback path (agentic suppressed them above).
@@ -600,17 +603,23 @@ async function* processMessage(params: {
   // subsequent turns see the full conversation and the ordering is correct.
   await userMessageInsert;
 
-  // Save assistant response
-  await database.insert(messages).values({
-    conversationId: conversation.id,
-    role: "assistant",
-    content: fullResponse,
-    metadata: {
-      sources: finalSources,
-      responseTime,
-      ragUsed: ragUsedFlag,
-    },
-  });
+  // Save the assistant reply only when the model actually produced text. The
+  // model decides its own wording (the agentic loop falls back to the static
+  // RAG path, so a "couldn't find it" answer is the model's own phrasing, not a
+  // canned string). A genuinely empty turn is not persisted, so reloaded
+  // history never shows a blank bubble.
+  if (fullResponse.trim()) {
+    await database.insert(messages).values({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: fullResponse,
+      metadata: {
+        sources: finalSources,
+        responseTime,
+        ragUsed: ragUsedFlag,
+      },
+    });
+  }
 
   const ragSimilarityScore =
     finalSources.length > 0

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -253,8 +253,10 @@ async function* processMessage(params: {
   }
 
   // Build message history for AI (budget-trimmed)
+  // Stored conversation turns are only user/assistant; the system prompt is
+  // passed separately via the streamText `system` option.
   const conversationHistory = trimmedHistory.map((msg) => ({
-    role: msg.role as "system" | "user" | "assistant",
+    role: msg.role as "user" | "assistant",
     content: msg.content,
   }));
 
@@ -302,11 +304,8 @@ async function* processMessage(params: {
 
     const result = await aiClient.streamText({
       model: modelId,
-      messages: [
-        { role: "system", content: systemPrompt },
-        ...conversationHistory,
-        { role: "user", content: message },
-      ],
+      system: systemPrompt,
+      messages: [...conversationHistory, { role: "user", content: message }],
       temperature: (chatbot.temperature ?? 70) / 100,
       maxTokens: maxOutputTokens,
     });
@@ -408,11 +407,8 @@ async function* processMessage(params: {
 
     const result = await aiClient.streamText({
       model: modelId,
-      messages: [
-        { role: "system", content: systemPrompt },
-        ...conversationHistory,
-        { role: "user", content: message },
-      ],
+      system: systemPrompt,
+      messages: [...conversationHistory, { role: "user", content: message }],
       temperature: (chatbot.temperature ?? 70) / 100,
       maxTokens: maxOutputTokens,
       // apps/web resolves `ai` to a different installed copy than

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -49,6 +49,33 @@ function clampMaxTokens(maxTokens: number | null | undefined): number {
 }
 
 /**
+ * Map an agentic retrieval tool-call to a human-readable status label shown
+ * in the live status line while the model works. Only the action + the
+ * user-derived query are surfaced -- never tool RESULT content (which could
+ * contain document text on public shared bots).
+ */
+function describeToolActivity(toolName: string, input: unknown): string {
+  const args = (input ?? {}) as {
+    query?: unknown;
+    pageNumber?: unknown;
+  };
+  switch (toolName) {
+    case "search_documents":
+      return typeof args.query === "string" && args.query.length > 0
+        ? `Searching documents for “${args.query}”`
+        : "Searching documents…";
+    case "get_page":
+      return `Reading page ${String(args.pageNumber)}…`;
+    case "get_context_around":
+      return "Reading surrounding context…";
+    case "list_documents":
+      return "Looking through your documents…";
+    default:
+      return "Working…";
+  }
+}
+
+/**
  * Cached token counter -- initialized once, reused across all requests.
  */
 let counterPromise: Promise<(text: string) => number> | null = null;
@@ -356,7 +383,9 @@ async function* processMessage(params: {
    * tool-call args).
    */
   async function* streamAgentic(): AsyncGenerator<
-    { type: "text"; content: string } | { type: "thinking" },
+    | { type: "text"; content: string }
+    | { type: "thinking" }
+    | { type: "status"; label: string },
     {
       fullResponse: string;
       finishReason: FinishReason | undefined;
@@ -409,9 +438,6 @@ async function* processMessage(params: {
     let anyToolCall = false;
     let doneAnswer: string | undefined;
 
-    // Guard so a single search emits at most one `thinking` indicator. Reset
-    // on tool-result so the next search re-arms it.
-    let searchIndicatorEmitted = false;
     let thinkingEmitted = false;
 
     for await (const part of result.fullStream) {
@@ -438,30 +464,35 @@ async function* processMessage(params: {
           break;
         }
         case "tool-input-start": {
-          // A tool call is being assembled. Surface activity once per search so
-          // the UI doesn't look frozen while the model retrieves.
+          // A tool call is being assembled. The richer `status` event is
+          // emitted on `tool-call` (below) once the tool name + args are known.
           anyToolCall = true;
-          if (!searchIndicatorEmitted) {
-            yield { type: "thinking" as const };
-            searchIndicatorEmitted = true;
-          }
           break;
         }
         case "tool-call": {
           anyToolCall = true;
+          thinkingEmitted = false;
           // The `done` tool has no execute; its answer is in the tool-call
-          // args (`part.input`), never a tool-result.
+          // args (`part.input`), never a tool-result. It's not a retrieval
+          // action, so it gets no status label.
           if (part.toolName === "done") {
             const input = part.input as { answer?: unknown } | undefined;
             if (typeof input?.answer === "string") {
               doneAnswer = input.answer;
             }
+            break;
           }
+          // Surface the tool activity as a human-readable status line. The
+          // `part.input` is the parsed args object (AI SDK v6 TypedToolCall).
+          // Only the action label + user-derived query are sent -- never tool
+          // RESULT content, which could contain document text on public bots.
+          yield {
+            type: "status" as const,
+            label: describeToolActivity(part.toolName, part.input),
+          };
           break;
         }
         case "tool-result": {
-          // A search returned; re-arm the indicator for the next one.
-          searchIndicatorEmitted = false;
           break;
         }
         case "finish": {

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -1,5 +1,7 @@
 import { router, publicProcedure, protectedProcedure } from "../trpc";
 import type { FinishReason } from "ai";
+import { stepCountIs, hasToolCall } from "ai";
+import { modelSupportsTools } from "@teachanything/ai/models";
 import { z } from "zod";
 import {
   chatbots,
@@ -17,6 +19,7 @@ import {
   calculateChunkLimit,
   allocateTokenBudget,
   CHARS_PER_TOKEN,
+  type OpenRouterClient,
 } from "@teachanything/ai";
 import { logInfo, logError, logWarn } from "@/lib/logger";
 import { env } from "@/lib/env";
@@ -25,7 +28,8 @@ import {
   authenticatedChatRateLimit,
   publicChatRateLimit,
 } from "@/lib/rate-limit";
-import { buildRAGContext } from "../rag-context";
+import { buildRAGContext, type RAGContextResult } from "../rag-context";
+import { createRetrievalTools } from "../retrieval-tools";
 import type { db as DbType } from "@teachanything/db";
 
 /**
@@ -197,25 +201,29 @@ async function* processMessage(params: {
     logWarn(warning, { chatbotId: chatbot.id, modelId });
   }
 
-  // Send RAG sources now that they're available. The client handles metadata
-  // events idempotently (updates only fields that are present).
-  yield {
-    type: "metadata" as const,
-    sources: ragResult.sources,
-  };
+  // Tool-capable models with at least one searchable file use the AGENTIC
+  // retrieval path: the model calls retrieval tools mid-turn instead of
+  // receiving statically-injected chunks. Everything else uses the STATIC
+  // path (today's behavior).
+  const useTools =
+    modelSupportsTools(chatbot.model) && ragResult.fileIds.length > 0;
+
+  // Send RAG sources now that they're available (static path only). The
+  // agentic path's sources aren't known until its tools run, so it emits its
+  // own metadata event after streaming. The client handles metadata events
+  // idempotently (updates only fields that are present).
+  if (!useTools) {
+    yield {
+      type: "metadata" as const,
+      sources: ragResult.sources,
+    };
+  }
 
   // Build message history for AI (budget-trimmed)
   const conversationHistory = trimmedHistory.map((msg) => ({
     role: msg.role as "system" | "user" | "assistant",
     content: msg.content,
   }));
-
-  // ragFailureNote + systemPrompt + fileManifest + contextText
-  const systemPrompt =
-    ragResult.ragFailureNote +
-    chatbot.systemPrompt +
-    ragResult.fileManifest +
-    ragResult.contextText;
 
   // Kick off the user-message insert alongside the streamText handshake
   // instead of blocking on it first. We await it before saving the assistant
@@ -238,79 +246,306 @@ async function* processMessage(params: {
       throw err;
     });
 
-  // Stream response using the same client
   const startTime = Date.now();
-  let fullResponse = "";
-  let finishReason: FinishReason | undefined;
 
-  const result = await aiClient.streamText({
-    model: modelId,
-    messages: [
-      { role: "system", content: systemPrompt },
-      ...conversationHistory,
-      { role: "user", content: message },
-    ],
-    temperature: (chatbot.temperature ?? 70) / 100,
-    maxTokens: maxOutputTokens,
+  /**
+   * STATIC retrieval path: inject RAG chunks into the system prompt and stream
+   * a single LLM turn. Behaviorally identical to the pre-agentic chat flow.
+   * Used directly for non-tool models and as the zero-tool-call fallback for
+   * tool models. Yields the same wire events as the agentic path and returns
+   * the accumulated response + finish reason.
+   */
+  async function* streamStatic(): AsyncGenerator<
+    { type: "text"; content: string } | { type: "thinking" },
+    { fullResponse: string; finishReason: FinishReason | undefined },
+    void
+  > {
+    // ragFailureNote + systemPrompt + fileManifest + contextText
+    const systemPrompt =
+      ragResult.ragFailureNote +
+      chatbot.systemPrompt +
+      ragResult.fileManifest +
+      ragResult.contextText;
+
+    const result = await aiClient.streamText({
+      model: modelId,
+      messages: [
+        { role: "system", content: systemPrompt },
+        ...conversationHistory,
+        { role: "user", content: message },
+      ],
+      temperature: (chatbot.temperature ?? 70) / 100,
+      maxTokens: maxOutputTokens,
+    });
+
+    let staticResponse = "";
+    let staticFinishReason: FinishReason | undefined;
+
+    // Consume fullStream so we get typed events: text deltas, reasoning deltas,
+    // errors, aborts, and finish reasons. textStream swallows all non-text parts,
+    // which means mid-stream errors look identical to a clean finish on the wire.
+    //
+    // Emit at most one `thinking` event per reasoning phase: reasoning-delta
+    // fires for every token and would spam the subscription otherwise.
+    let thinkingEmitted = false;
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case "text-delta": {
+          staticResponse += part.text;
+          thinkingEmitted = false;
+          yield { type: "text" as const, content: part.text };
+          break;
+        }
+        case "reasoning-start":
+        case "reasoning-delta": {
+          // Surface reasoning as a thinking indicator so the UI doesn't look
+          // frozen during long pauses. The reasoning text itself is never sent
+          // to the client -- on public shared chatbots it can restate system
+          // prompts or RAG context.
+          if (!thinkingEmitted) {
+            yield { type: "thinking" as const };
+            thinkingEmitted = true;
+          }
+          break;
+        }
+        case "reasoning-end":
+        case "text-start":
+        case "text-end":
+        case "finish-step": {
+          // Any phase boundary closes the current reasoning phase so the next
+          // reasoning-start/delta will re-emit the indicator.
+          thinkingEmitted = false;
+          break;
+        }
+        case "finish": {
+          thinkingEmitted = false;
+          staticFinishReason = part.finishReason;
+          break;
+        }
+        case "error": {
+          throw new Error(`Stream error: ${String(part.error)}`, {
+            cause: part.error,
+          });
+        }
+        case "abort": {
+          throw new Error("Stream aborted by provider");
+        }
+        default:
+          // Other event types (start, etc.) don't affect what we send to the
+          // client.
+          break;
+      }
+    }
+
+    return { fullResponse: staticResponse, finishReason: staticFinishReason };
+  }
+
+  /**
+   * AGENTIC retrieval path: give the model retrieval tools and let it search
+   * the attached documents during the turn. No static context injection; the
+   * model is forced to call `search_documents` on the first step. Yields the
+   * same wire events as the static path. Returns the accumulated response,
+   * finish reason, whether any tool call happened, and a captured `done`
+   * answer (the `done` tool has no execute -- its answer lives in the
+   * tool-call args).
+   */
+  async function* streamAgentic(): AsyncGenerator<
+    { type: "text"; content: string } | { type: "thinking" },
+    {
+      fullResponse: string;
+      finishReason: FinishReason | undefined;
+      anyToolCall: boolean;
+    },
+    void
+  > {
+    const nemotronPrefix = modelId.includes("nemotron")
+      ? "detailed thinking on\n\n"
+      : "";
+    const groundingRule =
+      "\n\nYou can search the attached documents using tools. You MUST call search_documents before stating whether the documents do or do not contain something. " +
+      "Never say 'the document does not mention X' -- if a search returns nothing, say 'I couldn't find that in the materials.' " +
+      "Cite the file name and page number for each claim, and include the exact quote you relied on.";
+    const systemPrompt =
+      nemotronPrefix +
+      chatbot.systemPrompt +
+      ragResult.fileManifest +
+      groundingRule;
+
+    const result = await aiClient.streamText({
+      model: modelId,
+      messages: [
+        { role: "system", content: systemPrompt },
+        ...conversationHistory,
+        { role: "user", content: message },
+      ],
+      temperature: (chatbot.temperature ?? 70) / 100,
+      maxTokens: maxOutputTokens,
+      // apps/web resolves `ai` to a different installed copy than
+      // @teachanything/ai does, so the `Tool` types are nominally distinct
+      // across the wrapper boundary (identical runtime shape, different
+      // package instances of @ai-sdk/provider-utils). Cast to the wrapper's
+      // own expected tools type. Runtime behavior is unchanged.
+      tools: tools as unknown as Parameters<
+        OpenRouterClient["streamText"]
+      >[0]["tools"],
+      stopWhen: [stepCountIs(6), hasToolCall("done")],
+      prepareStep: async ({ stepNumber }) =>
+        stepNumber === 0
+          ? {
+              toolChoice: { type: "tool", toolName: "search_documents" },
+              activeTools: ["search_documents"],
+            }
+          : {},
+    });
+
+    let agenticResponse = "";
+    let agenticFinishReason: FinishReason | undefined;
+    let anyToolCall = false;
+    let doneAnswer: string | undefined;
+
+    // Guard so a single search emits at most one `thinking` indicator. Reset
+    // on tool-result so the next search re-arms it.
+    let searchIndicatorEmitted = false;
+    let thinkingEmitted = false;
+
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case "text-delta": {
+          agenticResponse += part.text;
+          thinkingEmitted = false;
+          yield { type: "text" as const, content: part.text };
+          break;
+        }
+        case "reasoning-start":
+        case "reasoning-delta": {
+          if (!thinkingEmitted) {
+            yield { type: "thinking" as const };
+            thinkingEmitted = true;
+          }
+          break;
+        }
+        case "reasoning-end":
+        case "text-start":
+        case "text-end":
+        case "finish-step": {
+          thinkingEmitted = false;
+          break;
+        }
+        case "tool-input-start": {
+          // A tool call is being assembled. Surface activity once per search so
+          // the UI doesn't look frozen while the model retrieves.
+          anyToolCall = true;
+          if (!searchIndicatorEmitted) {
+            yield { type: "thinking" as const };
+            searchIndicatorEmitted = true;
+          }
+          break;
+        }
+        case "tool-call": {
+          anyToolCall = true;
+          // The `done` tool has no execute; its answer is in the tool-call
+          // args (`part.input`), never a tool-result.
+          if (part.toolName === "done") {
+            const input = part.input as { answer?: unknown } | undefined;
+            if (typeof input?.answer === "string") {
+              doneAnswer = input.answer;
+            }
+          }
+          break;
+        }
+        case "tool-result": {
+          // A search returned; re-arm the indicator for the next one.
+          searchIndicatorEmitted = false;
+          break;
+        }
+        case "finish": {
+          thinkingEmitted = false;
+          agenticFinishReason = part.finishReason;
+          break;
+        }
+        case "error": {
+          throw new Error(`Stream error: ${String(part.error)}`, {
+            cause: part.error,
+          });
+        }
+        case "abort": {
+          throw new Error("Stream aborted by provider");
+        }
+        default:
+          break;
+      }
+    }
+
+    // If the model only spoke through the `done` tool (no free-text), surface
+    // its answer as the response.
+    if (!agenticResponse && doneAnswer) {
+      agenticResponse = doneAnswer;
+      yield { type: "text" as const, content: doneAnswer };
+    }
+
+    return {
+      fullResponse: agenticResponse,
+      finishReason: agenticFinishReason,
+      anyToolCall,
+    };
+  }
+
+  // Build retrieval tools once (only the agentic path consumes them, but
+  // `toolSources` accumulates as the tools run and we read it after streaming).
+  const { tools, sources: toolSources } = createRetrievalTools({
+    db: database,
+    fileIds: ragResult.fileIds,
+    aiClient,
   });
 
-  // Consume fullStream so we get typed events: text deltas, reasoning deltas,
-  // errors, aborts, and finish reasons. textStream swallows all non-text parts,
-  // which means mid-stream errors look identical to a clean finish on the wire.
-  //
-  // Emit at most one `thinking` event per reasoning phase: reasoning-delta
-  // fires for every token and would spam the subscription otherwise.
-  let thinkingEmitted = false;
-  for await (const part of result.fullStream) {
-    switch (part.type) {
-      case "text-delta": {
-        fullResponse += part.text;
-        thinkingEmitted = false;
-        yield {
-          type: "text" as const,
-          content: part.text,
-        };
-        break;
-      }
-      case "reasoning-start":
-      case "reasoning-delta": {
-        // Surface reasoning as a thinking indicator so the UI doesn't look
-        // frozen during long pauses. The reasoning text itself is never sent
-        // to the client -- on public shared chatbots it can restate system
-        // prompts or RAG context.
-        if (!thinkingEmitted) {
-          yield { type: "thinking" as const };
-          thinkingEmitted = true;
-        }
-        break;
-      }
-      case "reasoning-end":
-      case "text-start":
-      case "text-end":
-      case "finish-step": {
-        // Any phase boundary closes the current reasoning phase so the next
-        // reasoning-start/delta will re-emit the indicator.
-        thinkingEmitted = false;
-        break;
-      }
-      case "finish": {
-        thinkingEmitted = false;
-        finishReason = part.finishReason;
-        break;
-      }
-      case "error": {
-        throw new Error(`Stream error: ${String(part.error)}`, {
-          cause: part.error,
-        });
-      }
-      case "abort": {
-        throw new Error("Stream aborted by provider");
-      }
-      default:
-        // Other event types (start, etc.) don't affect what we send to the
-        // client.
-        break;
+  let fullResponse: string;
+  let finishReason: FinishReason | undefined;
+  // Final source list for persistence + the metadata event. Static path uses
+  // ragResult.sources; agentic path maps toolSources (which carry pageNumber).
+  // similarity is coerced from null -> 0 so existing consumers (which expect a
+  // number and dedupe/score on it) keep working.
+  let finalSources: RAGContextResult["sources"];
+  let ragUsedFlag: boolean;
+
+  if (useTools) {
+    const agentic = yield* streamAgentic();
+
+    // Zero-tool-call safety net: the model produced no tool calls AND no text.
+    // Fall back to the static injection path so the user still gets an answer.
+    if (!agentic.anyToolCall && !agentic.fullResponse) {
+      logWarn(
+        "Agentic path produced no tool calls; falling back to static RAG",
+        {
+          chatbotId: chatbot.id,
+          modelId,
+        },
+      );
+      // Emit RAG sources for the fallback path (agentic suppressed them above).
+      yield { type: "metadata" as const, sources: ragResult.sources };
+      const fallback = yield* streamStatic();
+      fullResponse = fallback.fullResponse;
+      finishReason = fallback.finishReason;
+      finalSources = ragResult.sources;
+      ragUsedFlag = ragResult.ragUsed;
+    } else {
+      fullResponse = agentic.fullResponse;
+      finishReason = agentic.finishReason;
+      finalSources = toolSources.map((s) => ({
+        fileName: s.fileName,
+        chunkIndex: s.chunkIndex,
+        similarity: s.similarity ?? 0,
+        pageNumber: s.pageNumber,
+      }));
+      ragUsedFlag = finalSources.length > 0;
+      // Agentic sources are only known after the tools run, so emit them now.
+      yield { type: "metadata" as const, sources: finalSources };
     }
+  } else {
+    const staticResult = yield* streamStatic();
+    fullResponse = staticResult.fullResponse;
+    finishReason = staticResult.finishReason;
+    finalSources = ragResult.sources;
+    ragUsedFlag = ragResult.ragUsed;
   }
 
   const responseTime = Date.now() - startTime;
@@ -334,15 +569,15 @@ async function* processMessage(params: {
     role: "assistant",
     content: fullResponse,
     metadata: {
-      sources: ragResult.sources,
+      sources: finalSources,
       responseTime,
-      ragUsed: ragResult.ragUsed,
+      ragUsed: ragUsedFlag,
     },
   });
 
   const ragSimilarityScore =
-    ragResult.sources.length > 0
-      ? Math.max(...ragResult.sources.map((source) => source.similarity))
+    finalSources.length > 0
+      ? Math.max(...finalSources.map((source) => source.similarity))
       : undefined;
 
   // Track analytics

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -23,6 +23,7 @@ import {
 } from "@teachanything/ai";
 import { logInfo, logError, logWarn } from "@/lib/logger";
 import { env } from "@/lib/env";
+import { maybeEnqueueReprocess } from "../reprocess";
 import {
   checkRateLimit,
   authenticatedChatRateLimit,
@@ -114,6 +115,11 @@ async function* processMessage(params: {
       message: "Failed to create conversation",
     });
   }
+
+  // Fire-and-forget: lazily reprocess any files ingested under an older
+  // processing version so they gain page-aware chunks (#271). Must not block
+  // the current turn — it serves immediately with whatever chunks exist.
+  void maybeEnqueueReprocess(database, chatbot.id);
 
   // Yield the sessionId immediately so the client knows the subscription is
   // live before we start the expensive RAG embedding + history fetch. Sources

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -31,49 +31,8 @@ import {
 } from "@/lib/rate-limit";
 import { buildRAGContext, type RAGContextResult } from "../rag-context";
 import { createRetrievalTools } from "../retrieval-tools";
+import { clampMaxTokens, describeToolActivity } from "../chat-helpers";
 import type { db as DbType } from "@teachanything/db";
-
-/**
- * Clamp maxTokens to valid range (100-4000)
- */
-function clampMaxTokens(maxTokens: number | null | undefined): number {
-  const MIN_TOKENS = 100;
-  const MAX_TOKENS = 4000;
-  const DEFAULT_TOKENS = 2000;
-
-  if (maxTokens == null || isNaN(maxTokens)) {
-    return DEFAULT_TOKENS;
-  }
-
-  return Math.max(MIN_TOKENS, Math.min(MAX_TOKENS, maxTokens));
-}
-
-/**
- * Map an agentic retrieval tool-call to a human-readable status label shown
- * in the live status line while the model works. Only the action + the
- * user-derived query are surfaced -- never tool RESULT content (which could
- * contain document text on public shared bots).
- */
-function describeToolActivity(toolName: string, input: unknown): string {
-  const args = (input ?? {}) as {
-    query?: unknown;
-    pageNumber?: unknown;
-  };
-  switch (toolName) {
-    case "search_documents":
-      return typeof args.query === "string" && args.query.length > 0
-        ? `Searching documents for “${args.query}”`
-        : "Searching documents…";
-    case "get_page":
-      return `Reading page ${String(args.pageNumber)}…`;
-    case "get_context_around":
-      return "Reading surrounding context…";
-    case "list_documents":
-      return "Looking through your documents…";
-    default:
-      return "Working…";
-  }
-}
 
 /**
  * Cached token counter -- initialized once, reused across all requests.

--- a/apps/web/src/server/routers/files/procedures/list.ts
+++ b/apps/web/src/server/routers/files/procedures/list.ts
@@ -79,8 +79,13 @@ export const listProcedure = protectedProcedure
     const orderBy =
       input?.sortDir === "asc" ? asc(sortColumn) : desc(sortColumn);
 
-    // Build WHERE conditions - base + search + optional exclusion
-    const baseConditions = [eq(userFiles.userId, ctx.session.user.id)];
+    // Build WHERE conditions - base + search + optional exclusion.
+    // excludeCrawledPages keeps crawler-sourced files (storagePath = URL) out of
+    // the uploaded-files table; they're shown as grouped Web Sources rows.
+    const baseConditions = [
+      eq(userFiles.userId, ctx.session.user.id),
+      excludeCrawledPages,
+    ];
     if (searchCondition) baseConditions.push(searchCondition);
 
     // Validate chatbot ownership before using it for exclusion

--- a/apps/web/src/types/database.ts
+++ b/apps/web/src/types/database.ts
@@ -49,6 +49,7 @@ export interface ChatMessage {
     fileName: string;
     chunkIndex: number;
     similarity: number;
+    pageNumber?: number | null;
   }>;
   cancelled?: boolean;
   truncated?: boolean;
@@ -59,4 +60,5 @@ export interface MessageSource {
   fileName: string;
   chunkIndex: number;
   similarity: number;
+  pageNumber?: number | null;
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./error-utils": "./src/error-utils.ts",
     "./models": "./src/models.ts",
+    "./rrf": "./src/rrf.ts",
     "./openrouter": "./src/openrouter-client.ts",
     "./rag": "./src/rag-service.ts",
     "./crawler": "./src/crawler.ts",

--- a/packages/ai/src/__tests__/models.test.ts
+++ b/packages/ai/src/__tests__/models.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  MODEL_REGISTRY,
+  toolCapableModels,
+  modelSupportsTools,
+} from "../models";
+
+describe("supportsTools gating", () => {
+  it("every model declares supportsTools", () => {
+    for (const m of Object.values(MODEL_REGISTRY)) {
+      expect(typeof m.supportsTools).toBe("boolean");
+    }
+  });
+  it("Gemma is marked non-tool (broken via OpenRouter)", () => {
+    expect(MODEL_REGISTRY["google/gemma-4-31b-it"].supportsTools).toBe(false);
+  });
+  it("toolCapableModels excludes non-tool models", () => {
+    const ids = toolCapableModels().map((m) => m.id);
+    expect(ids).not.toContain("google/gemma-4-31b-it");
+    expect(ids).toContain("qwen/qwen3-235b-a22b");
+  });
+  it("modelSupportsTools resolves deprecated ids", () => {
+    expect(modelSupportsTools("mistralai/mistral-large")).toBe(true);
+  });
+});

--- a/packages/ai/src/__tests__/models.test.ts
+++ b/packages/ai/src/__tests__/models.test.ts
@@ -11,15 +11,28 @@ describe("supportsTools gating", () => {
       expect(typeof m.supportsTools).toBe("boolean");
     }
   });
-  it("Gemma is marked non-tool (broken via OpenRouter)", () => {
-    expect(MODEL_REGISTRY["google/gemma-4-31b-it"].supportsTools).toBe(false);
+  it("every registered model is tool-capable (picker requires tools)", () => {
+    expect(toolCapableModels().length).toBe(Object.keys(MODEL_REGISTRY).length);
   });
-  it("toolCapableModels excludes non-tool models", () => {
+  it("dropped models (Gemma, Mistral) are no longer registered", () => {
+    expect(
+      (MODEL_REGISTRY as Record<string, unknown>)["google/gemma-4-31b-it"],
+    ).toBeUndefined();
+    expect(
+      (MODEL_REGISTRY as Record<string, unknown>)[
+        "mistralai/mistral-large-2411"
+      ],
+    ).toBeUndefined();
+  });
+  it("toolCapableModels includes the current Qwen revision", () => {
     const ids = toolCapableModels().map((m) => m.id);
-    expect(ids).not.toContain("google/gemma-4-31b-it");
-    expect(ids).toContain("qwen/qwen3-235b-a22b");
+    expect(ids).toContain("qwen/qwen3-235b-a22b-2507");
+    expect(ids).not.toContain("qwen/qwen3-235b-a22b");
   });
-  it("modelSupportsTools resolves deprecated ids", () => {
+  it("modelSupportsTools resolves deprecated/dropped ids to tool-capable models", () => {
+    // old Qwen 3 -> 2507; retired Mistral/Gemma -> default tool model
+    expect(modelSupportsTools("qwen/qwen3-235b-a22b")).toBe(true);
     expect(modelSupportsTools("mistralai/mistral-large")).toBe(true);
+    expect(modelSupportsTools("google/gemma-4-31b-it")).toBe(true);
   });
 });

--- a/packages/ai/src/__tests__/page-chunking.test.ts
+++ b/packages/ai/src/__tests__/page-chunking.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "@jest/globals";
+import { RAGService } from "../rag-service";
+
+describe("RAGService page-aware chunking", () => {
+  it("chunkPagedText assigns page numbers and never spans pages", async () => {
+    const svc = new RAGService();
+    const page1 = "Alpha. ".repeat(400); // long -> multiple ~1000-char chunks
+    const page2 = "Beta lives on page two.";
+    const text = `${page1}\f${page2}`;
+
+    const chunks = await svc.chunkPagedText(text);
+
+    expect(chunks.every((c) => typeof c.pageNumber === "number")).toBe(true);
+    const beta = chunks.filter((c) => c.content.includes("Beta lives"));
+    expect(beta.length).toBeGreaterThan(0);
+    expect(beta.every((c) => c.pageNumber === 2)).toBe(true);
+    const p1 = chunks.filter((c) => c.pageNumber === 1);
+    expect(p1.length).toBeGreaterThan(1);
+    expect(
+      chunks.some(
+        (c) => c.content.includes("Alpha") && c.content.includes("Beta lives"),
+      ),
+    ).toBe(false);
+  });
+
+  it("skips empty pages but keeps 1-based numbering by position", async () => {
+    const svc = new RAGService();
+    const chunks = await svc.chunkPagedText("Page one.\f\fPage three.");
+    const pages = new Set(chunks.map((c) => c.pageNumber));
+    expect(
+      chunks.find((c) => c.content.includes("Page three"))?.pageNumber,
+    ).toBe(3);
+    expect([...pages]).not.toContain(2);
+  });
+});

--- a/packages/ai/src/__tests__/rrf.test.ts
+++ b/packages/ai/src/__tests__/rrf.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "@jest/globals";
+import { reciprocalRankFusion } from "../rrf";
+
+describe("reciprocalRankFusion", () => {
+  it("rewards items ranked highly across multiple lists", () => {
+    const fused = reciprocalRankFusion(
+      [
+        { items: ["A", "C", "B"], weight: 1 }, // ranks: A=1,C=2,B=3
+        { items: ["B", "D", "E", "F", "A"], weight: 1 }, // ranks: B=1..A=5
+      ],
+      { k: 60 },
+    );
+    // B (1 + 3) beats A (1 + 5)
+    expect(fused[0]).toBe("B");
+    expect(fused).toContain("A");
+  });
+
+  it("keeps items present in only one list", () => {
+    const fused = reciprocalRankFusion(
+      [
+        { items: ["A"], weight: 1 },
+        { items: ["B"], weight: 1 },
+      ],
+      { k: 60 },
+    );
+    expect(new Set(fused)).toEqual(new Set(["A", "B"]));
+  });
+
+  it("applies per-list weight (quoted-phrase boost)", () => {
+    const fused = reciprocalRankFusion(
+      [
+        { items: ["A", "B"], weight: 1 },
+        { items: ["B", "A"], weight: 3 },
+      ],
+      { k: 60 },
+    );
+    expect(fused[0]).toBe("B");
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,4 +3,5 @@ export * from "./error-utils";
 export * from "./models";
 export * from "./openrouter-client";
 export * from "./rag-service";
+export * from "./rrf";
 export * from "./token-budget";

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -14,6 +14,7 @@ export interface ModelMetadata {
   displayName: string;
   provider: Provider;
   contextWindow: number;
+  supportsTools: boolean;
 }
 
 /**
@@ -27,42 +28,49 @@ export const MODEL_REGISTRY = {
     displayName: "Llama 3.3 70B",
     provider: "Meta",
     contextWindow: 131_072,
+    supportsTools: true,
   },
   "mistralai/mistral-large-2411": {
     id: "mistralai/mistral-large-2411",
     displayName: "Mistral Large 2411",
     provider: "Mistral",
     contextWindow: 131_072,
+    supportsTools: true,
   },
   "qwen/qwen3-235b-a22b": {
     id: "qwen/qwen3-235b-a22b",
     displayName: "Qwen 3 235B",
     provider: "Qwen",
     contextWindow: 131_072,
+    supportsTools: true,
   },
   "openai/gpt-oss-120b": {
     id: "openai/gpt-oss-120b",
     displayName: "GPT-OSS 120B",
     provider: "OpenAI",
     contextWindow: 131_072,
+    supportsTools: true,
   },
   "meta-llama/llama-4-maverick": {
     id: "meta-llama/llama-4-maverick",
     displayName: "Llama 4 Maverick",
     provider: "Meta",
     contextWindow: 1_048_576,
+    supportsTools: true,
   },
   "nvidia/nemotron-3-super-120b-a12b": {
     id: "nvidia/nemotron-3-super-120b-a12b",
     displayName: "Nemotron 3 Super",
     provider: "NVIDIA",
     contextWindow: 262_144,
+    supportsTools: true,
   },
   "google/gemma-4-31b-it": {
     id: "google/gemma-4-31b-it",
     displayName: "Gemma 4 31B",
     provider: "Google",
     contextWindow: 262_144,
+    supportsTools: false,
   },
 } as const satisfies Record<string, ModelMetadata>;
 
@@ -130,4 +138,16 @@ export function formatContextWindow(tokens: number): string {
     return `${Math.round(tokens / 1_000_000)}M context`;
   }
   return `${Math.round(tokens / 1024)}K context`;
+}
+
+/** Models whose tool-calling is reliable enough for agentic retrieval. */
+export function toolCapableModels(): ModelMetadata[] {
+  return (Object.values(MODEL_REGISTRY) as ModelMetadata[]).filter(
+    (m) => m.supportsTools,
+  );
+}
+
+/** Whether a (possibly deprecated) model id supports tools, after resolution. */
+export function modelSupportsTools(modelId: string): boolean {
+  return MODEL_REGISTRY[resolveModel(modelId)].supportsTools;
 }

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,13 +1,7 @@
 // Centralized model registry -- single source of truth for all model metadata.
 // All consumers import from here; no independent model definitions elsewhere.
 
-export type Provider =
-  | "Meta"
-  | "Mistral"
-  | "Qwen"
-  | "OpenAI"
-  | "NVIDIA"
-  | "Google";
+export type Provider = "Meta" | "Qwen" | "OpenAI" | "NVIDIA" | "DeepSeek";
 
 export interface ModelMetadata {
   id: string;
@@ -23,6 +17,20 @@ export interface ModelMetadata {
  * so there is exactly one place to add, remove, or update models.
  */
 export const MODEL_REGISTRY = {
+  "openai/gpt-oss-120b": {
+    id: "openai/gpt-oss-120b",
+    displayName: "GPT-OSS 120B",
+    provider: "OpenAI",
+    contextWindow: 131_072,
+    supportsTools: true,
+  },
+  "qwen/qwen3-235b-a22b-2507": {
+    id: "qwen/qwen3-235b-a22b-2507",
+    displayName: "Qwen 3 235B (2507)",
+    provider: "Qwen",
+    contextWindow: 262_144,
+    supportsTools: true,
+  },
   "meta-llama/llama-3.3-70b-instruct": {
     id: "meta-llama/llama-3.3-70b-instruct",
     displayName: "Llama 3.3 70B",
@@ -30,25 +38,11 @@ export const MODEL_REGISTRY = {
     contextWindow: 131_072,
     supportsTools: true,
   },
-  "mistralai/mistral-large-2411": {
-    id: "mistralai/mistral-large-2411",
-    displayName: "Mistral Large 2411",
-    provider: "Mistral",
-    contextWindow: 131_072,
-    supportsTools: true,
-  },
-  "qwen/qwen3-235b-a22b": {
-    id: "qwen/qwen3-235b-a22b",
-    displayName: "Qwen 3 235B",
-    provider: "Qwen",
-    contextWindow: 131_072,
-    supportsTools: true,
-  },
-  "openai/gpt-oss-120b": {
-    id: "openai/gpt-oss-120b",
-    displayName: "GPT-OSS 120B",
-    provider: "OpenAI",
-    contextWindow: 131_072,
+  "nvidia/nemotron-3-super-120b-a12b": {
+    id: "nvidia/nemotron-3-super-120b-a12b",
+    displayName: "Nemotron 3 Super",
+    provider: "NVIDIA",
+    contextWindow: 1_000_000,
     supportsTools: true,
   },
   "meta-llama/llama-4-maverick": {
@@ -58,19 +52,12 @@ export const MODEL_REGISTRY = {
     contextWindow: 1_048_576,
     supportsTools: true,
   },
-  "nvidia/nemotron-3-super-120b-a12b": {
-    id: "nvidia/nemotron-3-super-120b-a12b",
-    displayName: "Nemotron 3 Super",
-    provider: "NVIDIA",
-    contextWindow: 262_144,
+  "deepseek/deepseek-v3.2": {
+    id: "deepseek/deepseek-v3.2",
+    displayName: "DeepSeek V3.2",
+    provider: "DeepSeek",
+    contextWindow: 131_072,
     supportsTools: true,
-  },
-  "google/gemma-4-31b-it": {
-    id: "google/gemma-4-31b-it",
-    displayName: "Gemma 4 31B",
-    provider: "Google",
-    contextWindow: 262_144,
-    supportsTools: false,
   },
 } as const satisfies Record<string, ModelMetadata>;
 
@@ -101,8 +88,14 @@ export const SUPPORTED_MODELS = Object.keys(MODEL_REGISTRY) as [
  * Used by resolveModel() to transparently migrate stored model references.
  */
 export const DEPRECATED_MODEL_MAP: Record<string, SupportedModel> = {
-  "mistralai/mistral-large": "mistralai/mistral-large-2411",
-  "qwen/qwen-2.5-72b-instruct": "qwen/qwen3-235b-a22b",
+  // Qwen 3 235B -> the cheaper, larger-context 2507 revision.
+  "qwen/qwen3-235b-a22b": "qwen/qwen3-235b-a22b-2507",
+  "qwen/qwen-2.5-72b-instruct": "qwen/qwen3-235b-a22b-2507",
+  // Mistral dropped (mistral-large-2411 retired from OpenRouter) and Gemma
+  // dropped (unreliable tool-calling) -> migrate to the default tool model.
+  "mistralai/mistral-large": "meta-llama/llama-3.3-70b-instruct",
+  "mistralai/mistral-large-2411": "meta-llama/llama-3.3-70b-instruct",
+  "google/gemma-4-31b-it": "meta-llama/llama-3.3-70b-instruct",
 };
 
 /** List of deprecated model IDs for quick membership checks. */

--- a/packages/ai/src/openrouter-client.ts
+++ b/packages/ai/src/openrouter-client.ts
@@ -75,7 +75,13 @@ export class OpenRouterClient {
    */
   async streamText(params: {
     model: SupportedModel;
-    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    /**
+     * System prompt. Passed via the dedicated `system` option (not as a
+     * role:"system" message) to avoid the AI SDK prompt-injection warning and
+     * keep system instructions out of the user/assistant turn stream.
+     */
+    system?: string;
+    messages: Array<{ role: "user" | "assistant"; content: string }>;
     temperature?: number;
     maxTokens?: number;
     // Agentic additions (all optional; omitted => behaves exactly as before)
@@ -92,6 +98,7 @@ export class OpenRouterClient {
       messages: params.messages,
       temperature: params.temperature ?? 0.7,
       maxOutputTokens: params.maxTokens ?? 2000,
+      ...(params.system ? { system: params.system } : {}),
       ...(params.tools ? { tools: params.tools } : {}),
       ...(params.stopWhen ? { stopWhen: params.stopWhen } : {}),
       ...(params.prepareStep ? { prepareStep: params.prepareStep } : {}),

--- a/packages/ai/src/openrouter-client.ts
+++ b/packages/ai/src/openrouter-client.ts
@@ -78,12 +78,27 @@ export class OpenRouterClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
     temperature?: number;
     maxTokens?: number;
+    // Agentic additions (all optional; omitted => behaves exactly as before)
+    tools?: Parameters<typeof streamText>[0]["tools"];
+    stopWhen?: Parameters<typeof streamText>[0]["stopWhen"];
+    prepareStep?: Parameters<typeof streamText>[0]["prepareStep"];
+    onStepFinish?: Parameters<typeof streamText>[0]["onStepFinish"];
+    experimental_repairToolCall?: Parameters<
+      typeof streamText
+    >[0]["experimental_repairToolCall"];
   }) {
     const result = await streamText({
       model: this.client(params.model),
       messages: params.messages,
       temperature: params.temperature ?? 0.7,
       maxOutputTokens: params.maxTokens ?? 2000,
+      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.stopWhen ? { stopWhen: params.stopWhen } : {}),
+      ...(params.prepareStep ? { prepareStep: params.prepareStep } : {}),
+      ...(params.onStepFinish ? { onStepFinish: params.onStepFinish } : {}),
+      ...(params.experimental_repairToolCall
+        ? { experimental_repairToolCall: params.experimental_repairToolCall }
+        : {}),
     });
 
     return result;

--- a/packages/ai/src/rag-service.ts
+++ b/packages/ai/src/rag-service.ts
@@ -21,11 +21,11 @@ export class RAGService {
   private encoderInitialized: boolean = false;
 
   constructor() {
-    // Initialize text splitter with optimal chunk size
-    // Increased from 1000 to 2500 to reduce number of chunks for large files
+    // Chunk size tuned for citation precision (~250 tokens). Smaller chunks keep a
+    // single claim per embedding, improving close-reading recall (issue #271).
     this.textSplitter = new RecursiveCharacterTextSplitter({
-      chunkSize: 2500,
-      chunkOverlap: 250,
+      chunkSize: 1000,
+      chunkOverlap: 150,
       separators: ["\n\n", "\n", ".", " ", ""],
     });
 

--- a/packages/ai/src/rag-service.ts
+++ b/packages/ai/src/rag-service.ts
@@ -65,6 +65,18 @@ export class RAGService {
   }
 
   /**
+   * Like sanitizeText but preserves form-feed (\f, \x0C) characters so PDF page
+   * boundaries survive sanitization. Per-page text is sanitized normally (with
+   * sanitizeText) once pages are split in chunkPagedText.
+   */
+  private sanitizeTextPreservingFormFeed(text: string): string {
+    return text
+      .replace(/\0/g, "")
+      .replace(/[\x01-\x08\x0B\x0E-\x1F\x7F]/g, " ") // \x0C (\f) preserved
+      .trim();
+  }
+
+  /**
    * Extract text content from various file types
    */
   async extractContent(buffer: Buffer, mimeType: string): Promise<string> {
@@ -135,8 +147,9 @@ export class RAGService {
         throw new Error("PDF parsing returned no text content");
       }
 
-      // Sanitize the text to remove null bytes and other problematic characters
-      const sanitizedText = this.sanitizeText(data.text);
+      // Sanitize the text to remove null bytes and other problematic characters,
+      // but preserve form-feed (\f) page boundaries for page-aware chunking (#271)
+      const sanitizedText = this.sanitizeTextPreservingFormFeed(data.text);
 
       if (!sanitizedText) {
         throw new Error("PDF contains no readable text content");
@@ -281,6 +294,50 @@ export class RAGService {
 
     const chunks = await this.textSplitter.splitText(content);
     return chunks;
+  }
+
+  /**
+   * Split text into pages on form-feed (\f) boundaries, then chunk WITHIN each
+   * page so no chunk spans a page. pageNumber is 1-based by position; empty pages
+   * produce no chunks but still consume a page number (preserves citation accuracy).
+   */
+  async chunkPagedText(
+    text: string,
+  ): Promise<Array<{ content: string; pageNumber: number }>> {
+    const pages = text.split("\f");
+    const result: Array<{ content: string; pageNumber: number }> = [];
+
+    for (let i = 0; i < pages.length; i++) {
+      const pageText = this.sanitizeText(pages[i] ?? "");
+      if (!pageText) continue;
+      const pageChunks = await this.textSplitter.splitText(pageText);
+      for (const content of pageChunks) {
+        if (content.trim().length === 0) continue;
+        result.push({ content, pageNumber: i + 1 });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract + chunk a file. PDFs get page-aware chunks (pageNumber set); all other
+   * types get plain chunks (pageNumber undefined).
+   */
+  async extractAndChunk(
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<Array<{ content: string; pageNumber?: number }>> {
+    if (mimeType === "application/pdf") {
+      const text = await this.extractPDF(buffer);
+      const paged = await this.chunkPagedText(text);
+      if (paged.length > 0) return paged;
+      const flat = await this.chunkText(text);
+      return flat.map((content) => ({ content, pageNumber: 1 }));
+    }
+    const content = await this.extractContent(buffer, mimeType);
+    const chunks = await this.chunkText(content);
+    return chunks.map((c) => ({ content: c }));
   }
 
   /**

--- a/packages/ai/src/rrf.ts
+++ b/packages/ai/src/rrf.ts
@@ -1,0 +1,36 @@
+/** A ranked candidate list from one retrieval method. items[0] is rank 1. */
+export interface RankedList<T> {
+  items: T[];
+  /** Multiplier on this list's RRF contribution. Default 1. */
+  weight?: number;
+}
+
+export interface RRFOptions {
+  /** Smoothing constant. Cormack 2009 default = 60. */
+  k?: number;
+}
+
+/**
+ * Reciprocal Rank Fusion. Fuses multiple ranked lists into one ordering using
+ * only ordinal rank (not raw scores), so heterogeneous scorers (cosine, BM25,
+ * trigram) combine without scale normalization. score(d) = Σ weight_i / (k + rank_i).
+ */
+export function reciprocalRankFusion<T>(
+  lists: Array<RankedList<T>>,
+  options: RRFOptions = {},
+): T[] {
+  const k = options.k ?? 60;
+  const scores = new Map<T, number>();
+
+  for (const { items, weight = 1 } of lists) {
+    items.forEach((item, index) => {
+      const rank = index + 1; // rank is 1-based
+      const contribution = weight / (k + rank);
+      scores.set(item, (scores.get(item) ?? 0) + contribution);
+    });
+  }
+
+  return [...scores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([item]) => item);
+}

--- a/packages/db/scripts/migrate-model-ids.ts
+++ b/packages/db/scripts/migrate-model-ids.ts
@@ -6,9 +6,12 @@
  * safely re-run (idempotent) -- if no rows match the old IDs, zero
  * rows are updated.
  *
- * Mapping:
- *   mistralai/mistral-large       -> mistralai/mistral-large-2411
- *   qwen/qwen-2.5-72b-instruct   -> qwen/qwen3-235b-a22b
+ * Mapping (kept in sync with DEPRECATED_MODEL_MAP in packages/ai/src/models.ts):
+ *   qwen/qwen3-235b-a22b          -> qwen/qwen3-235b-a22b-2507
+ *   qwen/qwen-2.5-72b-instruct    -> qwen/qwen3-235b-a22b-2507
+ *   mistralai/mistral-large       -> meta-llama/llama-3.3-70b-instruct
+ *   mistralai/mistral-large-2411  -> meta-llama/llama-3.3-70b-instruct  (retired from OpenRouter)
+ *   google/gemma-4-31b-it         -> meta-llama/llama-3.3-70b-instruct  (unreliable tool-calling)
  *
  * Usage:
  *   npx tsx packages/db/scripts/migrate-model-ids.ts
@@ -40,8 +43,11 @@ if (!databaseUrl) {
 
 // Inline mapping (self-contained -- no build dependency on models.ts)
 const MODEL_MIGRATIONS: Record<string, string> = {
-  "mistralai/mistral-large": "mistralai/mistral-large-2411",
-  "qwen/qwen-2.5-72b-instruct": "qwen/qwen3-235b-a22b",
+  "qwen/qwen3-235b-a22b": "qwen/qwen3-235b-a22b-2507",
+  "qwen/qwen-2.5-72b-instruct": "qwen/qwen3-235b-a22b-2507",
+  "mistralai/mistral-large": "meta-llama/llama-3.3-70b-instruct",
+  "mistralai/mistral-large-2411": "meta-llama/llama-3.3-70b-instruct",
+  "google/gemma-4-31b-it": "meta-llama/llama-3.3-70b-instruct",
 };
 
 async function migrate() {

--- a/packages/db/scripts/setup-extensions.sql
+++ b/packages/db/scripts/setup-extensions.sql
@@ -19,3 +19,17 @@
 -- This is required for the RAG (Retrieval Augmented Generation) functionality
 -- to store and query embeddings in the file_chunks table
 CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Enable pg_trgm for trigram (fuzzy / exact-substring) lexical search.
+-- Used alongside tsvector full-text search in hybrid retrieval (issue #271).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Lexical search indexes on file_chunks.content for hybrid retrieval.
+-- CONCURRENTLY is safe here: this file runs outside a transaction.
+-- Full-text (tsvector) expression index — zero-downtime, no stored column / table rewrite.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS file_chunks_fts_gin
+  ON file_chunks USING gin (to_tsvector('english', content));
+
+-- Trigram index for fuzzy / exact-substring matching.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS file_chunks_content_trgm_gin
+  ON file_chunks USING gin (content gin_trgm_ops);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -331,6 +331,8 @@ export const messages = pgTable(
           fileName: string;
           chunkIndex: number;
           similarity: number;
+          // Optional: only agentic-retrieval sources carry page numbers.
+          pageNumber?: number | null;
         }>;
         responseTime?: number;
         model?: string;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -204,6 +204,7 @@ export const userFiles = pgTable("user_files", {
     .notNull(),
   metadata: jsonb("metadata")
     .$type<{
+      processingVersion?: number;
       error?: string;
       chunkCount?: number;
       processedAt?: string;


### PR DESCRIPTION
## Summary

Fixes #271 — RAG missing specific PDF details and answering with overconfident false denials.

Replaces single-shot static top-k injection with **agentic retrieval**: tool-capable models call retrieval tools mid-turn (hybrid search + page/neighbor lookups), ground answers in what they find, and cite page numbers. Static RAG injection is kept as a fallback. Backed by **page-aware PDF ingestion** and **triple-fusion hybrid retrieval** (vector + Postgres full-text + trigram, fused via Reciprocal Rank Fusion).

## What changed

**Data layer**
- `pg_trgm` extension + FTS (`tsvector`) and trigram GIN indexes on `file_chunks` (`CREATE INDEX CONCURRENTLY`, non-destructive) in `setup-extensions.sql`
- `processingVersion` on `userFiles.metadata`

**Ingestion**
- Page-aware PDF chunking: split on form-feed `\f`, chunk within page boundaries, tag `pageNumber` (fixed `sanitizeText` stripping `\f`)
- Chunk size 2500/250 → 1000/150 for citation precision
- Persist `pageNumber` + stamp `processingVersion`

**Retrieval**
- `reciprocalRankFusion` helper (k=60, weighted)
- Chatbot-scoped triple-fusion hybrid search (vector + tsvector + trigram), quoted-phrase FTS boost

**Agentic layer**
- `supportsTools` flag on `MODEL_REGISTRY` (Gemma marked false — broken tool-calling via OpenRouter); model picker filtered to tool-capable models (legacy saved model still shown)
- 5 AI SDK v6 tools: `search_documents`, `get_page`, `get_context_around`, `list_documents`, `done`
- `streamText` multi-step loop: `stopWhen [stepCountIs(6), hasToolCall("done")]`, `prepareStep` forces search on step 0
- Grounding/anti-denial prompt; sources carry page numbers
- Static RAG path is the fallback (non-tool models, zero-tool-call turns, empty agentic output)

**Safety / UX**
- Authz: `search_documents` scopes model-supplied `fileId` to the chatbot (defense in depth in tool + `hybridSearch`)
- Never-empty answers: the model phrases its own "couldn't find it" via the static fallback (no hardcoded string); truly-empty turns stop the loader cleanly and aren't persisted
- Live agentic status line ("Searching documents…", "Reading page 14…") + page-number source badges (dedup by file+page)
- Lazy reprocess: stale (pre-v2) files re-enqueued non-blocking on chat access

## Test plan
- [x] `npm run check-types`, `npm run lint`, `npm run test` (355 web + 49 ai + 10 db pass; includes new RRF, page-chunking, models, message-sources, retrieval-tools tests)
- [ ] Run migration: `npm run db:setup-extensions` against the DB
- [ ] Live E2E: tool-capable model + multi-page PDF → the previously-failing close-reading question cites a page instead of denying
- [ ] Verify an empty-search question returns a real model sentence (not blank, not canned)

## Notes / follow-ups
- Open-weight tool reliability mitigated via `supportsTools` gating + forced step-0 search + static fallback + `experimental_repairToolCall` + tool-name lowercase normalization
- Known minor: lazy-reprocess can double-publish in the window between enqueue and job start (work is idempotent); no automated test yet for the empty-turn UI path
- `apps/web` and `packages/ai` resolve different `ai` minor versions — one localized boundary cast in `chat.ts` (commented); worth aligning later
