### PR TITLE
fix(files): externalize officeparser to fix PowerPoint upload error

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,9 +3,10 @@ const nextConfig = {
   images: {
     qualities: [75, 90, 95, 100],
   },
-  // Externalize pdf-parse to avoid bundling issues
-  // pdf-parse uses Node.js-specific modules that can't be bundled by webpack
-  serverExternalPackages: ["pdf-parse"],
+  // Externalize parsers that can't be bundled. pdf-parse uses Node.js-specific
+  // modules; officeparser dynamically requires `file-type` at runtime, which the
+  // bundler fails to trace into the function chunk (Cannot find package 'file-type').
+  serverExternalPackages: ["pdf-parse", "officeparser"],
   output: "standalone",
 };
 


### PR DESCRIPTION
## Problem

PowerPoint (.pptx) uploads fail in production during text extraction:

```
Failed to extract PowerPoint content: [OfficeParser]: Cannot find package 'file-type'
  imported from /var/task/apps/web/.next/server/chunks/node_modules_0i_i2an._.js
```

`officeparser` dynamically requires `file-type` at runtime. The Next standalone bundler bundles `officeparser` itself but fails to trace its `file-type` dependency into the serverless function chunk, so the require throws at runtime and every PowerPoint file processing job fails.

## Fix

Add `officeparser` to `serverExternalPackages`. This leaves it as a normal `node_modules` require instead of bundling it, so its `file-type` dependency resolves normally. Same pattern already in place for `pdf-parse`.

`officeparser` is a production dependency of `@teachanything/ai`, so it (and its transitive `file-type`) ships in `node_modules`.

## Testing

- types, lint, full test suite pass via pre-commit hook
- Post-merge: redeploy, re-upload a .pptx, confirm extraction succeeds