### PR TITLE
fix(auth): fail closed on rate-limit outage for updatePassword

### DIFF
--- a/apps/web/src/server/routers/auth.ts
+++ b/apps/web/src/server/routers/auth.ts
@@ -5,11 +5,7 @@ import { user, account } from "@teachanything/db/schema";
 import { eq, and } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import * as bcrypt from "bcryptjs";
-import {
-  checkRateLimit,
-  requireRateLimit,
-  passwordUpdateRateLimit,
-} from "@/lib/rate-limit";
+import { requireRateLimit, passwordUpdateRateLimit } from "@/lib/rate-limit";
 import { validatePasswordStrength } from "@/lib/password/password-strength";
 import { isPasswordDifferent } from "@/lib/password/password-validation";
 import { logInfo, logError } from "@/lib/logger";
@@ -179,8 +175,12 @@ export const authRouter = router({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      // Rate limiting: 5 attempts per hour per user
-      const { success, reset } = await checkRateLimit(
+      // Rate limiting: 5 attempts per hour per user. Use requireRateLimit so a
+      // Redis outage fails CLOSED -- this endpoint verifies the current
+      // password, so a fail-open limiter would restore unbounded brute-force of
+      // the existing password whenever Redis is unavailable. Mirrors
+      // deleteOwnAccount (the other current-password-guarded mutation).
+      const { success, reset } = await requireRateLimit(
         passwordUpdateRateLimit,
         userId,
         {


### PR DESCRIPTION
## Summary

`updatePassword` rate-limits with `checkRateLimit`, which fails **open** when Redis is unavailable (a runtime error or unconfigured limiter returns `success: true`). Because this endpoint verifies the user's **current password**, a fail-open limiter restores unbounded brute-force of the existing password during any Redis outage.

This switches it to `requireRateLimit`, which fails **closed**, matching `deleteOwnAccount` (the other current-password-guarded mutation, which already uses it and documents exactly this reasoning).

```diff
-      const { success, reset } = await checkRateLimit(
+      const { success, reset } = await requireRateLimit(
         passwordUpdateRateLimit,
         userId,
```

`checkRateLimit` was the only use of that import in the file, so it's dropped from the import to keep lint clean.

## Context

Surfaced while reviewing #380 (a code review flagged that `requireRateLimit` delegates to `checkRateLimit`; #380 fixed the delegation to honor a `failOpen` flag). This `updatePassword` gap is **pre-existing and independent** of #380, hence a separate PR.

## Verification

- `check-types`, `lint --max-warnings 0`, and the full test suite pass (pre-commit hook enforced).
- Behavior change is limited to a Redis-unavailable window: `updatePassword` now returns `TOO_MANY_REQUESTS` instead of allowing the attempt, consistent with `deleteOwnAccount`.
