### PR TITLE
perf(chat): fix many-files slowness/timeouts (reprocess throttle + manifest cap + step budget)

### DIFF
--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -106,10 +106,20 @@ export async function buildRAGContext(
     }
   }
 
-  // 2. Build file manifest (D-01, D-03: anti-hallucination instruction)
+  // 2. Build file manifest (D-01, D-03: anti-hallucination instruction).
+  // Cap the listed names so chatbots with many files don't bloat the system
+  // prompt (it is re-sent on every agentic step). The model can always discover
+  // the full set via the list_documents tool / search.
+  const MANIFEST_FILE_LIMIT = 20;
   const fileManifest =
     fileNames.length > 0
-      ? `\n\nYou have access to these documents: [${fileNames.join(", ")}]. When asked about files, refer only to this list. Do not invent or guess file names.`
+      ? `\n\nYou have access to ${fileNames.length} document${fileNames.length === 1 ? "" : "s"}, including: [${fileNames
+          .slice(0, MANIFEST_FILE_LIMIT)
+          .join(", ")}${
+          fileNames.length > MANIFEST_FILE_LIMIT
+            ? `, and ${fileNames.length - MANIFEST_FILE_LIMIT} more`
+            : ""
+        }]. When asked about files, refer only to documents that actually exist. Do not invent or guess file names.`
       : "";
 
   // 3. Short-circuit if no completed files (skip embedding API call entirely)

--- a/apps/web/src/server/reprocess.ts
+++ b/apps/web/src/server/reprocess.ts
@@ -6,6 +6,9 @@ import { env } from "@/lib/env";
 import { logError, logInfo } from "@/lib/logger";
 import type { db as DbType } from "@teachanything/db";
 
+/** Max stale files (re)enqueued per chat access — throttles the migration burst. */
+const REPROCESS_BATCH_SIZE = 5;
+
 /**
  * Lazily reprocess files ingested under an older processing version so they gain
  * page-aware chunks + pageNumber metadata (issue #271). Non-blocking and
@@ -29,7 +32,12 @@ export async function maybeEnqueueReprocess(
             sql`(${userFiles.metadata} ->> 'processingVersion')::int < ${CURRENT_PROCESSING_VERSION}`,
           ),
         ),
-      );
+      )
+      // Throttle: only (re)enqueue a small batch per chat access so a chatbot
+      // with many stale files doesn't fire a thundering herd of reprocess jobs
+      // that starves the live request. In-flight files flip to "processing" and
+      // drop out of this query, so successive accesses drain the rest.
+      .limit(REPROCESS_BATCH_SIZE);
     if (stale.length === 0) return;
     logInfo("Lazy reprocess: enqueuing stale files", {
       chatbotId,

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -378,7 +378,7 @@ async function* processMessage(params: {
       tools: tools as unknown as Parameters<
         OpenRouterClient["streamText"]
       >[0]["tools"],
-      stopWhen: [stepCountIs(6), hasToolCall("done")],
+      stopWhen: [stepCountIs(4), hasToolCall("done")],
       prepareStep: async ({ stepNumber }) =>
         stepNumber === 0
           ? {


### PR DESCRIPTION
Many-file chatbots were timing out. Three compounding causes fixed:

1. **Reprocess burst** — post-deploy, every file is v1 so each access enqueued ALL stale files at once, starving the live request. Now capped to 5 per access (in-flight files drop out of the query, so successive accesses drain the rest).
2. **File manifest bloat** — the system prompt listed every filename and is re-sent on each agentic step. Capped to 20 names + 'and N more'; the model can still discover all via list_documents.
3. **Step budget** — agentic loop `stepCountIs(6)` -> 4, fewer sequential model round-trips.

Together these address both the temporary migration spike and the permanent O(files) per-request cost.