### PR TITLE
feat(ai): add Mistral Large 3 to the model lineup

### DIFF
--- a/packages/ai/src/__tests__/models.test.ts
+++ b/packages/ai/src/__tests__/models.test.ts
@@ -40,7 +40,8 @@ describe("supportsTools gating", () => {
     expect(ids).toContain("mistralai/mistral-large-2512");
   });
   it("modelSupportsTools resolves deprecated/dropped ids to tool-capable models", () => {
-    // old Qwen 3 -> 2507; retired Gemma/Nemotron -> replacement tool models
+    // old Qwen 3 -> 2507; retired Mistral -> Mistral Large 3; retired
+    // Gemma/Nemotron -> replacement tool models
     expect(modelSupportsTools("qwen/qwen3-235b-a22b")).toBe(true);
     expect(modelSupportsTools("mistralai/mistral-large")).toBe(true);
     expect(modelSupportsTools("google/gemma-4-31b-it")).toBe(true);

--- a/packages/ai/src/__tests__/models.test.ts
+++ b/packages/ai/src/__tests__/models.test.ts
@@ -3,6 +3,7 @@ import {
   MODEL_REGISTRY,
   toolCapableModels,
   modelSupportsTools,
+  resolveModel,
 } from "../models";
 
 describe("supportsTools gating", () => {
@@ -34,11 +35,23 @@ describe("supportsTools gating", () => {
     expect(ids).toContain("qwen/qwen3-235b-a22b-2507");
     expect(ids).not.toContain("qwen/qwen3-235b-a22b");
   });
+  it("toolCapableModels includes Mistral Large 3", () => {
+    const ids = toolCapableModels().map((m) => m.id);
+    expect(ids).toContain("mistralai/mistral-large-2512");
+  });
   it("modelSupportsTools resolves deprecated/dropped ids to tool-capable models", () => {
-    // old Qwen 3 -> 2507; retired Mistral/Gemma -> default tool model
+    // old Qwen 3 -> 2507; retired Gemma/Nemotron -> replacement tool models
     expect(modelSupportsTools("qwen/qwen3-235b-a22b")).toBe(true);
     expect(modelSupportsTools("mistralai/mistral-large")).toBe(true);
     expect(modelSupportsTools("google/gemma-4-31b-it")).toBe(true);
     expect(modelSupportsTools("nvidia/nemotron-3-super-120b-a12b")).toBe(true);
+  });
+  it("retired Mistral ids resolve to Mistral Large 3, not the Llama stopgap", () => {
+    expect(resolveModel("mistralai/mistral-large")).toBe(
+      "mistralai/mistral-large-2512",
+    );
+    expect(resolveModel("mistralai/mistral-large-2411")).toBe(
+      "mistralai/mistral-large-2512",
+    );
   });
 });

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,7 +1,7 @@
 // Centralized model registry -- single source of truth for all model metadata.
 // All consumers import from here; no independent model definitions elsewhere.
 
-export type Provider = "Meta" | "Qwen" | "OpenAI" | "DeepSeek";
+export type Provider = "Meta" | "Qwen" | "OpenAI" | "DeepSeek" | "Mistral";
 
 export interface ModelMetadata {
   id: string;
@@ -52,6 +52,17 @@ export const MODEL_REGISTRY = {
     contextWindow: 131_072,
     supportsTools: true,
   },
+  // Successor to the retired mistral-large-2411 (open weights). Passed the
+  // live agentic-retrieval eval on OpenRouter 2026-07-07: reliable
+  // search_documents calls with valid args, grounded answers, graceful
+  // not-found handling across repeated runs.
+  "mistralai/mistral-large-2512": {
+    id: "mistralai/mistral-large-2512",
+    displayName: "Mistral Large 3",
+    provider: "Mistral",
+    contextWindow: 262_144,
+    supportsTools: true,
+  },
 } as const satisfies Record<string, ModelMetadata>;
 
 /**
@@ -84,10 +95,13 @@ export const DEPRECATED_MODEL_MAP: Record<string, SupportedModel> = {
   // Qwen 3 235B -> the cheaper, larger-context 2507 revision.
   "qwen/qwen3-235b-a22b": "qwen/qwen3-235b-a22b-2507",
   "qwen/qwen-2.5-72b-instruct": "qwen/qwen3-235b-a22b-2507",
-  // Mistral dropped (mistral-large-2411 retired from OpenRouter) and Gemma
-  // dropped (unreliable tool-calling) -> migrate to the default tool model.
-  "mistralai/mistral-large": "meta-llama/llama-3.3-70b-instruct",
-  "mistralai/mistral-large-2411": "meta-llama/llama-3.3-70b-instruct",
+  // mistral-large-2411 was retired from OpenRouter; its successor
+  // (Mistral Large 3) is back in the registry, so bots that chose Mistral
+  // return to Mistral instead of staying on the Llama stopgap.
+  "mistralai/mistral-large": "mistralai/mistral-large-2512",
+  "mistralai/mistral-large-2411": "mistralai/mistral-large-2512",
+  // Gemma dropped (unreliable tool-calling) -> migrate to the default
+  // tool model.
   "google/gemma-4-31b-it": "meta-llama/llama-3.3-70b-instruct",
   // Nemotron 3 Super dropped: OpenRouter serves it in v2 compatibility mode
   // where the step-0 forced tool choice silently never fires, so the agentic


### PR DESCRIPTION
## Context

Prof Joubin asked for Mistral back in the lineup (diversity + the French lab angle) after `mistral-large-2411` was retired by OpenRouter and took her Shakespeare chatbot down.

## Evaluation

Ran a live eval against OpenRouter mirroring the production agentic path (`streamText` + retrieval tools + `stopWhen`, production grounding rule) with three scenarios: answer-in-context, must-search, and not-found. Two full runs each for consistency.

| Model | Result | Notes |
| --- | --- | --- |
| `mistralai/mistral-large-2512` (Mistral Large 3) | PASS 6/6 | open weights, 256K ctx, $0.50/$1.50 per M — in family with lineup pricing |
| `mistralai/mistral-medium-3-5` | PASS 6/6 | proprietary weights, ~5x output price — not added (lineup is announced as open source) |
| `mistralai/mistral-small-2603` | PASS 6/6 | open, cheap — viable future budget option, not added now |

All passing runs: valid `search_documents` args, answers grounded in the retrieved passage (planted-fact check), graceful not-found handling, 1.3-3.5s turns.

## Changes

- `MODEL_REGISTRY` + Provider union: add `mistralai/mistral-large-2512` ("Mistral Large 3", Mistral, 262144 ctx, supportsTools)
- `DEPRECATED_MODEL_MAP`: retired Mistral ids now resolve to Mistral Large 3 instead of the Llama stopgap, so chatbots whose owners chose Mistral (like the Shakespeare bot) return to a Mistral model automatically on their next message
- Model picker inherits the new entry via `toolCapableModels()`, no UI change needed
- Tests: registry inclusion + deprecation re-pointing

Full suite green (62 ai / 425 web / 10 db), types and lint clean.