### PR TITLE
fix(auth): never reset unsubscribed when syncing to Resend segment

### DIFF
--- a/apps/web/src/__tests__/lib/resend-segment.test.ts
+++ b/apps/web/src/__tests__/lib/resend-segment.test.ts
@@ -1,84 +1,72 @@
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 
-type CreateContactPayload = {
-  email: string;
-  firstName?: string;
-  lastName?: string;
-  segments?: { id: string }[];
-};
-
-type CreateContactResult = {
-  data: { id: string } | null;
-  error: { statusCode: number | null; name: string; message: string } | null;
-};
-
-// Mock external dependencies before importing the module under test.
-// Mocks are held in test-scope variables (closed over by the factories);
-// implementations are (re)established in beforeEach because jest.config
-// sets resetMocks: true.
-const mockContactsCreate =
-  jest.fn<
-    (
-      payload: CreateContactPayload,
-      options?: unknown,
-    ) => Promise<CreateContactResult>
-  >();
-const mockResend = jest.fn();
 const mockEnv: { RESEND_API_KEY?: string; RESEND_SEGMENT_ID?: string } = {};
 const mockLogWarn = jest.fn();
 const mockLogError = jest.fn();
 
-jest.unstable_mockModule("resend", () => ({ Resend: mockResend }));
-
-jest.unstable_mockModule("@/lib/env", () => ({
-  env: mockEnv,
-}));
-
+jest.unstable_mockModule("@/lib/env", () => ({ env: mockEnv }));
 jest.unstable_mockModule("@/lib/logger", () => ({
   logInfo: jest.fn(),
   logWarn: mockLogWarn,
   logError: mockLogError,
 }));
 
-// Dynamic import after mocks are set up
 const { syncUserToResendSegment } = await import("@/lib/resend-segment");
