### PR TITLE
fix(chat): retire nemotron from tool models + cap static-path chunks

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,9 +3,10 @@ const nextConfig = {
   images: {
     qualities: [75, 90, 95, 100],
   },
-  // Externalize pdf-parse to avoid bundling issues
-  // pdf-parse uses Node.js-specific modules that can't be bundled by webpack
-  serverExternalPackages: ["pdf-parse"],
+  // Externalize parsers that can't be bundled. pdf-parse uses Node.js-specific
+  // modules; officeparser dynamically requires `file-type` at runtime, which the
+  // bundler fails to trace into the function chunk (Cannot find package 'file-type').
+  serverExternalPackages: ["pdf-parse", "officeparser"],
   output: "standalone",
 };
 

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -351,9 +351,6 @@ async function* processMessage(params: {
     },
     void
   > {
-    const nemotronPrefix = modelId.includes("nemotron")
-      ? "detailed thinking on\n\n"
-      : "";
     const groundingRule =
       "\n\nYou can search the attached documents using tools. You MUST call search_documents before stating whether the documents do or do not contain something. " +
       "If a search returns nothing, say you couldn't find it in the materials rather than denying it exists. " +
@@ -361,10 +358,7 @@ async function* processMessage(params: {
       '(e.g. "(file.pdf, p. 2)" or "【…】") in your answer text -- the app shows the user the sources ' +
       "separately. Reply in clean prose.";
     const systemPrompt =
-      nemotronPrefix +
-      chatbot.systemPrompt +
-      ragResult.fileManifest +
-      groundingRule;
+      chatbot.systemPrompt + ragResult.fileManifest + groundingRule;
 
     const result = await aiClient.streamText({
       model: modelId,

--- a/packages/ai/src/__tests__/models.test.ts
+++ b/packages/ai/src/__tests__/models.test.ts
@@ -14,13 +14,18 @@ describe("supportsTools gating", () => {
   it("every registered model is tool-capable (picker requires tools)", () => {
     expect(toolCapableModels().length).toBe(Object.keys(MODEL_REGISTRY).length);
   });
-  it("dropped models (Gemma, Mistral) are no longer registered", () => {
+  it("dropped models (Gemma, Mistral, Nemotron) are no longer registered", () => {
     expect(
       (MODEL_REGISTRY as Record<string, unknown>)["google/gemma-4-31b-it"],
     ).toBeUndefined();
     expect(
       (MODEL_REGISTRY as Record<string, unknown>)[
         "mistralai/mistral-large-2411"
+      ],
+    ).toBeUndefined();
+    expect(
+      (MODEL_REGISTRY as Record<string, unknown>)[
+        "nvidia/nemotron-3-super-120b-a12b"
       ],
     ).toBeUndefined();
   });
@@ -34,5 +39,6 @@ describe("supportsTools gating", () => {
     expect(modelSupportsTools("qwen/qwen3-235b-a22b")).toBe(true);
     expect(modelSupportsTools("mistralai/mistral-large")).toBe(true);
     expect(modelSupportsTools("google/gemma-4-31b-it")).toBe(true);
+    expect(modelSupportsTools("nvidia/nemotron-3-super-120b-a12b")).toBe(true);
   });
 });

--- a/packages/ai/src/__tests__/token-budget.test.ts
+++ b/packages/ai/src/__tests__/token-budget.test.ts
@@ -5,6 +5,7 @@ import {
   BUDGET_RATIO,
   CHUNK_SHARE,
   AVG_CHUNK_TOKENS,
+  MAX_CONTEXT_CHUNKS,
 } from "../token-budget";
 import type { TokenBudgetInput } from "../token-budget";
 
@@ -203,16 +204,14 @@ describe("token-budget", () => {
       expect(result).toBe(199);
     });
 
-    it("returns ~803 for 1M model with typical fixed costs", () => {
+    it("caps at MAX_CONTEXT_CHUNKS for 1M model instead of 803", () => {
       const result = calculateChunkLimit({
         ...typicalFixed,
         contextWindow: 1_048_576,
       });
-      // inputBudget = floor(1048576 * 0.8) - 2000 = 838860 - 2000 = 836860
-      // remaining = 836860 - 33 - 78 - 21 = 836728
-      // chunkBudget = floor(836728 * 0.6) = 502036
-      // chunkLimit = floor(502036 / 625) = 803
-      expect(result).toBe(803);
+      // Uncapped this would be floor(502036 / 625) = 803, but MAX_CONTEXT_CHUNKS
+      // bounds the static-path payload so oversized prompts don't 502.
+      expect(result).toBe(MAX_CONTEXT_CHUNKS);
     });
 
     it("clamps to 0 when fixed costs exceed budget", () => {

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,7 +1,7 @@
 // Centralized model registry -- single source of truth for all model metadata.
 // All consumers import from here; no independent model definitions elsewhere.
 
-export type Provider = "Meta" | "Qwen" | "OpenAI" | "NVIDIA" | "DeepSeek";
+export type Provider = "Meta" | "Qwen" | "OpenAI" | "DeepSeek";
 
 export interface ModelMetadata {
   id: string;
@@ -36,13 +36,6 @@ export const MODEL_REGISTRY = {
     displayName: "Llama 3.3 70B",
     provider: "Meta",
     contextWindow: 131_072,
-    supportsTools: true,
-  },
-  "nvidia/nemotron-3-super-120b-a12b": {
-    id: "nvidia/nemotron-3-super-120b-a12b",
-    displayName: "Nemotron 3 Super",
-    provider: "NVIDIA",
-    contextWindow: 1_000_000,
     supportsTools: true,
   },
   "meta-llama/llama-4-maverick": {
@@ -96,6 +89,11 @@ export const DEPRECATED_MODEL_MAP: Record<string, SupportedModel> = {
   "mistralai/mistral-large": "meta-llama/llama-3.3-70b-instruct",
   "mistralai/mistral-large-2411": "meta-llama/llama-3.3-70b-instruct",
   "google/gemma-4-31b-it": "meta-llama/llama-3.3-70b-instruct",
+  // Nemotron 3 Super dropped: OpenRouter serves it in v2 compatibility mode
+  // where the step-0 forced tool choice silently never fires, so the agentic
+  // retrieval loop produces no tool call and no text (~50s of dead reasoning)
+  // before falling back. Migrate to the strongest tool model (Qwen 3 235B).
+  "nvidia/nemotron-3-super-120b-a12b": "qwen/qwen3-235b-a22b-2507",
 };
 
 /** List of deprecated model IDs for quick membership checks. */

--- a/packages/ai/src/token-budget.ts
+++ b/packages/ai/src/token-budget.ts
@@ -17,6 +17,17 @@ export const CHARS_PER_TOKEN = 4;
 /** Conservative average chunk token estimate: 2500 chars / CHARS_PER_TOKEN (D-05). */
 export const AVG_CHUNK_TOKENS = 625;
 
+/**
+ * Hard ceiling on chunks injected into a single static-path request, regardless
+ * of how large the model's context window is. Without this, million-token
+ * models (e.g. Llama 4 Maverick) would inject 800+ chunks into one prompt; that
+ * oversized payload makes OpenRouter return `502 provider_unavailable`
+ * ("Response payload is not completed"). 256 leaves 128K/262K models unaffected
+ * (they self-limit below it) while bounding the 1M models. The agentic path is
+ * primary and tool-bounded; this only caps the static fallback.
+ */
+export const MAX_CONTEXT_CHUNKS = 256;
+
 /** Input for the full budget allocation (Pass 2). */
 export interface TokenBudgetInput {
   contextWindow: number;
@@ -68,7 +79,10 @@ export function calculateChunkLimit(input: {
   const remaining = Math.max(0, inputBudget - fixedTokens);
   const chunkBudget = Math.floor(remaining * CHUNK_SHARE);
 
-  return Math.max(0, Math.floor(chunkBudget / AVG_CHUNK_TOKENS));
+  return Math.min(
+    MAX_CONTEXT_CHUNKS,
+    Math.max(0, Math.floor(chunkBudget / AVG_CHUNK_TOKENS)),
+  );
 }
 
 /**
@@ -115,6 +129,7 @@ export function allocateTokenBudget(
   let chunkLimit = 0;
 
   for (const chunk of input.availableChunks) {
+    if (chunkLimit >= MAX_CONTEXT_CHUNKS) break;
     if (actualChunkTokens + chunk.tokens > chunkBudget) break;
     actualChunkTokens += chunk.tokens;
     chunkLimit++;


### PR DESCRIPTION
## Problem

A live shared chatbot ("Essential Shakespeare and Film", model `nvidia/nemotron-3-super-120b-a12b`) hung in "Thinking…" until timeout on every substantive question. Production logs showed **two compounding bugs**:

```
RAG built: 36 files, 762 chunks, chunkLimit=762
WARN: nemotron in "compatibility mode" — "Some features may not be available"
WARN: Agentic path produced no text, anyToolCall=false      ← ~50s, nothing
ERROR 502: "Response payload is not completed" (provider_unavailable)
```

1. **Nemotron ignores the forced tool call.** OpenRouter serves nemotron in v2 compatibility mode, where the step-0 forced `toolChoice: search_documents` silently never fires. The agentic loop produced no tool call and no text (`anyToolCall=false`) for ~50s — a reasoning model streaming dead reasoning tokens (the "Thinking…" the user saw) — before falling back. Our own model-reliability research ranked nemotron lowest for tool-calling.

2. **Static fallback payload is unbounded.** `calculateChunkLimit` scales with context window, so on nemotron's 1M window it selected all 762 chunks and injected them into one prompt. OpenRouter returned `502 provider_unavailable` on the oversized payload.

## Fix

1. **Retire nemotron** from `MODEL_REGISTRY`; migrate existing references to `qwen/qwen3-235b-a22b-2507` (strongest tool model) via `DEPRECATED_MODEL_MAP`. Existing nemotron chatbots resolve to Qwen transparently at read time — no data migration needed. (The affected prod bot was already switched manually to confirm the fix; verified working.)
2. **Cap static-path chunks** at `MAX_CONTEXT_CHUNKS = 256` in both budget passes. 128K/262K models self-limit below it and are unaffected; 1M models (Llama 4 Maverick) are now bounded so the static fallback can't 502.
3. Remove the now-dead nemotron `detailed thinking on` prefix in `chat.ts`.

## Testing

- `check-types`, `lint`, full suite (426 tests) pass
- Added assertions: nemotron unregistered + resolves to a tool-capable model; 1M-context chunk limit caps at `MAX_CONTEXT_CHUNKS`

## Notes

The static path is fallback-only (agentic is primary), so the chunk cap doesn't affect normal tool-based retrieval. A follow-up could add a wall-clock guard so any silent model can't burn ~50s before falling back.