### PR TITLE
feat(embed): enable voice input in embedded chatbots via delegation opt-in

### DIFF
--- a/apps/web/src/__tests__/components/embed-code-generators.test.ts
+++ b/apps/web/src/__tests__/components/embed-code-generators.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  generateWidgetHTML,
+  generateWidgetReact,
+  generateWindowHTML,
+} from "@/components/embed/embedCodeGenerators";
+
+const BASE = "https://app.example.edu";
+const TOKEN = "tok_abc123";
+
+describe("embed code generators — voice delegation", () => {
+  it("widget HTML window iframe delegates the mic and tags the URL", () => {
+    const html = generateWidgetHTML(BASE, TOKEN);
+    expect(html).toContain(
+      `src="${BASE}/embed/${TOKEN}/window?chatbox=false&withExitX=true&voice=1"`,
+    );
+    expect(html).toContain('allow="microphone;clipboard-read;clipboard-write"');
+  });
+
+  it("widget HTML button iframe does NOT request the mic", () => {
+    const html = generateWidgetHTML(BASE, TOKEN);
+    const buttonIframe = html.slice(
+      html.indexOf(`/button?`),
+      html.indexOf(`/window?`),
+    );
+    expect(buttonIframe).not.toContain("microphone");
+  });
+
+  it("widget React snippet delegates the mic and tags the URL", () => {
+    const jsx = generateWidgetReact(BASE, TOKEN);
+    expect(jsx).toContain(
+      `src="${BASE}/embed/${TOKEN}/window?chatbox=false&withExitX=true&voice=1"`,
+    );
+    expect(jsx).toContain(
+      'allow="microphone; clipboard-read; clipboard-write"',
+    );
+  });
+
+  it("window-only HTML delegates the mic and tags the URL", () => {
+    const html = generateWindowHTML(BASE, TOKEN);
+    expect(html).toContain(
+      `src="${BASE}/embed/${TOKEN}/window?chatbox=false&voice=1"`,
+    );
+    expect(html).toContain('allow="microphone;clipboard-read;clipboard-write"');
+  });
+
+  it("keeps clipboard delegation alongside the mic in every variant", () => {
+    for (const snippet of [
+      generateWidgetHTML(BASE, TOKEN),
+      generateWidgetReact(BASE, TOKEN),
+      generateWindowHTML(BASE, TOKEN),
+    ]) {
+      expect(snippet).toContain("clipboard-read");
+      expect(snippet).toContain("clipboard-write");
+    }
+  });
+});

