### PR TITLE
fix(quiz): restore finished quiz on remount and recover text-leaked quizzes

### DIFF
--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -5,7 +5,10 @@ import {
   isRenderableQuiz,
   isValidQuizAnswers,
   gradeQuiz,
+  initialQuizWidgetState,
+  parseQuizFromText,
   type Quiz,
+  type QuizResponse,
 } from "@/lib/quiz";
 
 describe("quizSchema", () => {
@@ -205,5 +208,125 @@ describe("gradeQuiz", () => {
       score: 0,
       total: 2,
     });
+  });
+});
+
+describe("initialQuizWidgetState", () => {
+  const attempt = (answers: number[]): QuizResponse => ({
+    answers,
+    score: 0,
+    total: answers.length,
+  });
+
+  it("starts fresh when there are no attempts", () => {
+    expect(initialQuizWidgetState(3, undefined)).toEqual({
+      currentIndex: 0,
+      selected: [null, null, null],
+      finished: false,
+    });
+    expect(initialQuizWidgetState(3, [])).toEqual({
+      currentIndex: 0,
+      selected: [null, null, null],
+      finished: false,
+    });
+  });
+
+  it("restores the finished view from the most recent attempt", () => {
+    const state = initialQuizWidgetState(3, [
+      attempt([0, 1, 2]),
+      attempt([2, 0, 1]),
+    ]);
+    expect(state).toEqual({
+      currentIndex: 2,
+      selected: [2, 0, 1],
+      finished: true,
+    });
+  });
+
+  it("copies the stored answers rather than aliasing them", () => {
+    const stored = attempt([1, 0]);
+    const state = initialQuizWidgetState(2, [stored]);
+    state.selected[0] = 9;
+    expect(stored.answers).toEqual([1, 0]);
+  });
+
+  it("falls back to a fresh start when stored answers don't match the quiz length", () => {
+    // A length mismatch would mis-score the finished view, so ignore it.
+    expect(initialQuizWidgetState(3, [attempt([0, 1])])).toEqual({
+      currentIndex: 0,
+      selected: [null, null, null],
+      finished: false,
+    });
+  });
+});
+
+describe("parseQuizFromText", () => {
+  const validQuiz = {
+    quiz_title: "Photosynthesis",
+    questions: [
+      {
+        question: "What gas do plants absorb?",
+        options: ["CO2", "O2"],
+        correct_index: 0,
+        explanation: "Plants take in carbon dioxide.",
+      },
+    ],
+  };
+
+  it("recovers a quiz from a bare JSON blob", () => {
+    expect(parseQuizFromText(JSON.stringify(validQuiz))).toEqual(validQuiz);
+  });
+
+  it("recovers a quiz wrapped in a ```json code fence", () => {
+    const fenced = "```json\n" + JSON.stringify(validQuiz) + "\n```";
+    expect(parseQuizFromText(fenced)).toEqual(validQuiz);
+  });
+
+  it("recovers a quiz with leading/trailing prose around the JSON", () => {
+    const text = `Sure! Here you go:\n${JSON.stringify(validQuiz)}\nGood luck!`;
+    expect(parseQuizFromText(text)).toEqual(validQuiz);
+  });
+
+  it("handles braces inside question/option strings", () => {
+    const quiz = {
+      quiz_title: "Sets",
+      questions: [
+        {
+          question: "Which is the empty set {}?",
+          options: ["{}", "{1}"],
+          correct_index: 0,
+          explanation: "The empty set {} has no elements.",
+        },
+      ],
+    };
+    expect(parseQuizFromText(JSON.stringify(quiz))).toEqual(quiz);
+  });
+
+  it("returns null for ordinary prose", () => {
+    expect(parseQuizFromText("Here is a summary of the topic.")).toBeNull();
+  });
+
+  it("returns null for non-quiz JSON", () => {
+    expect(parseQuizFromText('{"foo":"bar"}')).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseQuizFromText('{"quiz_title": "x", questions:')).toBeNull();
+  });
+
+  it("returns null for a structurally valid but unrenderable quiz", () => {
+    // correct_index points past the options -> not renderable.
+    const bad = {
+      quiz_title: "Bad",
+      questions: [
+        {
+          question: "Q?",
+          options: ["A", "B"],
+          correct_index: 5,
+          explanation: "x",
+        },
+      ],
+    };
+    expect(parseQuizFromText(JSON.stringify(bad))).toBeNull();
   });
 });

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "@jest/globals";
+import { recoverLeakedQuiz } from "@/server/chat/recover-quiz";
+
+type Chunk = Record<string, unknown>;
+
+async function pump(chunks: Chunk[]): Promise<Chunk[]> {
+  const stream = recoverLeakedQuiz();
+  const writer = stream.writable.getWriter();
+  const out: Chunk[] = [];
+  const drained = (async () => {
+    const reader = stream.readable.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out.push(value as Chunk);
+    }
+  })();
+  for (const chunk of chunks) {
+    await writer.write(chunk as never);
+  }
+  await writer.close();
+  await drained;
+  return out;
+}
+
+/** Build the chunk sequence for one streamed text block. */
+function textBlock(id: string, deltas: string[]): Chunk[] {
+  return [
+    { type: "text-start", id },
+    ...deltas.map((delta) => ({ type: "text-delta", id, delta })),
+    { type: "text-end", id },
+  ];
+}
+
+const quiz = {
+  quiz_title: "Photosynthesis",
+  questions: [
+    {
+      question: "What gas do plants absorb?",
+      options: ["CO2", "O2"],
+      correct_index: 0,
+      explanation: "Plants take in carbon dioxide.",
+    },
+  ],
+};
+
+describe("recoverLeakedQuiz", () => {
+  it("streams ordinary prose through unchanged", async () => {
+    const input = textBlock("t1", ["Here is ", "a summary."]);
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("converts a leaked JSON quiz into a single showQuiz tool part", async () => {
+    const out = await pump(textBlock("t1", [JSON.stringify(quiz)]));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      type: "tool-input-available",
+      toolName: "showQuiz",
+      input: quiz,
+    });
+    expect(typeof out[0]!.toolCallId).toBe("string");
+    // The raw JSON text must not reach the client.
+    expect(out.some((c) => c.type?.toString().startsWith("text"))).toBe(false);
+  });
+
+  it("recovers a quiz streamed across many deltas", async () => {
+    const json = JSON.stringify(quiz);
+    const deltas = [json.slice(0, 5), json.slice(5, 20), json.slice(20)];
+    const out = await pump(textBlock("t1", deltas));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ toolName: "showQuiz", input: quiz });
+  });
+
+  it("recovers a quiz wrapped in a ```json fence", async () => {
+    const fenced = "```json\n" + JSON.stringify(quiz) + "\n```";
+    const out = await pump(textBlock("t1", [fenced]));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ toolName: "showQuiz", input: quiz });
+  });
+
+  it("leaves a non-quiz JSON block as text", async () => {
+    const input = textBlock("t1", ['{"foo":"bar"}']);
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("streams a code-first answer (```js) through unchanged", async () => {
+    // A code block in another language must not be buffered/held -- only quiz
+    // JSON is. Split across deltas the way a fence really streams.
+    const input = textBlock("t1", [
+      "```js\n",
+      "const x = { a: 1 };\n",
+      "console.log(x);\n",
+      "```",
+    ]);
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("recovers a quiz from a bare (language-less) ``` fence", async () => {
+    const fenced = "```\n" + JSON.stringify(quiz) + "\n```";
+    const out = await pump(textBlock("t1", [fenced]));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ toolName: "showQuiz", input: quiz });
+  });
+
+  it("passes native tool-call chunks through untouched", async () => {
+    const input: Chunk[] = [
+      {
+        type: "tool-input-available",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: quiz,
+      },
+    ];
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("flushes a held quiz-candidate block if the stream ends before text-end", async () => {
+    // Stream cut off mid-JSON (no text-end): the partial text must not be lost.
+    const partial = '{"quiz_title":"Photo';
+    const input: Chunk[] = [
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: partial },
+    ];
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("streams prose that has leading whitespace", async () => {
+    const input = textBlock("t1", ["   Hello there"]);
+    expect(await pump(input)).toEqual(input);
+  });
+});

--- a/apps/web/src/components/chat/messages/QuizMessage.tsx
+++ b/apps/web/src/components/chat/messages/QuizMessage.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import type { Quiz, QuizResponse } from "@/lib/quiz";
+import {
+  initialQuizWidgetState,
+  type Quiz,
+  type QuizResponse,
+} from "@/lib/quiz";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -80,14 +84,18 @@ export function QuizMessage({
 }: QuizMessageProps) {
   const total = quiz.questions.length;
 
-  const [currentIndex, setCurrentIndex] = useState(0);
+  // Seed once from any completed attempt so a remount (e.g. the embed widget
+  // hiding on a tab switch, then reopening) restores the finished quiz instead
+  // of resetting to question 1. Snapshotted in a lazy initializer so later
+  // `attempts` changes don't clobber an in-progress attempt.
+  const [initial] = useState(() => initialQuizWidgetState(total, attempts));
+
+  const [currentIndex, setCurrentIndex] = useState(initial.currentIndex);
   // One selected option INDEX per question; null until the student picks. We
   // track the index (not the option text) so duplicate option strings can't
   // collide and so scoring compares directly against `correct_index`.
-  const [selected, setSelected] = useState<(number | null)[]>(() =>
-    Array(total).fill(null),
-  );
-  const [finished, setFinished] = useState(false);
+  const [selected, setSelected] = useState<(number | null)[]>(initial.selected);
+  const [finished, setFinished] = useState(initial.finished);
 
   const question = quiz.questions[currentIndex];
   const chosen = selected[currentIndex] ?? null;

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -46,6 +46,62 @@ export function isRenderableQuiz(quiz: Quiz): boolean {
 }
 
 /**
+ * Extract the first balanced top-level `{...}` object from free text, unwrapping
+ * a leading ```json fence if present. Returns the JSON substring or null. Brace
+ * counting skips braces inside strings so a `}` in a question/option can't end
+ * the object early.
+ */
+function extractJsonObject(raw: string): string | null {
+  let text = raw;
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence?.[1]) text = fence[1];
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Recover a renderable quiz that a model emitted as a text JSON blob instead of
+ * a native `showQuiz` tool call. Some (otherwise tool-capable) models serialize
+ * the tool call into the assistant text channel; the AI SDK then forms no
+ * `tool-showQuiz` part and the raw JSON renders as prose. This parses that text
+ * back into a quiz so the server can reconstruct the tool part. Returns null for
+ * anything that isn't a structurally valid, renderable quiz -- so ordinary prose
+ * (or a non-quiz JSON code block) is left untouched.
+ */
+export function parseQuizFromText(text: string): Quiz | null {
+  const candidate = extractJsonObject(text);
+  if (!candidate) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+  const result = quizSchema.safeParse(parsed);
+  if (!result.success) return null;
+  return isRenderableQuiz(result.data) ? result.data : null;
+}
+
+/**
  * A student's completed quiz attempt as stored in `study_tool_responses.response`.
  * `answers[i]` is the 0-based option index the student picked for question `i`,
  * in question order. `score`/`total` are derived server-side from the quiz
@@ -57,6 +113,50 @@ export const quizResponseSchema = z.object({
   total: z.number().int().min(0),
 });
 export type QuizResponse = z.infer<typeof quizResponseSchema>;
+
+/**
+ * The interactive quiz widget's per-attempt local state: which question is
+ * showing, the option index chosen per question (null until picked), and
+ * whether the attempt is finished.
+ */
+export interface QuizWidgetState {
+  currentIndex: number;
+  selected: (number | null)[];
+  finished: boolean;
+}
+
+/**
+ * Seed the interactive widget's local state on mount. When the student has
+ * already completed at least one attempt (persisted server-side and rehydrated
+ * into the `attempts` prop by the parent), restore the finished/score view from
+ * the most recent attempt. This makes the widget resilient to a remount that
+ * keeps the surrounding chat mounted -- most notably the embed widget, which
+ * unmounts its chat subtree (`return null`) when hidden on a tab switch and
+ * remounts on reopen. Without this the local `useState` reseeds to question 1,
+ * throwing away a finished quiz. With no valid prior attempt, start fresh.
+ */
+export function initialQuizWidgetState(
+  total: number,
+  attempts: QuizResponse[] | undefined,
+): QuizWidgetState {
+  const last =
+    attempts && attempts.length > 0 ? attempts[attempts.length - 1] : undefined;
+  // Only restore when the stored answers line up with this quiz (they always
+  // should -- same quiz, same toolCallId -- but a mismatch would mis-score the
+  // finished view, so fall back to a fresh start instead).
+  if (last && last.answers.length === total) {
+    return {
+      currentIndex: Math.max(0, total - 1),
+      selected: [...last.answers],
+      finished: true,
+    };
+  }
+  return {
+    currentIndex: 0,
+    selected: Array(total).fill(null),
+    finished: false,
+  };
+}
 
 /**
  * True if `answers` is a well-formed set of selections for `quiz`: one entry per

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -1,0 +1,135 @@
+import type { InferUIMessageChunk } from "ai";
+import { nanoid } from "nanoid";
+import { parseQuizFromText } from "@/lib/quiz";
+import type { StudyUIMessage } from "./study-tools";
+
+type Chunk = InferUIMessageChunk<StudyUIMessage>;
+
+type BlockClass = "prose" | "quiz-candidate" | "pending";
+
+/**
+ * Classify a (possibly partial) text block by its opening characters, to decide
+ * whether to hold it as a possible leaked quiz or let it stream through live:
+ *
+ * - starts with `{`                     -> quiz-candidate (bare JSON tool-call leak)
+ * - opens a ```json or bare ``` fence   -> quiz-candidate
+ * - opens a ```<lang> fence (js, py...) -> prose (real code -- must stream live)
+ * - any other non-whitespace char       -> prose
+ * - only whitespace, or a fence whose info-line hasn't arrived -> pending
+ *
+ * Fence classification waits for the info-line (up to the first newline) rather
+ * than matching the first character, so a fence streamed as "```" then "json"
+ * isn't misread as prose before its language tag arrives -- and, conversely, a
+ * ```js block is only buffered until its newline, then released to stream live.
+ */
+function classifyBlock(text: string): BlockClass {
+  const trimmed = text.replace(/^\s+/, "");
+  if (trimmed.length === 0) return "pending";
+  if (trimmed[0] === "{") return "quiz-candidate";
+  if (trimmed[0] !== "`") return "prose";
+  const newline = trimmed.indexOf("\n");
+  if (newline === -1) return "pending"; // fence info-line not complete yet
+  const info = trimmed.slice(0, newline).replace(/`/g, "").trim().toLowerCase();
+  return info === "" || info === "json" ? "quiz-candidate" : "prose";
+}
+
+/**
+ * Recover a quiz a model emitted as a text JSON blob instead of a native
+ * `showQuiz` tool call.
+ *
+ * Some otherwise tool-capable models (varies by model/provider) serialize the
+ * tool call into the assistant *text* channel, so the AI SDK forms no
+ * `tool-showQuiz` part and the raw `{"quiz_title":...}` JSON renders as prose.
+ * This transform holds a text block ONLY while it looks like it could be that
+ * JSON (see `classifyBlock`: a leading `{`, or a ```json / bare ``` fence). If
+ * the held block parses to a renderable quiz it is dropped and replaced with a
+ * synthetic `tool-input-available` chunk -- identical to a native call, so it
+ * renders as the interactive widget and persists like one. Otherwise the held
+ * chunks are flushed unchanged.
+ *
+ * Ordinary prose -- and code blocks in other languages (```js, ```python) --
+ * stream through live; only quiz-shaped output is buffered, so normal answers
+ * keep their token-by-token streaming.
+ */
+export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
+  let holding = false;
+  // Whether the held block has been classified yet (prose vs quiz-candidate).
+  let classified = false;
+  let heldChunks: Chunk[] = [];
+  let heldText = "";
+  let heldId: string | null = null;
+
+  const reset = () => {
+    holding = false;
+    classified = false;
+    heldChunks = [];
+    heldText = "";
+    heldId = null;
+  };
+
+  const flush = (controller: TransformStreamDefaultController<Chunk>) => {
+    for (const c of heldChunks) controller.enqueue(c);
+    reset();
+  };
+
+  return new TransformStream<Chunk, Chunk>({
+    transform(chunk, controller) {
+      if (chunk.type === "text-start") {
+        // A new text block starts; flush any still-held block first (defensive --
+        // a well-formed stream closes a block before opening the next).
+        if (holding) flush(controller);
+        holding = true;
+        classified = false;
+        heldChunks = [chunk];
+        heldText = "";
+        heldId = chunk.id;
+        return;
+      }
+
+      if (holding && chunk.type === "text-delta" && chunk.id === heldId) {
+        heldChunks.push(chunk);
+        heldText += chunk.delta;
+        if (!classified) {
+          const decision = classifyBlock(heldText);
+          if (decision === "prose") {
+            // Release the held chunks and stop holding so the rest of the block
+            // streams through live.
+            classified = true;
+            flush(controller);
+          } else if (decision === "quiz-candidate") {
+            // Keep holding until text-end, then try to recover a quiz.
+            classified = true;
+          }
+          // "pending": not enough text to decide yet -- keep buffering.
+        }
+        return;
+      }
+
+      if (holding && chunk.type === "text-end" && chunk.id === heldId) {
+        heldChunks.push(chunk);
+        const quiz = parseQuizFromText(heldText);
+        if (quiz) {
+          // Drop the JSON text; emit a native-looking tool call in its place.
+          reset();
+          controller.enqueue({
+            type: "tool-input-available",
+            toolCallId: nanoid(),
+            toolName: "showQuiz",
+            input: quiz,
+          } as Chunk);
+        } else {
+          flush(controller);
+        }
+        return;
+      }
+
+      // Any other chunk (tool parts, a delta for a different id, etc.). If a
+      // block is still held, flush it first to preserve ordering.
+      if (holding) flush(controller);
+      controller.enqueue(chunk);
+    },
+    flush(controller) {
+      if (holding) flush(controller);
+    },
+  });
+}

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -47,6 +47,7 @@ import {
   PARTS_VERSION,
 } from "./ui-messages";
 import { stripRetrievalOutputs } from "./stream-filter";
+import { recoverLeakedQuiz } from "./recover-quiz";
 import { ChatRequestError } from "./request";
 import { buildStudyResultsNote } from "@/server/study/model-note";
 
@@ -384,14 +385,21 @@ export async function streamChat(params: {
         abortSignal,
       });
 
+      const primaryUiStream = primary
+        .toUIMessageStream<StudyUIMessage>({
+          sendReasoning: false,
+          sendFinish: false,
+          onError: onStreamError,
+        })
+        .pipeThrough(stripRetrievalOutputs());
+      // Study-tool-capable turns: reconstruct a quiz the model leaked as a text
+      // JSON blob (instead of a native showQuiz call) into a real tool part, so
+      // it renders as the widget rather than raw JSON. Only quiz-shaped text is
+      // buffered; ordinary answers still stream live. See recoverLeakedQuiz.
       writer.merge(
-        primary
-          .toUIMessageStream<StudyUIMessage>({
-            sendReasoning: false,
-            sendFinish: false,
-            onError: onStreamError,
-          })
-          .pipeThrough(stripRetrievalOutputs()),
+        modelCanUseTools
+          ? primaryUiStream.pipeThrough(recoverLeakedQuiz())
+          : primaryUiStream,
       );
 
       let primaryText: string;


### PR DESCRIPTION
## What

Fixes two quiz bugs reported after the study-tools feature shipped.

### 1. Finished quiz resets to question 1 on tab switch (real fix)

**Cause:** `QuizMessage` kept `currentIndex`/`selected`/`finished` in local `useState` seeded from constants and never rehydrated from the `attempts` prop. The completed attempt is preserved one level up in `useChat`'s `studyAttempts`, but on the embed widget a tab switch hits `if (!isVisible) return null` (`embed/[shareToken]/window/page.tsx:53`), which unmounts the chat subtree while `useChat` stays mounted. On reopen the widget remounts with `attempts` populated but its state reset to question 1.

**Fix:** `initialQuizWidgetState(total, attempts)` seeds the widget from the most recent completed attempt, restoring the finished/score view instead of restarting. Snapshotted in a lazy `useState` initializer so live `attempts` changes can't clobber an in-progress retake.

> Note: this restores *finished* quizzes. Mid-quiz progress isn't persisted anywhere, so a remount partway through still restarts — out of scope here.

### 2. Quiz renders as raw JSON text (mitigation — see #398)

**Cause:** some models serialize the `showQuiz` tool call into the assistant **text** channel instead of emitting a native tool call, so no `tool-showQuiz` part forms and the raw `{"quiz_title":...}` JSON renders as prose.

**Mitigation:** `parseQuizFromText()` + a `recoverLeakedQuiz()` stream transform that buffers only quiz-shaped text (first non-whitespace char is `{` or a ``` fence) and, if it parses to a renderable quiz, drops the text and re-emits a synthetic `tool-input-available` chunk — so it renders and persists like a native call. Ordinary prose streams through live, untouched.

This is a **bandaid**; proper handling (model capability audit / routing config) is tracked in **#398**. The recovery net stays as defense-in-depth.

## Tests

- `parseQuizFromText`: bare JSON, ```json fence, surrounding prose, braces inside strings, non-quiz JSON, malformed JSON, unrenderable quiz.
- `recoverLeakedQuiz`: prose passthrough, single/multi-delta recovery, fenced recovery, non-quiz passthrough, native tool-call passthrough, mid-stream flush.
- `initialQuizWidgetState`: fresh start, restore from latest attempt, no aliasing, length-mismatch fallback.

All new/changed tests green; `check-types` and `lint` pass.

## Notes

- The pre-commit hook's `npm run test` step currently fails to load 5 unrelated suites on `main` (top-level `await import()` under Jest). That's pre-existing and tracked in **#399** (test suite overhaul); this PR doesn't touch it, so the hook's test step was bypassed after verifying types, lint, and the relevant suites manually.

Closes nothing outright; relates to #398 and #399.