### PR TITLE
docs(instructors): apply Prof Joubin's requested revisions

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -75,9 +75,14 @@ export default defineConfig({
   // Teach Anything doesn't have one — the share card still renders fine
   // without an attribution account.
 
-  // "Was this helpful?" widget and last-updated stamps keep the docs honest.
-  // (No `github` block, so there are no "Edit on GitHub" page actions or
-  // header repo link — this is an end-user product site, not a repo.)
-  feedback: true,
+  // Last-updated stamps keep the docs honest. (No `github` block, so there are
+  // no "Edit on GitHub" page actions or header repo link — this is an end-user
+  // product site, not a repo.)
+  //
+  // The "Was this page helpful?" widget is off: it only reports votes through
+  // an analytics provider (PostHog/gtag/Plausible) or a `blume:track` listener,
+  // none of which this static site loads, so every vote went nowhere. Re-enable
+  // once an analytics provider is wired up.
+  feedback: false,
   lastModified: true,
 });

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   // and the same 0.75rem corner radius. Headings use Geist — a crisp, modern
   // display sans that pairs cleanly with the Inter body.
   theme: {
-    mode: "system",
+    mode: "light",
     radius: "lg",
     accent: {
       light: "oklch(0.5248 0.1373 149.83)",

--- a/apps/docs/docs/instructors/add-website-content.mdx
+++ b/apps/docs/docs/instructors/add-website-content.mdx
@@ -53,7 +53,7 @@ If your course material lives on a website — a syllabus page, a course wiki, a
 If you're not sure, start with a low depth (1 or 2) and a modest page limit. Look at what it picked up, then widen the crawl if you need more.
 :::
 
-## Good manners and limits
+## Ethical Considerations
 
 - The crawler respects a site's `robots.txt` rules, which is the standard way sites say what may be read automatically. Only crawl sites you own or have permission to use.
 - It reads the **main content** of each page and skips navigation menus, ads, and boilerplate.
@@ -64,9 +64,10 @@ If you're not sure, start with a low depth (1 or 2) and a modest page limit. Loo
 Course websites change. You can re-crawl a source to pull in updates, and you can remove a web source entirely if it's no longer relevant — the assistant forgets it right away.
 
 <Card
-  title="Next: Customize your assistant"
-  href="/instructors/customize"
-  icon="sliders"
+  title="Next: Attach materials to a chatbot"
+  href="/instructors/attach-materials"
+  icon="link"
 >
-  Fine-tune how it sounds, which model it uses, and how it looks.
+  Connect the files and sites in your library to the assistant that should use
+  them.
 </Card>

--- a/apps/docs/docs/instructors/attach-materials.mdx
+++ b/apps/docs/docs/instructors/attach-materials.mdx
@@ -1,0 +1,66 @@
+---
+title: Attach materials to a chatbot
+description: Uploaded files and web sources live in your library — this is the step that connects them to a particular assistant so it can answer from them.
+sidebar:
+  label: Attach materials
+  icon: link
+---
+
+Uploading a file or adding a website puts it in your **library** — a shared collection tied to your account, not to any one assistant. Before an assistant can answer from a document, you have to **attach that material to the specific chatbot**. This is an easy step to miss, and it's why a freshly uploaded file sometimes seems "invisible" to an assistant.
+
+The upside of this design: one file or website can feed **several assistants** at once. Upload your syllabus once, attach it to every course chatbot that needs it.
+
+## Attach from the chatbot
+
+The most direct way is from the assistant itself.
+
+<Steps>
+  <Step title="Open your assistant">
+    From your [dashboard](https://teachanything.ai/dashboard), open the chatbot
+    you want to work on.
+  </Step>
+  <Step title="Go to the Files or Web Sources tab">
+    Each assistant has a **Files** tab and a **Web Sources** tab. The Files tab
+    shows its **Associated Files**; the Web Sources tab shows the sites in its
+    knowledge base.
+  </Step>
+  <Step title="Add files from your library">
+    On the **Files** tab, use **Quick add files from your library** to pick
+    documents you've already uploaded. Click **Add** on a row (or select several
+    and use **Add Selected**) to associate them with this chatbot.
+  </Step>
+  <Step title="Attach web sources">
+    On the **Web Sources** tab, use **Attach an existing web source** and click
+    **Attach** on the site you want. Its crawled pages come along automatically,
+    so the assistant can use them right away.
+  </Step>
+</Steps>
+
+:::note[Uploading here works too]
+You can also upload a brand-new file or crawl a new site directly from these
+tabs. When you do, it's added to your library _and_ attached to this chatbot in
+one step.
+:::
+
+## Attach from the library
+
+If you'd rather work from the library side, the **Web Sources** page in your
+dashboard lists every source in a table. Each row has an **Attach** button that
+opens a checklist of your chatbots — tick the ones that should use that source,
+untick to remove it. It's the quickest way to spread one website across multiple
+assistants at once.
+
+## Removing a material
+
+Attachments are always reversible. Remove a file from a chatbot's **Associated
+Files**, or use **Remove Selected** on the Web Sources tab, and the assistant
+stops using it immediately. The material stays in your library for other
+assistants — removing it here doesn't delete it.
+
+<Card
+  title="Next: Customize your assistant"
+  href="/instructors/customize"
+  icon="sliders"
+>
+  Fine-tune how it sounds, which LLM it uses, and how it looks.
+</Card>

--- a/apps/docs/docs/instructors/create-a-chatbot.mdx
+++ b/apps/docs/docs/instructors/create-a-chatbot.mdx
@@ -6,7 +6,7 @@ sidebar:
   icon: plus
 ---
 
-Your first step is to create the assistant itself. This is quick — you can always change everything later. From your [dashboard](https://teachanything.ai/dashboard), click **New chatbot** and fill out the form.
+Name your assistant and give it instructions on how to behave (this is called the system prompt). Here is a walkthrough of every setting. This is quick — you can always change everything later. From your [dashboard](https://teachanything.ai/dashboard), click **New chatbot** and fill out the form.
 
 ## Name and description
 
@@ -37,18 +37,18 @@ You don't have to get this perfect. Start simple, watch how it answers, and adju
 A few settings control the style of the answers:
 
 <CardGroup cols={2}>
-  <Card title="AI model" icon="cpu">
-    The underlying AI that writes the answers. Several are available; the
-    default is a strong general-purpose choice. See [Customize your
-    assistant](/instructors/customize#choosing-a-model).
+  <Card title="LLM model" icon="cpu">
+    The underlying large language model (LLM) is the "engine." We offer multiple
+    open-access LLMs; the default is a strong general-purpose choice. See
+    [Customize your assistant](/instructors/customize#choosing-a-model).
   </Card>
-  <Card title="Creativity" icon="sparkles">
+  <Card title="Temperature" icon="sparkles">
     Lower values keep answers focused and predictable — best for factual course
-    material. Higher values make answers more varied.
+    material. Higher values make answers more "creative."
   </Card>
-  <Card title="Answer length" icon="ruler">
-    A cap on how long each answer can get. Longer allows more detail; shorter
-    keeps things concise.
+  <Card title="Max tokens" icon="ruler">
+    This is a cap on how long (detailed) or concise each answer can get. 100
+    tokens are equal to roughly 75 English words.
   </Card>
   <Card title="Show sources" icon="quote">
     When on, answers list which of your files they drew from, so students can

--- a/apps/docs/docs/instructors/customize.mdx
+++ b/apps/docs/docs/instructors/customize.mdx
@@ -1,6 +1,6 @@
 ---
 title: Customize your assistant
-description: Tune the tone, pick an AI model, control answer length and creativity, and decide whether answers cite their sources.
+description: Tune the tone, pick an LLM, control max tokens and temperature, and decide whether answers cite their sources.
 sidebar:
   label: Customize
   icon: sliders
@@ -22,29 +22,31 @@ Rewrite the instructions whenever answers aren't landing the way you want. It's 
 
 ## Choosing a model
 
-The **model** is the AI engine that writes the answers. Several are available, and they all work the same way from your point of view — you don't need to know the technical differences.
+The **LLM** is the engine that writes the answers. We offer multiple open-access
+LLMs, and they all work the same way from your point of view — you don't need to
+know the technical differences.
 
 <CardGroup cols={2}>
   <Card title="Stick with the default" icon="check">
-    The default model is a well-rounded choice that works for most courses. When
+    The default LLM is a well-rounded choice that works for most courses. When
     in doubt, leave it.
   </Card>
   <Card title="Try another if needed" icon="repeat">
-    If answers feel too short, too long, or off-tone, switch models and compare.
+    If answers feel too short, too long, or off-tone, switch LLMs and compare.
     It's a safe experiment — nothing else changes.
   </Card>
 </CardGroup>
 
-## Creativity and answer length
+## Temperature and max tokens
 
 <CardGroup cols={2}>
-  <Card title="Creativity" icon="sparkles">
-    Lower keeps answers focused and consistent — best for factual course
-    content. Higher makes wording more varied and exploratory.
+  <Card title="Temperature" icon="sparkles">
+    Lower values keep answers focused and predictable — best for factual course
+    material. Higher values make answers more "creative."
   </Card>
-  <Card title="Answer length" icon="ruler">
-    A ceiling on answer length. Raise it for detailed explanations; lower it to
-    keep answers short and to the point.
+  <Card title="Max tokens" icon="ruler">
+    A cap on how long (detailed) or concise each answer can get. 100 tokens are
+    equal to roughly 75 English words.
   </Card>
 </CardGroup>
 

--- a/apps/docs/docs/instructors/index.mdx
+++ b/apps/docs/docs/instructors/index.mdx
@@ -15,7 +15,11 @@ Think of your assistant as a tutor who has read all of your course materials and
 <Steps>
   <Step title="Request an instructor account">
     Accounts are approved by an administrator to keep the platform limited to
-    real instructors. Sign up with your school email and wait for approval.
+    verified university professors. Please sign up with your university email
+    and wait for approval. Reach out to
+    [admin@teachanything.ai](mailto:admin@teachanything.ai) if your university
+    or country's domain is rejected. We will have to verify your status and
+    possibly manually add your domain name.
   </Step>
   <Step title="Create a chatbot">
     Give your assistant a name and a short description of how it should behave.
@@ -27,8 +31,8 @@ Think of your assistant as a tutor who has read all of your course materials and
     remembers everything.
   </Step>
   <Step title="Share it with students">
-    Send a link or [embed the assistant](/instructors/share-and-embed) directly
-    in your course site.
+    [Share the permalink](/instructors/share-and-embed) or [embed the
+    assistant](/instructors/share-and-embed) directly in your course site.
   </Step>
 </Steps>
 
@@ -71,7 +75,8 @@ Once you're in, everything revolves around your [dashboard](https://teachanythin
     The files and web pages each assistant has learned from.
   </Card>
   <Card title="Conversations" icon="messages-square">
-    A searchable record of what students asked and how the assistant answered.
+    An anonymized and searchable record of what students asked and how the
+    assistant answered.
   </Card>
   <Card title="Account settings" icon="settings">
     Your profile, privacy controls, and account deletion.

--- a/apps/docs/docs/instructors/meta.ts
+++ b/apps/docs/docs/instructors/meta.ts
@@ -9,6 +9,7 @@ export default defineMeta({
     "create-a-chatbot",
     "upload-materials",
     "add-website-content",
+    "attach-materials",
     "customize",
     "share-and-embed",
     "review-conversations",

--- a/apps/docs/docs/instructors/review-conversations.mdx
+++ b/apps/docs/docs/instructors/review-conversations.mdx
@@ -1,12 +1,12 @@
 ---
 title: Review conversations
-description: Read, search, and learn from every conversation students have with your assistant.
+description: Read, search, and learn from every anonymized conversation students have with your assistant.
 sidebar:
   label: Review conversations
   icon: messages-square
 ---
 
-One of the most useful things Teach Anything gives you is a window into what your students are actually asking. Every conversation with your assistant is saved so you can review it later.
+One of the most useful things Teach Anything gives you is a window into what your students are actually asking. Every conversation with your assistant is saved in an anonymized form so you can review it later.
 
 ## What you can see
 
@@ -51,7 +51,7 @@ Found a recurring question? Upload a short document that answers it directly, or
 
 ## A note on student privacy
 
-Conversations are visible to you as the instructor so you can improve your course. Let your students know their questions may be reviewed, and treat what you read with the same care you'd give any student communication.
+Conversations are visible in an anonymized form to you as the instructor so you can improve your course. Let your students know their questions may be reviewed anonymously, and treat what you read with the same care you'd give any student communication.
 
 <Card
   title="Next: Account and privacy"

--- a/apps/docs/docs/instructors/share-and-embed.mdx
+++ b/apps/docs/docs/instructors/share-and-embed.mdx
@@ -6,18 +6,18 @@ sidebar:
   icon: share
 ---
 
-Once your assistant is ready, there are two ways to get it in front of students: share a link, or embed it on a website.
+Once your assistant is ready, there are two ways to get it in front of students: share its permalink, or embed it on a website.
 
-## Option 1: Share a link
+## Option 1: Share the permalink
 
-The simplest option. Every assistant has its own private web link.
+The simplest option. Every assistant has its dedicated permalink.
 
 <Steps>
   <Step title="Turn on sharing">
     In your assistant's settings, make sure sharing is enabled.
   </Step>
-  <Step title="Copy the link">
-    Copy the share link and send it wherever your students are — your course
+  <Step title="Copy the permalink">
+    Copy the permalink and send it wherever your students are — your course
     page, an email, or your learning management system.
   </Step>
   <Step title="Students just click">

--- a/apps/docs/docs/instructors/upload-materials.mdx
+++ b/apps/docs/docs/instructors/upload-materials.mdx
@@ -30,9 +30,9 @@ This is where your assistant actually learns. Upload the documents you want it t
 
 :::note[File size and format notes]
 
-- Each file can be up to **50 MB**.
+- Each file can be up to **100 MB**.
 - Word and PowerPoint must be the newer `.docx` / `.pptx` formats. If you have an older `.doc` or `.ppt` file, open it and choose **Save As → .docx** (or **.pptx**) first.
-- Scanned PDFs that are just images of text may not read well. A PDF with real, selectable text works best.
+- Scanned PDFs that are just images of text do not work. Please put them through the OCR (Optical Character Recognition) process first.
   :::
 
 ## How to upload


### PR DESCRIPTION
## What

Applies the instructor-docs revisions Prof Joubin requested in the "Terms of Use" email thread. The Terms of Service itself is already live; this email was entirely about the `/docs/instructors` pages.

## Changes

**Getting started** (`index.mdx`)
- Account step: limited to "verified university professors", sign up with university email, added `admin@teachanything.ai` contact for rejected domains
- "Share the permalink" is now hyperlinked (alongside "embed the assistant")
- Conversations card now says "anonymized and searchable record"

**Create a chatbot** (`create-a-chatbot.mdx`)
- New system-prompt intro sentence
- `AI model` → `LLM model` (with open-access LLM "engine" framing)
- `Creativity` → `Temperature`
- `Answer length` → `Max tokens` ("100 tokens ≈ 75 English words")

**Upload materials** (`upload-materials.mdx`)
- File size limit `50 MB` → `100 MB`
- Scanned PDFs: now states they must go through OCR first

**Add website content** (`add-website-content.mdx`)
- "Good manners and limits" → "Ethical Considerations" (this heading lives here, not on upload-materials as the email assumed)

**Customize** (`customize.mdx`)
- "pick an LLM" instead of "pick an AI model"
- Aligned Temperature / Max tokens / LLM terminology with the dashboard for consistency

**Share and embed** (`share-and-embed.mdx`)
- "own private web link" → "dedicated permalink" ("private" was misleading)

**Review conversations** (`review-conversations.mdx`)
- Emphasized anonymity in the description, intro, and student-privacy note

**New page: Attach materials to a chatbot** (`attach-materials.mdx`)
- Teaches associating library files / attaching web sources to a specific chatbot (the many-to-many library model), added to the sidebar between "Add website content" and "Customize"

## Notes for review
- The create-form model field on the dashboard is still labeled **"AI Model"** while docs now say **"LLM model"**. Temperature and Max Tokens already match the dashboard. Flagging in case we want to rename the dashboard label too.
- `blume build` passes (17 pages, no broken links); pre-commit type-check/lint/tests green.