--- a/apps/web/src/__tests__/lib/embed-voice.test.ts
+++ b/apps/web/src/__tests__/lib/embed-voice.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  embedVoiceEnabled,
+  micPermissionsPolicyAllows,
+  type PolicyDocument,
+} from "@/lib/embed-voice";
+
+const allowingDoc: PolicyDocument = {
+  permissionsPolicy: { allowsFeature: () => true },
+};
+const denyingDoc: PolicyDocument = {
+  permissionsPolicy: { allowsFeature: () => false },
+};
+const noPolicyDoc: PolicyDocument = {};
+
+describe("micPermissionsPolicyAllows", () => {
+  it("returns the policy's answer when the API is available", () => {
+    expect(micPermissionsPolicyAllows(allowingDoc)).toBe(true);
+    expect(micPermissionsPolicyAllows(denyingDoc)).toBe(false);
+  });
+
+  it("falls back to legacy featurePolicy when permissionsPolicy is absent", () => {
+    expect(
+      micPermissionsPolicyAllows({
+        featurePolicy: { allowsFeature: () => false },
+      }),
+    ).toBe(false);
+    expect(
+      micPermissionsPolicyAllows({
+        featurePolicy: { allowsFeature: () => true },
+      }),
+    ).toBe(true);
+  });
+
+  it("is optimistic when no policy API exists (Safari/Firefox)", () => {
+    expect(micPermissionsPolicyAllows(noPolicyDoc)).toBe(true);
+  });
+
+  it("is optimistic when allowsFeature throws on the feature name", () => {
+    expect(
+      micPermissionsPolicyAllows({
+        permissionsPolicy: {
+          allowsFeature: () => {
+            throw new TypeError("unrecognized feature");
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("embedVoiceEnabled", () => {
+  it("requires the voice=1 param even when the policy allows the mic", () => {
+    expect(embedVoiceEnabled("?chatbox=false", allowingDoc)).toBe(false);
+    expect(embedVoiceEnabled("", allowingDoc)).toBe(false);
+  });
+
+  it("rejects other values of the voice param", () => {
+    expect(embedVoiceEnabled("?voice=true", allowingDoc)).toBe(false);
+    expect(embedVoiceEnabled("?voice=0", allowingDoc)).toBe(false);
+  });
+
+  it("enables voice when the param is set and the policy allows", () => {
+    expect(
+      embedVoiceEnabled("?chatbox=false&withExitX=true&voice=1", allowingDoc),
+    ).toBe(true);
+  });
+
+  it("disables voice when the host stripped the allow attribute (policy denies)", () => {
+    expect(embedVoiceEnabled("?voice=1", denyingDoc)).toBe(false);
+  });
+
+  it("trusts the param on browsers without a policy API", () => {
+    expect(embedVoiceEnabled("?voice=1", noPolicyDoc)).toBe(true);
+  });
+});

--- a/apps/web/src/app/embed/[shareToken]/window/page.tsx
+++ b/apps/web/src/app/embed/[shareToken]/window/page.tsx
@@ -8,6 +8,7 @@ import { EmbedError } from "@/components/embed/EmbedError";
 import { EmbedHeader } from "@/components/embed/EmbedHeader";
 import { EmbedFooter } from "@/components/embed/EmbedFooter";
 import { useEmbedVisibility } from "@/hooks/useEmbedVisibility";
+import { useEmbedVoice } from "@/hooks/useEmbedVoice";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 export default function EmbedWindowPage() {
@@ -15,6 +16,7 @@ export default function EmbedWindowPage() {
   const shareToken =
     typeof params.shareToken === "string" ? params.shareToken : "";
   const { isMounted, isVisible, withExitX, close } = useEmbedVisibility();
+  const voiceInputEnabled = useEmbedVoice();
 
   const {
     messages,
@@ -86,13 +88,16 @@ export default function EmbedWindowPage() {
             embedMode={true}
             showSources={chatbot.showSources ?? false}
             shareToken={shareToken}
-            // Voice disabled in embeds: getUserMedia() inside a third-party
-            // iframe requires the embedding page to set
-            // `<iframe allow="microphone">`, which most embedders won't.
-            // Rather than ship a half-working mic that fails silently on
-            // most sites, the feature stays off here. Re-enable per-embed
-            // once we expose an opt-in flag on the share configuration.
-            voiceInputEnabled={false}
+            // Voice in embeds is opt-in: getUserMedia() inside a
+            // third-party iframe only works when the embedding page sets
+            // `<iframe allow="microphone">`. Current embed snippets carry
+            // that attribute plus a `voice=1` URL param; useEmbedVoice
+            // requires the param and, where the browser exposes the
+            // Permissions Policy API, verifies the delegation actually
+            // survived (some CMS editors strip iframe attributes). Older
+            // pasted embeds have neither and stay text-only rather than
+            // showing a mic that can never get permission.
+            voiceInputEnabled={voiceInputEnabled}
           />
         </ErrorBoundary>
       </div>

--- a/apps/web/src/components/embed/embedCodeGenerators.ts
+++ b/apps/web/src/components/embed/embedCodeGenerators.ts
@@ -5,9 +5,15 @@ const IFRAME_IDS = {
 
 const WIDGET_SCRIPT = `window.addEventListener("message",function(e){var t=document.getElementById("${IFRAME_IDS.window}"),n=document.getElementById("${IFRAME_IDS.button}");"openChat"===e.data&&t&&n&&(t.contentWindow.postMessage("openChat","*"),n.contentWindow.postMessage("openChat","*"),t.style.pointerEvents="auto",t.style.display="block",window.innerWidth<640?(t.style.position="fixed",t.style.width="100%",t.style.height="100%",t.style.top="0",t.style.left="0",t.style.zIndex="9999"):(t.style.position="fixed",t.style.width="55rem",t.style.height="75vh",t.style.bottom="0",t.style.right="0"));"closeChat"===e.data&&t&&n&&(t.style.display="none",t.style.pointerEvents="none",t.contentWindow.postMessage("closeChat","*"),n.contentWindow.postMessage("closeChat","*"))});`;
 
+// The window iframe delegates mic access (`allow="microphone"`) and tags
+// its URL with `voice=1` so the embed page knows the snippet is
+// voice-capable. Both must travel together: the embed page only shows the
+// mic button when the param is present AND the delegation survived (see
+// lib/embed-voice.ts). Embeds pasted before voice shipped have neither and
+// keep working as text-only chat.
 function generateWidgetHTML(baseUrl: string, shareToken: string) {
   const buttonUrl = `${baseUrl}/embed/${shareToken}/button?chatbox=false`;
-  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false&withExitX=true`;
+  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false&withExitX=true&voice=1`;
 
   const buttonStyle =
     "position:fixed;right:0;bottom:0;width:60px;height:60px;border:2px solid #e2e8f0;border-radius:50%;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);z-index:50;margin-right:1rem;margin-bottom:1rem";
@@ -27,14 +33,14 @@ function generateWidgetHTML(baseUrl: string, shareToken: string) {
   src="${windowUrl}"
   style="${windowStyle}"
   id="${IFRAME_IDS.window}"
-  allow="clipboard-read;clipboard-write"
+  allow="microphone;clipboard-read;clipboard-write"
   scrolling="no">
 </iframe>`;
 }
 
 function generateWidgetReact(baseUrl: string, shareToken: string) {
   const buttonUrl = `${baseUrl}/embed/${shareToken}/button?chatbox=false`;
-  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false&withExitX=true`;
+  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false&withExitX=true&voice=1`;
 
   return `export default function Chatbot() {
   const windowStyle = {
@@ -67,7 +73,7 @@ function generateWidgetReact(baseUrl: string, shareToken: string) {
         src="${windowUrl}"
         id="${IFRAME_IDS.window}"
         style={windowStyle}
-        allow="clipboard-read; clipboard-write"
+        allow="microphone; clipboard-read; clipboard-write"
         scrolling="no"
       />
     </>
@@ -76,14 +82,14 @@ function generateWidgetReact(baseUrl: string, shareToken: string) {
 }
 
 function generateWindowHTML(baseUrl: string, shareToken: string) {
-  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false`;
+  const windowUrl = `${baseUrl}/embed/${shareToken}/window?chatbox=false&voice=1`;
   const windowStyle =
     "position:fixed;right:0;bottom:-30px;width:480px;height:80vh;border:2px solid #e2e8f0;border-radius:0.375rem;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);overflow:hidden";
 
   return `<iframe
   src="${windowUrl}"
   style="${windowStyle}"
-  allow="clipboard-read;clipboard-write">
+  allow="microphone;clipboard-read;clipboard-write">
 </iframe>`;
 }
 

--- a/apps/web/src/hooks/useEmbedVoice.ts
+++ b/apps/web/src/hooks/useEmbedVoice.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { embedVoiceEnabled, type PolicyDocument } from "@/lib/embed-voice";
+
+/**
+ * Whether the embedded chat window should offer voice input. Resolved
+ * after mount (same pattern as useEmbedVisibility) so server and client
+ * renders never disagree about window state.
+ */
+export function useEmbedVoice(): boolean {
+  const [voiceEnabled, setVoiceEnabled] = useState(false);
+
+  useEffect(() => {
+    // Document doesn't declare the (Chromium-only) policy APIs, so widen
+    // it to the structural type embed-voice reads.
+    setVoiceEnabled(
+      embedVoiceEnabled(window.location.search, document as PolicyDocument),
+    );
+  }, []);
+
+  return voiceEnabled;
+}

--- a/apps/web/src/lib/embed-voice.ts
+++ b/apps/web/src/lib/embed-voice.ts
@@ -1,0 +1,54 @@
+/**
+ * Voice-input gating for the embedded chat window.
+ *
+ * In a cross-origin iframe, getUserMedia() only works when the HOST page
+ * delegates access via `<iframe allow="microphone">`. That attribute lives
+ * in the embedder's pasted snippet, so it can't be added from our side.
+ * Voice is therefore double-gated:
+ *
+ * 1. The `voice=1` query param -- only present in embed snippets generated
+ *    after voice input shipped, the same snippets that carry
+ *    `allow="microphone"` on the iframe. Older pasted embeds have neither,
+ *    so they stay text-only instead of showing a mic that can never get
+ *    permission.
+ * 2. The Permissions Policy API, where the browser exposes it (Chromium's
+ *    `document.permissionsPolicy`, older `document.featurePolicy`). This
+ *    catches snippets whose `allow` attribute was stripped in transit --
+ *    some CMS editors sanitize iframe attributes. Safari and Firefox don't
+ *    expose the API; there we trust the param and let the recorder's
+ *    permission-denied dialog handle the rare stripped-attribute case.
+ */
+
+export interface PolicyDocument {
+  permissionsPolicy?: { allowsFeature?: (feature: string) => boolean };
+  featurePolicy?: { allowsFeature?: (feature: string) => boolean };
+}
+
+/**
+ * Whether this document may use the microphone under the Permissions
+ * Policy it was embedded with. Optimistic (true) when the browser doesn't
+ * expose a policy API -- the caller's own gating decides there.
+ */
+export function micPermissionsPolicyAllows(doc: PolicyDocument): boolean {
+  const policy = doc.permissionsPolicy ?? doc.featurePolicy;
+  if (policy && typeof policy.allowsFeature === "function") {
+    try {
+      return policy.allowsFeature("microphone");
+    } catch {
+      // An implementation that rejects the feature name must not disable
+      // the button.
+      return true;
+    }
+  }
+  return true;
+}
+
+/** Full gate: `voice=1` in the embed URL AND the policy permits the mic. */
+export function embedVoiceEnabled(
+  search: string,
+  doc: PolicyDocument,
+): boolean {
+  const params = new URLSearchParams(search);
+  if (params.get("voice") !== "1") return false;
+  return micPermissionsPolicyAllows(doc);
+}


### PR DESCRIPTION
## Problem

#307 shipped voice input on the dashboard and standalone share links, but hard-disabled it in embeds: mic capture inside a cross-origin iframe only works when the **host page** delegates it via `<iframe allow="microphone">`, which no existing pasted embed does. Result: no mic button on WordPress-embedded chatbots.

## Changes

Double gate instead of a hard disable:

1. **Embed snippet generators** (`embedCodeGenerators.ts`): the window iframe now carries `allow="microphone;clipboard-read;clipboard-write"` and its URL is tagged with `voice=1` in all three variants (widget HTML, widget React, window-only HTML). The launcher button iframe doesn't request the mic.
2. **Embed window page**: new `useEmbedVoice` hook enables the mic button only when
   - the `voice=1` param is present (i.e. the snippet was generated after voice shipped), **and**
   - where the browser exposes the Permissions Policy API (Chromium's `document.permissionsPolicy` / legacy `featurePolicy`), the delegation actually survived. This catches CMS editors that strip iframe attributes; Safari/Firefox don't expose the API and trust the param.

Gating logic is pure (`lib/embed-voice.ts`) with unit tests; the hook resolves post-mount, matching the `useEmbedVisibility` pattern so SSR and client renders never disagree.

## Behavior matrix

| Embed | Mic button |
| --- | --- |
| Existing pasted embeds (no param, no attr) | hidden, text-only chat as before |
| New snippet, delegation intact | shown |
| New snippet, `allow` stripped by CMS (Chromium) | hidden (policy check) |
| New snippet, `allow` stripped (Safari/Firefox) | shown; permission-denied dialog on use |

## Rollout note

Already-embedded sites get voice by re-pasting the embed code from the dashboard. No action needed for sites that don't care; they keep working unchanged.

## Tests

14 new tests (9 gating, 5 generator snapshots). Full suite green: 439 web + 60 ai + 10 db. Types and lint clean.