### PR TITLE
docs(students): add quiz feature guide

### DIFF
--- a/apps/docs/docs/students/meta.ts
+++ b/apps/docs/docs/students/meta.ts
@@ -4,5 +4,5 @@ export default defineMeta({
   title: "For Students",
   icon: "book-open",
   order: 2,
-  pages: ["index", "asking-good-questions", "understanding-answers"],
+  pages: ["index", "asking-good-questions", "understanding-answers", "quizzes"],
 });

--- a/apps/docs/docs/students/quizzes.mdx
+++ b/apps/docs/docs/students/quizzes.mdx
@@ -1,0 +1,64 @@
+---
+title: Quiz yourself
+description: How to ask the assistant to quiz you, and how the interactive practice quizzes work.
+sidebar:
+  label: Quiz yourself
+  icon: list-checks
+---
+
+One of the best ways to study is to test yourself. Instead of just reading an answer, you can ask the assistant to quiz you and see how much actually stuck.
+
+## Ask to be quizzed
+
+Just ask, in your own words. The assistant turns it into an interactive quiz instead of writing the questions out as plain text.
+
+<CardGroup cols={2}>
+  <Card title="On a topic" icon="help-circle">
+    "Quiz me on the light-dependent reactions."
+  </Card>
+  <Card title="On a reading" icon="book-open">
+    "Test me on chapter 3."
+  </Card>
+  <Card title="After a chat" icon="message-circle">
+    "Now quiz me on what we just went over."
+  </Card>
+  <Card title="Mixed practice" icon="list-checks">
+    "Give me a few practice questions from week 4."
+  </Card>
+</CardGroup>
+
+## How a quiz works
+
+<Steps>
+  <Step title="One question at a time">
+    You get a multiple-choice question with a progress bar so you know how far
+    along you are.
+  </Step>
+  <Step title="Pick an answer">
+    Click the option you think is right. Your choice locks in.
+  </Step>
+  <Step title="See if you were right">
+    It immediately shows whether you got it, marks the correct answer, and gives
+    a short explanation of why.
+  </Step>
+  <Step title="Get your score">
+    At the end you see how many you got right, and you can retake the quiz to
+    try again.
+  </Step>
+</Steps>
+
+## It's built from your course material
+
+When your instructor has added course materials, the questions are drawn from them, so you're practicing the actual content of your course rather than general trivia. If there aren't materials for a topic, the assistant will do its best from the conversation instead.
+
+## It's for practice
+
+Quizzes are a low-stakes way to check yourself, not a graded assignment. Retake them as many times as you want, and use the explanations to fill in the gaps.
+
+:::tip[Turn a study session into a quiz]
+After the assistant explains something, just say "quiz me on that." It's a quick way to find out whether it really landed.
+:::
+
+<Card title="Back to the student guide" href="/students" icon="arrow-left">
+  Return to using your course assistant.
+</Card>

--- a/apps/docs/docs/students/understanding-answers.mdx
+++ b/apps/docs/docs/students/understanding-answers.mdx
@@ -61,6 +61,6 @@ For anything that matters — an exam topic, a formula, a due date — confirm i
   </Card>
 </CardGroup>
 
-<Card title="Back to the student guide" href="/students" icon="arrow-left">
-  Return to using your course assistant.
+<Card title="Next: Quiz yourself" href="/students/quizzes" icon="list-checks">
+  Turn what you've learned into interactive practice quizzes.
 </Card>


### PR DESCRIPTION
## What

Adds a student-facing docs page for the quiz study mode that shipped in release 1.33.0 (`fd31463`, PR #380).

- New page `apps/docs/docs/students/quizzes.mdx` covering how to ask for a quiz, how the interactive multiple-choice widget works (one question at a time, instant feedback + explanation, score, retake), and that questions are drawn from course materials.
- Registers the page in `students/meta.ts`.
- Points the "Understanding answers" page's Next link to the new page so the student guide flows into it.

## Why

Prof Joubin is announcing the quiz feature in her July newsletter, so students need a short how-to. Only the `showQuiz` mode is live (Phase 1); flashcards/test/mindmap/matching are Phase 2 and intentionally not documented yet.

## Notes

- Docs-only change. `blume build` passes (19 pages). The built output embeds into the web app via `scripts/embed-docs.mjs` at web build time, so the page goes live on the next web deploy.