### PR TITLE
fix(chat): cut agentic RAG latency and harden stream transport

### DIFF
--- a/apps/web/src/__tests__/lib/message-sources.test.ts
+++ b/apps/web/src/__tests__/lib/message-sources.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "@jest/globals";
-import { dedupeSourcesByFileName, describeSource } from "@/lib/message-sources";
+import {
+  dedupeSourcesByFileName,
+  describeSource,
+  sourceDisplayName,
+} from "@/lib/message-sources";
 
 describe("dedupeSourcesByFileName", () => {
   it("keeps the highest-similarity chunk per file", () => {
@@ -41,6 +45,36 @@ describe("dedupeSourcesByFileName", () => {
 
   it("returns the input untouched when empty", () => {
     expect(dedupeSourcesByFileName([])).toEqual([]);
+  });
+});
+
+describe("sourceDisplayName", () => {
+  it("collapses crawler URLs to Web: <hostname>", () => {
+    expect(
+      sourceDisplayName("Course Syllabus", "https://example.edu/syllabus"),
+    ).toBe("Web: example.edu");
+    expect(sourceDisplayName("Page", "http://sub.example.com/a/b?q=1")).toBe(
+      "Web: sub.example.com",
+    );
+  });
+
+  it("keeps the file name for storage-path uploads", () => {
+    expect(sourceDisplayName("syllabus.pdf", "uploads/user/syllabus.pdf")).toBe(
+      "syllabus.pdf",
+    );
+  });
+
+  it("keeps the file name when storagePath is missing", () => {
+    expect(sourceDisplayName("syllabus.pdf", null)).toBe("syllabus.pdf");
+    expect(sourceDisplayName("syllabus.pdf", undefined)).toBe("syllabus.pdf");
+  });
+
+  it("falls back to the raw name on a malformed URL", () => {
+    expect(sourceDisplayName("page.html", "http://")).toBe("page.html");
+  });
+
+  it("labels an empty file name as Unknown", () => {
+    expect(sourceDisplayName("", "uploads/x")).toBe("Unknown");
   });
 });
 

--- a/apps/web/src/__tests__/server/chat-helpers.test.ts
+++ b/apps/web/src/__tests__/server/chat-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "@jest/globals";
-import { clampMaxTokens, describeToolActivity } from "@/server/chat-helpers";
+import {
+  clampMaxTokens,
+  describeToolActivity,
+  mergeSources,
+} from "@/server/chat-helpers";
 
 describe("clampMaxTokens", () => {
   it("returns the default for null/undefined/NaN", () => {
@@ -47,5 +51,57 @@ describe("describeToolActivity", () => {
   it("never throws on missing input and uses a generic fallback", () => {
     expect(describeToolActivity("done", undefined)).toBe("Working…");
     expect(describeToolActivity("unknown_tool", null)).toBe("Working…");
+  });
+});
+
+describe("mergeSources", () => {
+  const rag = (fileName: string, chunkIndex: number, similarity = 0.8) => ({
+    fileName,
+    chunkIndex,
+    similarity,
+  });
+  const tool = (
+    fileName: string,
+    chunkIndex: number,
+    similarity: number | null = 0.5,
+    pageNumber: number | null = null,
+  ) => ({ fileName, chunkIndex, similarity, pageNumber });
+
+  it("returns rag sources unchanged when no tool sources exist", () => {
+    const sources = [rag("a.pdf", 0), rag("b.pdf", 3)];
+    expect(mergeSources(sources, [])).toEqual(sources);
+  });
+
+  it("appends tool-discovered chunks after the injected sources", () => {
+    const merged = mergeSources([rag("a.pdf", 0)], [tool("b.pdf", 2, 0.6, 4)]);
+    expect(merged).toEqual([
+      rag("a.pdf", 0),
+      { fileName: "b.pdf", chunkIndex: 2, similarity: 0.6, pageNumber: 4 },
+    ]);
+  });
+
+  it("dedupes by file + chunk, keeping the injected source", () => {
+    const merged = mergeSources(
+      [rag("a.pdf", 0, 0.9)],
+      [tool("a.pdf", 0, 0.4), tool("a.pdf", 1)],
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toEqual(rag("a.pdf", 0, 0.9));
+    expect(merged[1]?.chunkIndex).toBe(1);
+  });
+
+  it("dedupes repeated tool sources (same chunk hit by multiple searches)", () => {
+    const merged = mergeSources([], [tool("a.pdf", 5), tool("a.pdf", 5)]);
+    expect(merged).toHaveLength(1);
+  });
+
+  it("coerces null tool similarity to 0", () => {
+    const merged = mergeSources([], [tool("a.pdf", 1, null)]);
+    expect(merged[0]?.similarity).toBe(0);
+  });
+
+  it("does not conflate same chunk index across different files", () => {
+    const merged = mergeSources([rag("a.pdf", 1)], [tool("b.pdf", 1)]);
+    expect(merged).toHaveLength(2);
   });
 });

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -6,6 +6,12 @@ import { env } from "@/lib/env";
 // Disable static optimization for API routes
 export const dynamic = "force-dynamic";
 
+// Chat subscriptions stream long agentic turns (multiple LLM round trips plus
+// retrieval) through this route. Without an explicit maxDuration Vercel applies
+// the project default, which can kill the function mid-stream -- the client's
+// EventSource then reconnects and replays the whole message.
+export const maxDuration = 300;
+
 const handler = (req: Request) =>
   fetchRequestHandler({
     endpoint: "/api/trpc",

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -31,7 +31,9 @@ export function useChat(shareToken: string) {
     messageToSend ?? { shareToken: "", message: "", sessionId: undefined },
     {
       enabled: !!messageToSend,
-      onData: state.handleStreamData,
+      // Events arrive as tracked envelopes ({ id, data }) so the server can
+      // tell a reconnect replay from a fresh message; unwrap the payload.
+      onData: (envelope) => state.handleStreamData(envelope.data),
       onError: state.handleStreamError,
     },
   );

--- a/apps/web/src/hooks/useChatState.ts
+++ b/apps/web/src/hooks/useChatState.ts
@@ -188,9 +188,15 @@ export function useChatState() {
   };
 
   /** Shared onError handler for tRPC streaming subscriptions. */
-  const handleStreamError = () => {
+  const handleStreamError = (error?: { data?: { code?: string } | null }) => {
     clearStreamingTimeout();
-    toast.error("Failed to send message. Please try again.");
+    // CONFLICT is the server refusing an EventSource reconnect replay: the
+    // stream died mid-turn and regenerating would duplicate the answer.
+    toast.error(
+      error?.data?.code === "CONFLICT"
+        ? "The connection was interrupted. Keeping the partial response."
+        : "Failed to send message. Please try again.",
+    );
     setIsStreaming(false);
     setIsThinking(false);
     setStatusLabel(null);

--- a/apps/web/src/hooks/useChatbot.ts
+++ b/apps/web/src/hooks/useChatbot.ts
@@ -28,7 +28,9 @@ export function useChatbot(
     messageToSend ?? { chatbotId: "", message: "", sessionId: undefined },
     {
       enabled: !!messageToSend,
-      onData: state.handleStreamData,
+      // Events arrive as tracked envelopes ({ id, data }) so the server can
+      // tell a reconnect replay from a fresh message; unwrap the payload.
+      onData: (envelope) => state.handleStreamData(envelope.data),
       onError: state.handleStreamError,
     },
   );

--- a/apps/web/src/lib/message-sources.ts
+++ b/apps/web/src/lib/message-sources.ts
@@ -37,6 +37,28 @@ export function dedupeSourcesByFileName<
 const WEB_PREFIX = "Web: ";
 
 /**
+ * Display name for a retrieved chunk's source. Crawler-sourced files carry a
+ * URL in storagePath -- collapse them to `Web: <hostname>` so many pages from
+ * one site dedupe into a single badge. Uploads keep their file name. Used by
+ * both the static RAG path and the agentic retrieval tools so their source
+ * names match and merge/dedupe correctly.
+ */
+export function sourceDisplayName(
+  fileName: string,
+  storagePath: string | null | undefined,
+): string {
+  const rawName = fileName || "Unknown";
+  if (storagePath && /^https?:\/\//i.test(storagePath)) {
+    try {
+      return `${WEB_PREFIX}${new URL(storagePath).hostname}`;
+    } catch {
+      // malformed URL, fall back to raw filename
+    }
+  }
+  return rawName;
+}
+
+/**
  * rag-context.ts tags crawler-sourced chunks as `Web: <hostname>` so many
  * pages from the same site collapse to one badge. Splitting returns the
  * human label (without the prefix) and whether it came from the web.

--- a/apps/web/src/server/chat-helpers.ts
+++ b/apps/web/src/server/chat-helpers.ts
@@ -17,6 +17,49 @@ export function clampMaxTokens(maxTokens: number | null | undefined): number {
   return Math.max(MIN_TOKENS, Math.min(MAX_TOKENS, maxTokens));
 }
 
+export interface ChatSource {
+  fileName: string;
+  chunkIndex: number;
+  similarity: number;
+  pageNumber?: number | null;
+}
+
+export interface ToolSource {
+  fileName: string;
+  chunkIndex: number;
+  pageNumber: number | null;
+  similarity: number | null;
+}
+
+/**
+ * Merge the statically-injected RAG sources with sources accumulated from
+ * agentic tool calls, deduping by file + chunk. Injected sources keep their
+ * position; tool-discovered chunks are appended in call order. Tool similarity
+ * is coerced null -> 0 so existing consumers (which expect a number and
+ * dedupe/score on it) keep working.
+ */
+export function mergeSources(
+  ragSources: ChatSource[],
+  toolSources: ToolSource[],
+): ChatSource[] {
+  const seen = new Set(
+    ragSources.map((s) => `${s.fileName}\u0000${s.chunkIndex}`),
+  );
+  const merged = [...ragSources];
+  for (const s of toolSources) {
+    const key = `${s.fileName}\u0000${s.chunkIndex}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({
+      fileName: s.fileName,
+      chunkIndex: s.chunkIndex,
+      similarity: s.similarity ?? 0,
+      pageNumber: s.pageNumber,
+    });
+  }
+  return merged;
+}
+
 /**
  * Map an agentic retrieval tool-call to a human-readable status label shown in
  * the live status line while the model works. Only the action + the

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -17,6 +17,8 @@ export interface HybridChunk {
   chunkId: string;
   fileId: string;
   fileName: string;
+  /** Supabase path for uploads, source URL for crawled pages. */
+  storagePath: string;
   chunkIndex: number;
   pageNumber: number | null;
   content: string;
@@ -62,42 +64,46 @@ export async function hybridSearch(
     isNotNull(fileChunks.embedding),
   );
 
-  // 1. Vector candidates (HNSW, distance ascending)
-  const vectorRows = await db
-    .select({
-      chunkId: fileChunks.id,
-      similarity: sql<number>`1 - (${fileChunks.embedding} <=> ${embeddingLiteral})`,
-    })
-    .from(fileChunks)
-    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
-    .where(baseWhere)
-    .orderBy(sql`${fileChunks.embedding} <=> ${embeddingLiteral}`)
-    .limit(overfetch);
+  // The three retrievers are independent -- run them concurrently so the
+  // search costs one DB round trip instead of three.
+  const [vectorRows, ftsRows, trgmRows] = await Promise.all([
+    // 1. Vector candidates (HNSW, distance ascending)
+    db
+      .select({
+        chunkId: fileChunks.id,
+        similarity: sql<number>`1 - (${fileChunks.embedding} <=> ${embeddingLiteral})`,
+      })
+      .from(fileChunks)
+      .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+      .where(baseWhere)
+      .orderBy(sql`${fileChunks.embedding} <=> ${embeddingLiteral}`)
+      .limit(overfetch),
 
-  // 2. Full-text candidates (websearch_to_tsquery + ts_rank_cd)
-  const ftsRows = await db
-    .select({ chunkId: fileChunks.id })
-    .from(fileChunks)
-    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
-    .where(
-      and(
-        baseWhere,
-        sql`to_tsvector('english', ${fileChunks.content}) @@ websearch_to_tsquery('english', ${query})`,
-      ),
-    )
-    .orderBy(
-      sql`ts_rank_cd(to_tsvector('english', ${fileChunks.content}), websearch_to_tsquery('english', ${query})) DESC`,
-    )
-    .limit(overfetch);
+    // 2. Full-text candidates (websearch_to_tsquery + ts_rank_cd)
+    db
+      .select({ chunkId: fileChunks.id })
+      .from(fileChunks)
+      .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+      .where(
+        and(
+          baseWhere,
+          sql`to_tsvector('english', ${fileChunks.content}) @@ websearch_to_tsquery('english', ${query})`,
+        ),
+      )
+      .orderBy(
+        sql`ts_rank_cd(to_tsvector('english', ${fileChunks.content}), websearch_to_tsquery('english', ${query})) DESC`,
+      )
+      .limit(overfetch),
 
-  // 3. Trigram candidates (similarity DESC). Uses pg_trgm % operator.
-  const trgmRows = await db
-    .select({ chunkId: fileChunks.id })
-    .from(fileChunks)
-    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
-    .where(and(baseWhere, sql`${fileChunks.content} % ${query}`))
-    .orderBy(sql`similarity(${fileChunks.content}, ${query}) DESC`)
-    .limit(overfetch);
+    // 3. Trigram candidates (similarity DESC). Uses pg_trgm % operator.
+    db
+      .select({ chunkId: fileChunks.id })
+      .from(fileChunks)
+      .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
+      .where(and(baseWhere, sql`${fileChunks.content} % ${query}`))
+      .orderBy(sql`similarity(${fileChunks.content}, ${query}) DESC`)
+      .limit(overfetch),
+  ]);
 
   // Fuse via RRF. FTS weighted higher when the user quoted an exact phrase.
   const ftsWeight = hasQuotedPhrase(query) ? 2 : 1;
@@ -118,6 +124,7 @@ export async function hybridSearch(
       chunkId: fileChunks.id,
       fileId: fileChunks.fileId,
       fileName: userFiles.fileName,
+      storagePath: userFiles.storagePath,
       chunkIndex: fileChunks.chunkIndex,
       metadata: fileChunks.metadata,
       content: fileChunks.content,
@@ -134,6 +141,7 @@ export async function hybridSearch(
       chunkId: r.chunkId,
       fileId: r.fileId,
       fileName: r.fileName,
+      storagePath: r.storagePath,
       chunkIndex: r.chunkIndex,
       pageNumber:
         (r.metadata as { pageNumber?: number } | null)?.pageNumber ?? null,

--- a/apps/web/src/server/hybrid-search.ts
+++ b/apps/web/src/server/hybrid-search.ts
@@ -64,8 +64,9 @@ export async function hybridSearch(
     isNotNull(fileChunks.embedding),
   );
 
-  // The three retrievers are independent -- run them concurrently so the
-  // search costs one DB round trip instead of three.
+  // The three retrievers are independent -- run them concurrently. Still
+  // three queries (and three pool connections), but wall-clock cost drops
+  // from the sum of all three to the slowest one.
   const [vectorRows, ftsRows, trgmRows] = await Promise.all([
     // 1. Vector candidates (HNSW, distance ascending)
     db

--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -7,6 +7,7 @@ import {
   crawlSources,
 } from "@teachanything/db/schema";
 import { hybridSearch } from "./hybrid-search";
+import { sourceDisplayName } from "@/lib/message-sources";
 import {
   createOpenRouterClient,
   EMBEDDING_MODEL,
@@ -223,19 +224,10 @@ export async function buildRAGContext(
     relevantChunks
       .map((chunk) => {
         const rawName = chunk.fileName || "Unknown";
-        // Crawler-sourced files have storagePath as a URL. Collapse the
-        // display name to "Web: <hostname>" so many pages from one site
-        // dedupe into a single source badge in the UI.
-        let displayName = rawName;
-        if (chunk.storagePath && /^https?:\/\//i.test(chunk.storagePath)) {
-          try {
-            displayName = `Web: ${new URL(chunk.storagePath).hostname}`;
-          } catch {
-            // malformed URL, fall back to raw filename
-          }
-        }
         sources.push({
-          fileName: displayName,
+          // Crawler-sourced files collapse to "Web: <hostname>" so many pages
+          // from one site dedupe into a single source badge in the UI.
+          fileName: sourceDisplayName(chunk.fileName, chunk.storagePath),
           chunkIndex: chunk.chunkIndex,
           // D-05: real similarity in metadata only. Chunks surfaced by the
           // lexical retrievers (FTS/trigram) but outside the vector top-k have

--- a/apps/web/src/server/rag-context.ts
+++ b/apps/web/src/server/rag-context.ts
@@ -1,12 +1,12 @@
-import { eq, and, sql, inArray, isNotNull } from "drizzle-orm";
+import { eq, and, isNotNull } from "drizzle-orm";
 import {
-  fileChunks,
   chatbotFileAssociations,
   chatbotCrawlSourceAssociations,
   userFiles,
   crawledPages,
   crawlSources,
 } from "@teachanything/db/schema";
+import { hybridSearch } from "./hybrid-search";
 import {
   createOpenRouterClient,
   EMBEDDING_MODEL,
@@ -33,8 +33,7 @@ export interface RAGContextResult {
     fileName: string;
     chunkIndex: number;
     similarity: number;
-    // Optional: only the agentic retrieval path supplies page numbers. The
-    // static path leaves it undefined so existing consumers keep validating.
+    // Present when the chunk carries page metadata (page-aware PDF ingestion).
     pageNumber?: number | null;
   }>;
   ragUsed: boolean;
@@ -49,8 +48,9 @@ export interface RAGContextResult {
  * Build RAG context for a chatbot message.
  *
  * Queries completed files, builds a file manifest with anti-hallucination
- * instructions, generates a query embedding, performs vector similarity search,
- * and formats chunk context with source attribution.
+ * instructions, generates a query embedding, runs the same hybrid search
+ * (vector + full-text + trigram, RRF-fused) the agentic tools use, and formats
+ * chunk context with source attribution.
  *
  * Returns fileManifest even when embedding fails (file awareness without RAG).
  */
@@ -190,33 +190,19 @@ export async function buildRAGContext(
     };
   }
 
-  // 5. Vector similarity search with all fixes
+  // 5. Hybrid retrieval (vector + FTS + trigram, RRF-fused). Same retriever
+  // the agentic search_documents tool uses, so both chat paths share one
+  // embedding and one search implementation.
   const effectiveChunkLimit =
     params.chunkLimit ?? Math.min(fileIds.length * 2, 30);
 
-  // D-06, RAG-03: Real cosine similarity in SELECT
-  const similarityExpr = sql<number>`1 - (${fileChunks.embedding} <=> ${JSON.stringify(queryEmbedding)})`;
-
-  const relevantChunks = await params.db
-    .select({
-      content: fileChunks.content,
-      chunkIndex: fileChunks.chunkIndex,
-      fileName: userFiles.fileName,
-      storagePath: userFiles.storagePath,
-      similarity: similarityExpr,
-    })
-    .from(fileChunks)
-    .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
-    .where(
-      and(
-        inArray(fileChunks.fileId, fileIds),
-        eq(userFiles.processingStatus, "completed"), // D-08: defense-in-depth
-        isNotNull(fileChunks.embedding), // D-09, RAG-06
-      ),
-    )
-    // CRITICAL: ORDER BY raw distance ascending to use HNSW index
-    .orderBy(sql`${fileChunks.embedding} <=> ${JSON.stringify(queryEmbedding)}`)
-    .limit(effectiveChunkLimit);
+  const relevantChunks = await hybridSearch({
+    db: params.db,
+    fileIds,
+    query: params.message,
+    queryEmbedding,
+    limit: effectiveChunkLimit,
+  });
 
   // 6. Format chunks with source attribution (D-04)
   const sources: RAGContextResult["sources"] = [];
@@ -251,7 +237,11 @@ export async function buildRAGContext(
         sources.push({
           fileName: displayName,
           chunkIndex: chunk.chunkIndex,
-          similarity: chunk.similarity, // D-05: real similarity in metadata only
+          // D-05: real similarity in metadata only. Chunks surfaced by the
+          // lexical retrievers (FTS/trigram) but outside the vector top-k have
+          // no vector similarity -- record 0 rather than a fake score.
+          similarity: chunk.vectorSimilarity ?? 0,
+          pageNumber: chunk.pageNumber,
         });
         // D-04: give the LLM the actual page title/URL for accurate citations
         return `[Source: ${rawName}, Part ${chunk.chunkIndex + 1}]\n${chunk.content}`;

--- a/apps/web/src/server/retrieval-tools.ts
+++ b/apps/web/src/server/retrieval-tools.ts
@@ -133,6 +133,7 @@ export function createRetrievalTools(ctx: RetrievalToolContext) {
           rows.map((r) => ({
             chunkId: "",
             fileId,
+            storagePath: "",
             fileName: r.fileName,
             chunkIndex: r.chunkIndex,
             pageNumber:

--- a/apps/web/src/server/retrieval-tools.ts
+++ b/apps/web/src/server/retrieval-tools.ts
@@ -5,6 +5,7 @@ import { fileChunks, userFiles } from "@teachanything/db/schema";
 import type { db as DbType } from "@teachanything/db";
 import type { OpenRouterClient } from "@teachanything/ai/openrouter";
 import { hybridSearch, type HybridChunk } from "./hybrid-search";
+import { sourceDisplayName } from "@/lib/message-sources";
 import {
   searchDocumentsInput,
   getPageInput,
@@ -35,7 +36,9 @@ export function createRetrievalTools(ctx: RetrievalToolContext) {
   const record = (chunks: HybridChunk[]) => {
     for (const c of chunks) {
       sources.push({
-        fileName: c.fileName,
+        // Same display normalization as the static path (Web: <hostname> for
+        // crawled pages) so merged source lists dedupe on matching names.
+        fileName: sourceDisplayName(c.fileName, c.storagePath),
         chunkIndex: c.chunkIndex,
         pageNumber: c.pageNumber,
         similarity: c.vectorSimilarity,
@@ -111,10 +114,12 @@ export function createRetrievalTools(ctx: RetrievalToolContext) {
         if (!ctx.fileIds.includes(fileId)) return { error: "Unknown document" };
         const rows = await ctx.db
           .select({
+            chunkId: fileChunks.id,
             content: fileChunks.content,
             chunkIndex: fileChunks.chunkIndex,
             metadata: fileChunks.metadata,
             fileName: userFiles.fileName,
+            storagePath: userFiles.storagePath,
           })
           .from(fileChunks)
           .innerJoin(userFiles, eq(fileChunks.fileId, userFiles.id))
@@ -131,9 +136,9 @@ export function createRetrievalTools(ctx: RetrievalToolContext) {
           .orderBy(asc(fileChunks.chunkIndex));
         record(
           rows.map((r) => ({
-            chunkId: "",
+            chunkId: r.chunkId,
             fileId,
-            storagePath: "",
+            storagePath: r.storagePath,
             fileName: r.fileName,
             chunkIndex: r.chunkIndex,
             pageNumber:

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -31,7 +31,11 @@ import {
 } from "@/lib/rate-limit";
 import { buildRAGContext, type RAGContextResult } from "../rag-context";
 import { createRetrievalTools } from "../retrieval-tools";
-import { clampMaxTokens, describeToolActivity } from "../chat-helpers";
+import {
+  clampMaxTokens,
+  describeToolActivity,
+  mergeSources,
+} from "../chat-helpers";
 import type { db as DbType } from "@teachanything/db";
 
 /**
@@ -200,16 +204,15 @@ async function* processMessage(params: {
   const useTools =
     modelSupportsTools(chatbot.model) && ragResult.fileIds.length > 0;
 
-  // Send RAG sources now that they're available (static path only). The
-  // agentic path's sources aren't known until its tools run, so it emits its
-  // own metadata event after streaming. The client handles metadata events
+  // Send RAG sources now that they're available. Both paths inject the
+  // pre-fetched hybrid-search results, so the initial sources are known up
+  // front; the agentic path may add more as its tools run and re-emits a
+  // merged list after streaming. The client handles metadata events
   // idempotently (updates only fields that are present).
-  if (!useTools) {
-    yield {
-      type: "metadata" as const,
-      sources: ragResult.sources,
-    };
-  }
+  yield {
+    type: "metadata" as const,
+    sources: ragResult.sources,
+  };
 
   // Build message history for AI (budget-trimmed)
   // Stored conversation turns are only user/assistant; the system prompt is
@@ -332,13 +335,14 @@ async function* processMessage(params: {
   }
 
   /**
-   * AGENTIC retrieval path: give the model retrieval tools and let it search
-   * the attached documents during the turn. No static context injection; the
-   * model is forced to call `search_documents` on the first step. Yields the
-   * same wire events as the static path. Returns the accumulated response,
-   * finish reason, whether any tool call happened, and a captured `done`
-   * answer (the `done` tool has no execute -- its answer lives in the
-   * tool-call args).
+   * AGENTIC retrieval path: inject the pre-fetched hybrid-search results as
+   * context AND give the model retrieval tools for follow-up searches. The
+   * common case (initial retrieval suffices) answers in a single LLM round
+   * trip, matching static-path latency; the model only pays extra round trips
+   * when it genuinely needs to search again. Yields the same wire events as
+   * the static path. Returns the accumulated response, finish reason, whether
+   * any tool call happened, and a captured `done` answer (the `done` tool has
+   * no execute -- its answer lives in the tool-call args).
    */
   async function* streamAgentic(): AsyncGenerator<
     | { type: "text"; content: string }
@@ -352,13 +356,20 @@ async function* processMessage(params: {
     void
   > {
     const groundingRule =
-      "\n\nYou can search the attached documents using tools. You MUST call search_documents before stating whether the documents do or do not contain something. " +
+      "\n\nYou can search the attached documents using tools." +
+      (ragResult.contextText
+        ? " The passages above were already retrieved by searching the documents for the user's message; search again only when they are insufficient."
+        : "") +
+      " You MUST check the retrieved passages or call search_documents before stating whether the documents do or do not contain something. " +
       "If a search returns nothing, say you couldn't find it in the materials rather than denying it exists. " +
       "Do NOT put inline citations, source tags, page numbers, bracketed reference markers, or JSON anchors " +
       '(e.g. "(file.pdf, p. 2)" or "【…】") in your answer text -- the app shows the user the sources ' +
       "separately. Reply in clean prose.";
     const systemPrompt =
-      chatbot.systemPrompt + ragResult.fileManifest + groundingRule;
+      chatbot.systemPrompt +
+      ragResult.fileManifest +
+      ragResult.contextText +
+      groundingRule;
 
     const result = await aiClient.streamText({
       model: modelId,
@@ -375,13 +386,6 @@ async function* processMessage(params: {
         OpenRouterClient["streamText"]
       >[0]["tools"],
       stopWhen: [stepCountIs(4), hasToolCall("done")],
-      prepareStep: async ({ stepNumber }) =>
-        stepNumber === 0
-          ? {
-              toolChoice: { type: "tool", toolName: "search_documents" },
-              activeTools: ["search_documents"],
-            }
-          : {},
     });
 
     let agenticResponse = "";
@@ -489,9 +493,8 @@ async function* processMessage(params: {
   let fullResponse: string;
   let finishReason: FinishReason | undefined;
   // Final source list for persistence + the metadata event. Static path uses
-  // ragResult.sources; agentic path maps toolSources (which carry pageNumber).
-  // similarity is coerced from null -> 0 so existing consumers (which expect a
-  // number and dedupe/score on it) keep working.
+  // ragResult.sources; agentic path merges in toolSources (which carry
+  // pageNumber) from any follow-up searches the model ran.
   let finalSources: RAGContextResult["sources"];
   let ragUsedFlag: boolean;
 
@@ -511,8 +514,6 @@ async function* processMessage(params: {
           anyToolCall: agentic.anyToolCall,
         },
       );
-      // Emit RAG sources for the fallback path (agentic suppressed them above).
-      yield { type: "metadata" as const, sources: ragResult.sources };
       const fallback = yield* streamStatic();
       fullResponse = fallback.fullResponse;
       finishReason = fallback.finishReason;
@@ -521,15 +522,13 @@ async function* processMessage(params: {
     } else {
       fullResponse = agentic.fullResponse;
       finishReason = agentic.finishReason;
-      finalSources = toolSources.map((s) => ({
-        fileName: s.fileName,
-        chunkIndex: s.chunkIndex,
-        similarity: s.similarity ?? 0,
-        pageNumber: s.pageNumber,
-      }));
+      finalSources = mergeSources(ragResult.sources, toolSources);
       ragUsedFlag = finalSources.length > 0;
-      // Agentic sources are only known after the tools run, so emit them now.
-      yield { type: "metadata" as const, sources: finalSources };
+      // Follow-up tool searches discovered sources beyond the injected
+      // context -- re-emit the merged list (client overwrites idempotently).
+      if (toolSources.length > 0) {
+        yield { type: "metadata" as const, sources: finalSources };
+      }
     }
   } else {
     const staticResult = yield* streamStatic();

--- a/apps/web/src/server/routers/chat.ts
+++ b/apps/web/src/server/routers/chat.ts
@@ -11,7 +11,7 @@ import {
 } from "@teachanything/db/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { TRPCError } from "@trpc/server";
+import { TRPCError, tracked } from "@trpc/server";
 import {
   createOpenRouterClient,
   resolveModel,
@@ -198,11 +198,15 @@ async function* processMessage(params: {
   }
 
   // Tool-capable models with at least one searchable file use the AGENTIC
-  // retrieval path: the model calls retrieval tools mid-turn instead of
-  // receiving statically-injected chunks. Everything else uses the STATIC
-  // path (today's behavior).
+  // retrieval path: the model gets the pre-fetched context plus retrieval
+  // tools for follow-up searches. Everything else uses the STATIC path.
+  // A ragFailureNote means embeddings are down -- tool searches would fail
+  // the same way, so take the static path, whose prompt carries the note
+  // instructing the model to tell the user document search is unavailable.
   const useTools =
-    modelSupportsTools(chatbot.model) && ragResult.fileIds.length > 0;
+    modelSupportsTools(chatbot.model) &&
+    ragResult.fileIds.length > 0 &&
+    !ragResult.ragFailureNote;
 
   // Send RAG sources now that they're available. Both paths inject the
   // pre-fetched hybrid-search results, so the initial sources are known up
@@ -609,6 +613,38 @@ async function* processMessage(params: {
   };
 }
 
+/**
+ * Guard against EventSource replay. tRPC's httpSubscriptionLink auto-
+ * reconnects when a stream dies abnormally (function timeout, network drop,
+ * or a retryable error code like INTERNAL_SERVER_ERROR) and re-invokes the
+ * subscription with the same input plus the last received event id. For chat
+ * that would silently regenerate the whole answer: duplicate LLM cost,
+ * duplicate message inserts, and new deltas appended onto the partial text
+ * already on screen. A lastEventId can only mean such a reconnect, so refuse
+ * with CONFLICT -- a non-retryable code -- which the client surfaces as a
+ * terminal "interrupted" error while keeping the partial response.
+ */
+function rejectStreamReplay(lastEventId: string | null | undefined): void {
+  if (!lastEventId) return;
+  throw new TRPCError({
+    code: "CONFLICT",
+    message: "The response stream was interrupted.",
+  });
+}
+
+/**
+ * Wrap every stream event in tracked() so the browser's EventSource carries a
+ * Last-Event-ID on reconnect, which rejectStreamReplay uses to distinguish a
+ * replay from a fresh message. IDs are opaque; only their presence matters.
+ */
+async function* trackEvents<T>(events: AsyncIterable<T>) {
+  const streamId = nanoid();
+  let seq = 0;
+  for await (const event of events) {
+    yield tracked(`${streamId}:${seq++}`, event);
+  }
+}
+
 export const chatRouter = router({
   /**
    * Send message to chatbot with streaming (protected - requires auth)
@@ -624,10 +660,16 @@ export const chatRouter = router({
           .max(30)
           .regex(/^[a-zA-Z0-9_-]+$/)
           .optional(),
+        // Populated by tRPC from the Last-Event-ID header when the client's
+        // EventSource reconnects after a dropped stream. Never sent on a
+        // fresh message.
+        lastEventId: z.string().nullish(),
       }),
     )
     .subscription(async function* ({ ctx, input }) {
       try {
+        rejectStreamReplay(input.lastEventId);
+
         // Rate limit per user
         const { success } = await checkRateLimit(
           authenticatedChatRateLimit,
@@ -659,13 +701,15 @@ export const chatRouter = router({
           });
         }
 
-        yield* processMessage({
-          chatbot,
-          message: input.message,
-          sessionId: input.sessionId,
-          db: ctx.db,
-          eventType: "message_sent",
-        });
+        yield* trackEvents(
+          processMessage({
+            chatbot,
+            message: input.message,
+            sessionId: input.sessionId,
+            db: ctx.db,
+            eventType: "message_sent",
+          }),
+        );
       } catch (error) {
         if (error instanceof TRPCError) throw error;
 
@@ -695,10 +739,16 @@ export const chatRouter = router({
           .max(30)
           .regex(/^[a-zA-Z0-9_-]+$/)
           .optional(),
+        // Populated by tRPC from the Last-Event-ID header when the client's
+        // EventSource reconnects after a dropped stream. Never sent on a
+        // fresh message.
+        lastEventId: z.string().nullish(),
       }),
     )
     .subscription(async function* ({ ctx, input }) {
       try {
+        rejectStreamReplay(input.lastEventId);
+
         // Rate limit by IP + share token (public endpoint, no userId available)
         const clientIp =
           ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
@@ -733,13 +783,15 @@ export const chatRouter = router({
           });
         }
 
-        yield* processMessage({
-          chatbot,
-          message: input.message,
-          sessionId: input.sessionId,
-          db: ctx.db,
-          eventType: "shared_message_sent",
-        });
+        yield* trackEvents(
+          processMessage({
+            chatbot,
+            message: input.message,
+            sessionId: input.sessionId,
+            db: ctx.db,
+            eventType: "shared_message_sent",
+          }),
+        );
       } catch (error) {
         if (error instanceof TRPCError) throw error;
 

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -25,6 +25,13 @@ export type Context = Awaited<ReturnType<typeof createTRPCContext>>;
 // Initialize tRPC
 const t = initTRPC.context<Context>().create({
   transformer: superjson,
+  sse: {
+    // Keep-alive comments on subscription streams. Agentic chat turns can go
+    // 10-30s with nothing on the wire (tool execution, reasoning phases);
+    // idle SSE connections get dropped by proxies, and a drop makes the
+    // client's EventSource reconnect and replay the whole message.
+    ping: { enabled: true, intervalMs: 10_000 },
+  },
   errorFormatter({ shape, error }) {
     // Only surface Zod validation errors to the client. Spreading any
     // `cause.message` leaks provider/internal error details (upstream URLs,


### PR DESCRIPTION
## Problem

Two production symptoms in student chat:
1. Responses take too long to start.
2. Streams sometimes stall or die mid-response.

### Root causes

**Latency**: every agentic turn paid two embeddings, two full LLM round trips, and ~6 serialized DB queries before the first visible token:
- `buildRAGContext` ran fully up front (embedding + vector search + context build) but its output was thrown away on the agentic path except as a fallback.
- The forced step-0 `search_documents` call cost a full LLM round trip just to produce tool args, then re-embedded the query and searched again.
- `hybridSearch` ran its three retrievers (vector / FTS / trigram) sequentially.

**Stalls**: the tRPC route carrying chat subscriptions had no `maxDuration`, so Vercel could kill the function mid-stream at the project default. There were also no SSE keep-alive pings, so idle phases (tool execution, reasoning) could get the connection dropped by proxies. Either way the client EventSource silently reconnects and replays the whole message (duplicate generation + garbled partial text).

## Changes

**Latency**
- `rag-context.ts` now retrieves via `hybridSearch` (vector + FTS + trigram, RRF-fused), so both chat paths share one embedding and one retriever implementation. Static path gets a retrieval-quality upgrade for free.
- The agentic path injects the pre-fetched context into the system prompt and no longer forces the step-0 search. Tools stay available for follow-up searches, and the grounding rule still requires checking passages or searching before claiming something is or is not in the documents. Common case: one LLM round trip, static-path latency, agentic depth on demand.
- `hybridSearch` runs its three retrievers concurrently via `Promise.all`.
- Sources metadata is emitted up front on both paths; the agentic path re-emits a merged list (injected + tool-discovered, deduped by file + chunk via the new `mergeSources` helper) after streaming if tools ran.

**Transport**
- `export const maxDuration = 300` on `/api/trpc/[trpc]` so long streaming turns aren't killed at the project default.
- SSE keep-alive pings (10s) via `initTRPC.create({ sse: { ping: ... } })`.

## Tests

- 6 new unit tests for `mergeSources` (dedupe, ordering, null-similarity coercion).
- Full suite: 372 passed. Type-check and lint clean.

## Notes

- Worth verifying in the Vercel dashboard that Fluid Compute is enabled for `aialexa-v2-web` so the 300s limit applies.
- The empty-response static fallback is unchanged and should fire much less often now that the agentic path always has injected context.