### PR TITLE
fix(db): setup-extensions must run statements individually for CONCURRENTLY

### DIFF
--- a/packages/db/scripts/setup-extensions.ts
+++ b/packages/db/scripts/setup-extensions.ts
@@ -45,13 +45,26 @@ async function setupExtensions() {
   try {
     console.log("🔧 Enabling required database extensions...");
 
-    // Read and execute the SQL file from same directory
+    // Read the SQL file from the same directory
     const sqlContent = readFileSync(
       resolve(__dirname, "./setup-extensions.sql"),
       "utf-8",
     );
 
-    await sql.unsafe(sqlContent);
+    // Execute statements one at a time. Sending the whole file as a single
+    // multi-statement simple query makes Postgres wrap it in an implicit
+    // transaction block, which breaks `CREATE INDEX CONCURRENTLY` ("cannot run
+    // inside a transaction block"). Running each statement on its own keeps it
+    // auto-committed so CONCURRENTLY is allowed. Chunks that are only comments
+    // (e.g. trailing) are skipped.
+    const statements = sqlContent
+      .split(";")
+      .map((s) => s.trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+
+    for (const statement of statements) {
+      await sql.unsafe(statement);
+    }
 
     console.log("✅ Database extensions enabled successfully");
   } catch (error) {


### PR DESCRIPTION
## Problem
The 1.28.0 `deploy-production` job failed at **Run database migrations**:
`CREATE INDEX CONCURRENTLY cannot run inside a transaction block`.

`setup-extensions.ts` sent the whole .sql file as one multi-statement `sql.unsafe()` call. Postgres wraps a multi-statement simple query in an implicit transaction, which forbids `CREATE INDEX CONCURRENTLY`. So the pg_trgm/FTS GIN indexes never got created and prod was not promoted.

## Fix
Split the file and run each statement as its own auto-commit query, so CONCURRENTLY is allowed. Extensions + indexes are all idempotent (`IF NOT EXISTS`).

## After merge
The release PR for this will run `deploy-production` → `db:migrate` again; the migration step should now go green and create the indexes, then promote to production.