### PR TITLE
fix(chat): stop inline citation markers in answers

### DIFF
--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -356,8 +356,10 @@ async function* processMessage(params: {
       : "";
     const groundingRule =
       "\n\nYou can search the attached documents using tools. You MUST call search_documents before stating whether the documents do or do not contain something. " +
-      "Never say 'the document does not mention X' -- if a search returns nothing, say 'I couldn't find that in the materials.' " +
-      "Cite the file name and page number for each claim, and include the exact quote you relied on.";
+      "If a search returns nothing, say you couldn't find it in the materials rather than denying it exists. " +
+      "Do NOT put inline citations, source tags, page numbers, bracketed reference markers, or JSON anchors " +
+      '(e.g. "(file.pdf, p. 2)" or "【…】") in your answer text -- the app shows the user the sources ' +
+      "separately. Reply in clean prose.";
     const systemPrompt =
       nemotronPrefix +
       chatbot.systemPrompt +


### PR DESCRIPTION
Model was emitting inline `(file.pdf, p.1)` and invented JSON anchors like `【{"id":3,...}`】 because the grounding prompt told it to cite file+page per claim. The UI already shows source badges, so the inline citations are redundant noise. Reworded the grounding rule to forbid inline citations / page refs / bracketed markers and reply in clean prose (kept the must-search-before-denial rule).