### PR TITLE
docs: surface and document the quiz feature

### DIFF
--- a/apps/docs/docs/instructors/index.mdx
+++ b/apps/docs/docs/instructors/index.mdx
@@ -83,6 +83,10 @@ Once you're in, everything revolves around your [dashboard](https://teachanythin
   </Card>
 </CardGroup>
 
+:::tip[Students can quiz themselves]
+Students can ask the assistant to quiz them on a topic, and it builds an interactive practice quiz from your materials. Their results show up when you [review conversations](/instructors/review-conversations).
+:::
+
 ## Next step
 
 <Card

--- a/apps/docs/docs/instructors/review-conversations.mdx
+++ b/apps/docs/docs/instructors/review-conversations.mdx
@@ -49,6 +49,28 @@ Reading conversations tells you things a syllabus can't:
 Found a recurring question? Upload a short document that answers it directly, or fold the answer into your assistant's [instructions](/instructors/customize#the-instructions-field), so it's always ready.
 :::
 
+## Quiz results show up here too
+
+When a student asks the assistant to quiz them, the quiz shows up right inside their conversation, so you can see how they did while you review.
+
+<CardGroup cols={2}>
+  <Card title="The questions asked" icon="list-checks">
+    See the multiple-choice questions the assistant generated from your
+    materials.
+  </Card>
+  <Card title="What the student picked" icon="mouse-pointer-click">
+    Each question shows the answer they chose and whether it was right.
+  </Card>
+  <Card title="Their score" icon="target">
+    See how many they got right out of the total.
+  </Card>
+  <Card title="Every attempt" icon="repeat">
+    If a student retook the quiz, each attempt is recorded.
+  </Card>
+</CardGroup>
+
+Quiz results are also included when you [export chat records](/instructors/export-chat-records), so you can pull them alongside the rest of the conversation.
+
 ## A note on student privacy
 
 Conversations are visible in an anonymized form to you as the instructor so you can improve your course. Let your students know their questions may be reviewed anonymously, and treat what you read with the same care you'd give any student communication.

--- a/apps/docs/docs/students/index.mdx
+++ b/apps/docs/docs/students/index.mdx
@@ -45,6 +45,10 @@ Depending on your course, you'll reach the assistant one of two ways:
 If your instructor enabled voice, you can tap the microphone and speak your question instead of typing. Your browser will ask permission to use your mic the first time.
 :::
 
+:::tip[You can quiz yourself]
+Ask the assistant to quiz you on a topic or a reading and it will build an interactive practice quiz from your course materials. See [Quiz yourself](/students/quizzes).
+:::
+
 ## What to expect
 
 <CardGroup cols={2}>
@@ -82,5 +86,8 @@ If your instructor enabled voice, you can tap the microphone and speak your ques
     icon="quote"
   >
     How to read sources and double-check what you're told.
+  </Card>
+  <Card title="Quiz yourself" href="/students/quizzes" icon="list-checks">
+    Turn a study session into an interactive practice quiz.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What

Follow-up to the merged student quiz how-to (#393). Makes the quiz feature clearly discoverable across the docs and documents the instructor side.

- **Instructor review page** (`instructors/review-conversations.mdx`): quizzes render inline in the conversation review with the questions, the student's chosen answer per question, correctness, score, and per-attempt history; also included in chat-record exports.
- **Student landing page** (`students/index.mdx`): a "You can quiz yourself" tip and a "Quiz yourself" card in Learn more.
- **Instructor landing page** (`instructors/index.mdx`): a tip noting students can quiz themselves and where the results appear.

## Why

Prof Joubin is announcing the quiz feature in her July newsletter and asked that the docs make it clear the feature exists, and cover the instructor side, not just the student how-to.

## Notes

- Docs-only. All links are relative. `blume build` passes (19 pages). Output embeds into the web app via `scripts/embed-docs.mjs` at web build time.