+
+const mockFetch = jest.fn<typeof fetch>();
+
+// Minimal Response stub — the helper only reads .ok, .status and .text().
+function makeRes(status: number, body = ""): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+// Responses for the two calls the helper may make, dispatched by URL.
+let addResponse: Response;
+let createResponse: Response;
+
+const addCalls = () =>
+  mockFetch.mock.calls.filter(([url]) => String(url).includes("/segments/"));
+const createCalls = () =>
+  mockFetch.mock.calls.filter(
+    ([url]) => String(url) === "https://api.resend.com/contacts",
+  );
 
 describe("syncUserToResendSegment", () => {
   beforeEach(() => {
-    mockResend.mockImplementation(() => ({
-      contacts: { create: mockContactsCreate },
-    }));
-    mockContactsCreate.mockResolvedValue({
-      data: { id: "contact_1" },
-      error: null,
-    });
     mockEnv.RESEND_API_KEY = "re_test_key";
     mockEnv.RESEND_SEGMENT_ID = "seg_123";
+    addResponse = makeRes(201, JSON.stringify({ id: "c1" }));
+    createResponse = makeRes(201, JSON.stringify({ id: "c1" }));
+    global.fetch = mockFetch;
+    mockFetch.mockImplementation((async (url: unknown) =>
+      String(url).includes("/segments/")
+        ? addResponse
+        : createResponse) as unknown as typeof fetch);
   });
 
   it("warns and returns false without calling Resend when the API key is not configured", async () => {
     mockEnv.RESEND_API_KEY = undefined;
-
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(false);
-    expect(mockContactsCreate).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(mockLogWarn).toHaveBeenCalled();
   });
 
-  it("logs an error (not a silent warn) and returns false when the API key is set but RESEND_SEGMENT_ID is missing", async () => {
+  it("logs an error (not a silent warn) and returns false when RESEND_SEGMENT_ID is missing", async () => {
     mockEnv.RESEND_SEGMENT_ID = undefined;
-
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(false);
-    expect(mockContactsCreate).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(mockLogError).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining("RESEND_SEGMENT_ID"),
@@ -88,110 +76,101 @@ describe("syncUserToResendSegment", () => {
     );
   });
 
-  it("creates a global contact in the segment with the split name and returns true", async () => {
+  it("adds an EXISTING contact to the segment and never re-creates it (preserves unsubscribed)", async () => {
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(true);
-    expect(mockResend).toHaveBeenCalledWith("re_test_key");
-    expect(mockContactsCreate).toHaveBeenCalledWith(
-      {
-        email: "prof@university.edu",
-        firstName: "Prof",
-        lastName: "Joubin",
-        segments: [{ id: "seg_123" }],
-      },
-      // the abort signal that bounds the request
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    // add-to-segment hit with the encoded email + segment id
+    expect(addCalls()).toHaveLength(1);
+    expect(String(addCalls()[0][0])).toBe(
+      "https://api.resend.com/contacts/prof%40university.edu/segments/seg_123",
     );
+    expect((addCalls()[0][1] as RequestInit).method).toBe("POST");
+    // crucially, NO POST /contacts (which would upsert and reset unsubscribed)
+    expect(createCalls()).toHaveLength(0);
   });
 
-  it("splits a multi-part name: first token is firstName, the rest is lastName", async () => {
+  it("creates the contact only when it does not exist (add-to-segment 404)", async () => {
+    addResponse = makeRes(
+      404,
+      JSON.stringify({ message: "Contact not found" }),
+    );
+    const result = await syncUserToResendSegment({
+      email: "new@university.edu",
+      name: "Prof Joubin",
+    });
+    expect(result).toBe(true);
+    expect(createCalls()).toHaveLength(1);
+    expect(
+      JSON.parse((createCalls()[0][1] as RequestInit).body as string),
+    ).toEqual({
+      email: "new@university.edu",
+      first_name: "Prof",
+      last_name: "Joubin",
+      segments: [{ id: "seg_123" }],
+    });
+  });
+
+  it("splits a multi-part name on create", async () => {
+    addResponse = makeRes(404, "not found");
     await syncUserToResendSegment({
-      email: "prof@university.edu",
+      email: "new@university.edu",
       name: "Alexa Alice Joubin",
     });
-
-    expect(mockContactsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        firstName: "Alexa",
-        lastName: "Alice Joubin",
-      }),
-      expect.anything(),
-    );
+    expect(
+      JSON.parse((createCalls()[0][1] as RequestInit).body as string),
+    ).toMatchObject({ first_name: "Alexa", last_name: "Alice Joubin" });
   });
 
-  it("omits both name fields when the user has no name", async () => {
-    await syncUserToResendSegment({
-      email: "prof@university.edu",
-      name: null,
-    });
-
-    expect(mockContactsCreate).toHaveBeenCalledWith(
-      {
-        email: "prof@university.edu",
-        firstName: undefined,
-        lastName: undefined,
-        segments: [{ id: "seg_123" }],
-      },
-      expect.anything(),
-    );
+  it("omits name fields on create when there is no name", async () => {
+    addResponse = makeRes(404, "not found");
+    await syncUserToResendSegment({ email: "new@university.edu", name: null });
+    expect(
+      JSON.parse((createCalls()[0][1] as RequestInit).body as string),
+    ).toEqual({ email: "new@university.edu", segments: [{ id: "seg_123" }] });
   });
 
-  it("treats an already-existing contact (409) as success", async () => {
-    mockContactsCreate.mockResolvedValue({
-      data: null,
-      error: {
-        statusCode: 409,
-        name: "invalid_parameter",
-        message: "Contact already exists",
-      },
-    });
-
+  it("treats an already-in-segment response (409) as success", async () => {
+    addResponse = makeRes(409, "already in segment");
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(true);
+    expect(createCalls()).toHaveLength(0);
     expect(mockLogError).not.toHaveBeenCalled();
   });
 
-  it("returns false and logs when Resend responds with an error", async () => {
-    mockContactsCreate.mockResolvedValue({
-      data: null,
-      error: {
-        statusCode: 422,
-        name: "validation_error",
-        message: "Invalid email",
-      },
-    });
-
+  it("returns false and logs when add-to-segment fails with a non-404 error", async () => {
+    addResponse = makeRes(500, "server error");
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(false);
-    expect(mockLogError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Invalid email" }),
-      "Failed to add contact to Resend segment",
-      { email: "prof@university.edu" },
-    );
+    expect(createCalls()).toHaveLength(0);
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it("returns false and logs when the create (after 404) fails", async () => {
+    addResponse = makeRes(404, "not found");
+    createResponse = makeRes(422, JSON.stringify({ message: "Invalid email" }));
+    const result = await syncUserToResendSegment({
+      email: "bad@university.edu",
+      name: "Prof Joubin",
+    });
+    expect(result).toBe(false);
+    expect(mockLogError).toHaveBeenCalled();
   });
 
   it("returns false and logs when the request throws (network error / timeout abort)", async () => {
-    mockContactsCreate.mockRejectedValue(
-      new Error("The operation was aborted"),
-    );
-
+    mockFetch.mockRejectedValue(new Error("The operation was aborted"));
     const result = await syncUserToResendSegment({
       email: "prof@university.edu",
       name: "Prof Joubin",
     });
-
     expect(result).toBe(false);
     expect(mockLogError).toHaveBeenCalled();
   });

--- a/apps/web/src/lib/resend-segment.ts
+++ b/apps/web/src/lib/resend-segment.ts
@@ -1,45 +1,44 @@
-import { Resend, type CreateContactRequestOptions } from "resend";
 import { env } from "./env";
 import { logInfo, logWarn, logError } from "./logger";
 
-// A human waits on the approval mutation, so bound the request tightly.
+// A human waits on the approval mutation, so bound each request tightly.
 // AbortSignal.timeout both bounds the latency and aborts the request.
-const CREATE_TIMEOUT_MS = 5_000;
+const REQUEST_TIMEOUT_MS = 5_000;
 
 /**
- * Split a single display name into Resend's firstName/lastName fields. The
+ * Split a single display name into Resend's first_name/last_name fields. The
  * user schema only stores one `name`, so this is a best-effort split on
  * whitespace: the first token is the first name, everything after is the last.
  */
 function splitName(name?: string | null): {
-  firstName?: string;
-  lastName?: string;
+  first_name?: string;
+  last_name?: string;
 } {
   const trimmed = name?.trim();
   if (!trimmed) return {};
   const [first, ...rest] = trimmed.split(/\s+/);
   return {
-    firstName: first,
-    lastName: rest.length ? rest.join(" ") : undefined,
+    first_name: first,
+    last_name: rest.length ? rest.join(" ") : undefined,
   };
 }
 
 /**
  * Add a user to the Resend segment configured via RESEND_SEGMENT_ID.
  *
- * Uses the current Contacts API (global contact + `segments`) — the Audiences
- * API this originally targeted is deprecated in favour of Segments.
+ * This must NEVER overwrite an existing contact's `unsubscribed` flag.
+ * `POST /contacts` is an upsert that resets omitted fields, so it would
+ * silently re-subscribe someone who had opted out. Instead we:
+ *   1. add-to-segment (`POST /contacts/{email}/segments/{id}`), which does not
+ *      touch `unsubscribed`, and
+ *   2. only create the contact (`POST /contacts`) if that returns 404, i.e. the
+ *      contact does not exist yet (a brand-new contact is correctly subscribed).
  *
  * Never throws and never rolls back approval: every failure path returns a
- * logged `false`, and the caller commits the approval before calling this.
- * It is not zero-cost — on a hung Resend it blocks the approval mutation for
- * up to CREATE_TIMEOUT_MS, at which point the request is aborted.
+ * logged `false`, and the caller commits the approval before calling this. On
+ * a hung Resend it blocks for up to REQUEST_TIMEOUT_MS per request, then aborts.
  *
- * The payload omits `unsubscribed` so that re-creating an existing contact can
- * never silently overwrite an opt-out.
- *
- * Returns true when the contact was added (or already present), false when
- * skipped or failed.
+ * Returns true when the contact is in the segment, false when skipped or failed.
  */
 export async function syncUserToResendSegment(params: {
   email: string;
@@ -76,36 +75,61 @@ export async function syncUserToResendSegment(params: {
     return false;
   };
 
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+  const enc = encodeURIComponent(params.email);
+
   try {
-    const resend = new Resend(apiKey);
-    const { firstName, lastName } = splitName(params.name);
-
-    const { error } = await resend.contacts.create(
+    // 1. Add an existing contact to the segment. Does NOT touch unsubscribed.
+    const addRes = await fetch(
+      `https://api.resend.com/contacts/${enc}/segments/${segmentId}`,
       {
-        email: params.email,
-        firstName,
-        lastName,
-        segments: [{ id: segmentId }],
+        method: "POST",
+        headers,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       },
-      // The SDK forwards request options to fetch, so AbortSignal.timeout both
-      // bounds and aborts the request. `signal` isn't in the option type, hence
-      // the cast.
-      {
-        signal: AbortSignal.timeout(CREATE_TIMEOUT_MS),
-      } as CreateContactRequestOptions,
     );
+    const addBody = await addRes.text();
 
-    if (error) {
-      // Contact already exists — treat as success, the user is a contact.
-      if (error.statusCode === 409 || /already/i.test(error.message)) {
-        logInfo("Contact already present in Resend", { email: params.email });
-        return true;
-      }
-      return logFailure(error);
+    if (addRes.ok || addRes.status === 409 || /already/i.test(addBody)) {
+      logInfo("Contact added to Resend segment", { email: params.email });
+      return true;
     }
 
-    logInfo("Contact added to Resend segment", { email: params.email });
-    return true;
+    // 2. Contact does not exist yet -> create it (new contact is subscribed).
+    if (addRes.status === 404) {
+      const createRes = await fetch("https://api.resend.com/contacts", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          email: params.email,
+          ...splitName(params.name),
+          segments: [{ id: segmentId }],
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const createBody = await createRes.text();
+
+      if (createRes.ok) {
+        logInfo("Contact created in Resend segment", { email: params.email });
+        return true;
+      }
+      // Raced: created between our add and create -> it's in the segment now.
+      if (createRes.status === 409 || /already/i.test(createBody)) {
+        return true;
+      }
+      return logFailure(
+        new Error(
+          `Resend create contact failed: ${createRes.status} ${createBody}`,
+        ),
+      );
+    }
+
+    return logFailure(
+      new Error(`Resend add-to-segment failed: ${addRes.status} ${addBody}`),
+    );
   } catch (error) {
     return logFailure(error);
   }

--- a/packages/db/scripts/backfill-resend-segment.ts
+++ b/packages/db/scripts/backfill-resend-segment.ts
@@ -1,23 +1,30 @@
 /**
  * Resend Segment Backfill Script
  *
- * One-time backfill: pushes every already-approved user into the Resend
- * segment configured via RESEND_SEGMENT_ID, using the current global Contacts
- * API (POST /contacts with a `segments` array). The Audiences API is
- * deprecated in favour of Segments.
+ * One-time backfill: puts every already-approved user into the Resend segment
+ * configured via RESEND_SEGMENT_ID.
  *
- * Safe to re-run: it never removes contacts and omits `unsubscribed`, so an
- * existing opt-out is never overwritten, and contacts already present (HTTP
- * 409 / an "already" response) are counted separately rather than as
- * failures, so a clean re-run exits 0.
+ * IMPORTANT — this must never overwrite an existing contact's `unsubscribed`
+ * flag. `POST /contacts` is an UPSERT: for an existing contact it resets
+ * omitted fields to their defaults, so it would silently re-subscribe anyone
+ * who had opted out. Instead, for each user we:
+ *   1. POST /contacts/{email}/segments/{segmentId}  (add-to-segment) — this
+ *      adds an existing contact to the segment and does NOT touch
+ *      `unsubscribed`.
+ *   2. Only if that returns 404 (contact does not exist yet) do we
+ *      POST /contacts to create a brand-new contact (subscribed by default,
+ *      which is correct for someone who was never a contact).
+ *
+ * Safe to re-run: it never removes contacts and never resets `unsubscribed`;
+ * a contact already in the segment is counted, not failed.
  *
  * Usage:
  *   npx tsx packages/db/scripts/backfill-resend-segment.ts
  *   npx tsx packages/db/scripts/backfill-resend-segment.ts --dry-run
  *
- * With --dry-run it reads the approved users and prints exactly what it would
- * POST to Resend, without making any requests. Only DATABASE_URL is required
- * in that mode (RESEND_API_KEY / RESEND_SEGMENT_ID are not needed).
+ * With --dry-run it reads the approved users and prints what it would send,
+ * without making any requests. Only DATABASE_URL is required in that mode
+ * (RESEND_API_KEY / RESEND_SEGMENT_ID are not needed).
  */
 
 import postgres from "postgres";
@@ -54,8 +61,8 @@ if (!databaseUrl || (!isDryRun && (!resendApiKey || !segmentId))) {
 }
 
 // In a dry run RESEND_SEGMENT_ID may be unset; show a placeholder so the
-// printed payload is still readable.
-const segmentIdForPayload = segmentId ?? "<RESEND_SEGMENT_ID>";
+// printed payload is still readable. In a real run this is always the real id.
+const seg = segmentId ?? "<RESEND_SEGMENT_ID>";
 
 // Resend's documented default rate limit is 10 requests/second per team --
 // stay well under it to leave room for concurrent app traffic
@@ -64,6 +71,11 @@ const REQUEST_DELAY_MS = 250;
 // Node's fetch has no overall deadline; bound each request so one hung
 // connection can't stall the serial loop
 const REQUEST_TIMEOUT_MS = 15_000;
+
+const authHeaders = {
+  Authorization: `Bearer ${resendApiKey}`,
+  "Content-Type": "application/json",
+};
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -84,6 +96,56 @@ function splitName(name: string | null): {
   };
 }
 
+type SyncResult = "added" | "created" | "failed";
+
+// Add an existing contact to the segment (preserving unsubscribed), or create
+// it if it does not exist yet. Never sends `unsubscribed`.
+async function syncOne(u: { email: string; name: string | null }): Promise<{
+  result: SyncResult;
+  detail?: string;
+}> {
+  const enc = encodeURIComponent(u.email);
+
+  // 1. Add existing contact to the segment. This does NOT touch unsubscribed.
+  const addRes = await fetch(
+    `https://api.resend.com/contacts/${enc}/segments/${seg}`,
+    {
+      method: "POST",
+      headers: authHeaders,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  const addBody = await addRes.text();
+
+  if (addRes.ok || addRes.status === 409 || /already/i.test(addBody)) {
+    return { result: "added" };
+  }
+
+  // 2. Contact does not exist yet -> create it. A brand-new contact defaults to
+  // subscribed, which is correct for someone who was never a contact.
+  if (addRes.status === 404) {
+    const createRes = await fetch("https://api.resend.com/contacts", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({
+        email: u.email,
+        ...splitName(u.name),
+        segments: [{ id: seg }],
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const createBody = await createRes.text();
+    if (createRes.ok) return { result: "created" };
+    // Raced: created between our add and create -> it's in the segment now.
+    if (createRes.status === 409 || /already/i.test(createBody)) {
+      return { result: "added" };
+    }
+    return { result: "failed", detail: `${createRes.status} ${createBody}` };
+  }
+
+  return { result: "failed", detail: `${addRes.status} ${addBody}` };
+}
+
 async function backfill() {
   const sql = postgres(databaseUrl!);
 
@@ -96,72 +158,51 @@ async function backfill() {
       `Found ${users.length} approved users to sync${isDryRun ? " (dry run — no requests will be made)" : ""}`,
     );
 
-    let synced = 0;
-    let alreadyPresent = 0;
+    let added = 0;
+    let created = 0;
     let failed = 0;
 
     for (const [i, u] of users.entries()) {
-      // Payload sent to POST /contacts (segments takes an array of { id }).
-      const payload = {
-        email: u.email,
-        ...splitName(u.name),
-        segments: [{ id: segmentIdForPayload }],
-      };
+      const tag = `[${i + 1}/${users.length}]`;
 
       if (isDryRun) {
-        synced++;
+        added++;
         console.log(
-          `[${i + 1}/${users.length}] would create ${JSON.stringify(payload)}`,
+          `${tag} would add ${u.email} to segment ${seg} (create if new)`,
         );
         continue;
       }
 
       try {
-        const res = await fetch("https://api.resend.com/contacts", {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${resendApiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        });
-
-        // Always consume the body so undici can reuse the connection
-        const body = await res.text();
-
-        if (res.ok) {
-          synced++;
-          console.log(`[${i + 1}/${users.length}] synced ${u.email}`);
-        } else if (res.status === 409 || /already/i.test(body)) {
-          // Contact already present — expected on a re-run, not a failure, so
-          // it doesn't set a nonzero exit code.
-          alreadyPresent++;
-          console.log(`[${i + 1}/${users.length}] already present ${u.email}`);
+        const { result, detail } = await syncOne(u);
+        if (result === "added") {
+          added++;
+          console.log(`${tag} added to segment ${u.email}`);
+        } else if (result === "created") {
+          created++;
+          console.log(`${tag} created ${u.email}`);
         } else {
           failed++;
-          console.error(
-            `[${i + 1}/${users.length}] FAILED ${u.email}: ${res.status} ${body}`,
-          );
+          console.error(`${tag} FAILED ${u.email}: ${detail}`);
         }
       } catch (error) {
         failed++;
-        console.error(`[${i + 1}/${users.length}] FAILED ${u.email}:`, error);
+        console.error(`${tag} FAILED ${u.email}:`, error);
       }
 
       if (i < users.length - 1) await sleep(REQUEST_DELAY_MS);
     }
 
     if (isDryRun) {
-      console.log(`Dry run: would sync ${synced} contacts. No requests made.`);
+      console.log(`Dry run: would sync ${added} contacts. No requests made.`);
       return;
     }
 
     console.log(
-      `Done: ${synced} synced, ${alreadyPresent} already present, ${failed} failed`,
+      `Done: ${created} created, ${added} added to segment, ${failed} failed`,
     );
     // exitCode (not process.exit) so the finally block still runs. Only real
-    // failures fail the run — a clean re-run (all already present) exits 0.
+    // failures fail the run — a clean re-run (all already in segment) exits 0.
     if (failed > 0) process.exitCode = 1;
   } finally {
     await sql.end();


### PR DESCRIPTION
## The bug

`POST /contacts` is an **upsert**. For an existing contact it resets omitted fields to their defaults, so calling it (even without `unsubscribed` in the body) silently flips opted-out contacts back to **subscribed**. The backfill hit ~331 existing contacts this way and re-subscribed every opt-out in the segment.

## The fix

Both the runtime helper (`resend-segment.ts`) and the backfill script now:

1. **add-to-segment** via `POST /contacts/{email}/segments/{id}` — adds an existing contact to the segment and does **not** touch `unsubscribed`.
2. only **create** (`POST /contacts`) when add-to-segment returns **404** (contact doesn't exist yet; a brand-new contact is correctly subscribed).

Nobody's `unsubscribed` flag is ever written by this path again.

## Verified against the live API (not assumed this time)

- add-to-segment on an **unsubscribed** throwaway contact → it stays `unsubscribed: true` ✅
- add-to-segment on a **non-existent** contact → `404 Contact not found`, no side effect ✅

## Notes

- Helper moved from the Resend SDK back to raw `fetch`: the SDK's `contacts.segments.add` takes no request options, so it can't carry the `AbortSignal` that bounds the approval mutation. Raw fetch keeps the 5s timeout/abort and uses the verified wire shapes.
- Tests rewritten (10 cases) — the key one asserts an existing contact is added to the segment and **never** re-created.
- `check-types`, `lint`, tests all pass.