### PR TITLE
feat(chat): surface pipeline working steps in the thinking indicator

### DIFF
--- a/apps/web/src/__tests__/server/chat-helpers.test.ts
+++ b/apps/web/src/__tests__/server/chat-helpers.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect } from "@jest/globals";
 import {
   clampMaxTokens,
   describeToolActivity,
+  deriveStatusLine,
   mergeSources,
 } from "@/server/chat-helpers";
+import type { StudyUIMessage } from "@/server/chat/study-tools";
+
+// Minimal fixtures: deriveStatusLine only reads `role` and the last part's
+// `type`/`input`, so we cast small literals rather than build full UIMessages.
+const assistantWith = (part: unknown): StudyUIMessage =>
+  ({ id: "m", role: "assistant", parts: [part] }) as unknown as StudyUIMessage;
 
 describe("clampMaxTokens", () => {
   it("returns the default for null/undefined/NaN", () => {
@@ -27,6 +34,23 @@ describe("describeToolActivity", () => {
   it("includes the user query for search_documents", () => {
     expect(describeToolActivity("search_documents", { query: "Berlin" })).toBe(
       "Searching documents for “Berlin”",
+    );
+  });
+  it("truncates an over-long search query with an ellipsis", () => {
+    const label = describeToolActivity("search_documents", {
+      query: "a".repeat(200),
+    });
+    expect(label.startsWith("Searching documents for “aaaa")).toBe(true);
+    expect(label.endsWith("…”")).toBe(true);
+    // Fixed prose + quotes, plus 48 query chars and the one ellipsis char.
+    expect(label.length).toBe("Searching documents for “”".length + 48 + 1);
+  });
+  it("truncates on a code-point boundary so it never splits an emoji", () => {
+    // 47 ASCII + 3 emoji = 50 code points; the 48-char cut lands right after the
+    // first emoji, which must stay whole (a naive UTF-16 slice would halve it).
+    const query = "a".repeat(47) + "😀😀😀";
+    expect(describeToolActivity("search_documents", { query })).toBe(
+      `Searching documents for “${"a".repeat(47)}😀…”`,
     );
   });
   it("falls back to a generic search label when query is missing/empty", () => {
@@ -53,6 +77,32 @@ describe("describeToolActivity", () => {
   it("never throws on missing input and uses a generic fallback", () => {
     expect(describeToolActivity("done", undefined)).toBe("Working…");
     expect(describeToolActivity("unknown_tool", null)).toBe("Working…");
+  });
+});
+
+describe("deriveStatusLine", () => {
+  it("shows retrieval while the request is pre-stream (submitted)", () => {
+    expect(deriveStatusLine(undefined, "submitted")).toBe("Searching sources…");
+  });
+  it("falls back to a generic label once the stream ends", () => {
+    expect(deriveStatusLine(undefined, "ready")).toBe("Thinking…");
+    expect(deriveStatusLine(undefined, "error")).toBe("Thinking…");
+  });
+  it("names the active retrieval tool while streaming", () => {
+    const msg = assistantWith({
+      type: "tool-search_documents",
+      input: { query: "Berlin" },
+    });
+    expect(deriveStatusLine(msg, "streaming")).toBe(
+      "Searching documents for “Berlin”",
+    );
+  });
+  it("shows generation while streaming with no active tool", () => {
+    expect(
+      deriveStatusLine(assistantWith({ type: "text", text: "" }), "streaming"),
+    ).toBe("Generating answer…");
+    // The transient window before the assistant message lands.
+    expect(deriveStatusLine(undefined, "streaming")).toBe("Generating answer…");
   });
 });
 

--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -24,7 +24,7 @@ export default function SharedChatPage() {
     messages,
     currentMessage,
     setCurrentMessage,
-    isStreaming,
+    status,
     messagesEndRef,
     chatbot,
     chatbotLoading,
@@ -81,7 +81,7 @@ export default function SharedChatPage() {
         <ErrorBoundary>
           <ChatInterface
             messages={messages}
-            isStreaming={isStreaming}
+            status={status}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}
             handleSendMessage={handleSendMessage}

--- a/apps/web/src/app/chatbot/[id]/page.tsx
+++ b/apps/web/src/app/chatbot/[id]/page.tsx
@@ -69,7 +69,7 @@ export default function ChatbotDetailPage() {
     messages,
     currentMessage,
     setCurrentMessage,
-    isStreaming,
+    status,
     messagesEndRef,
     chatbot,
     chatbotLoading,
@@ -213,7 +213,7 @@ export default function ChatbotDetailPage() {
             <ErrorBoundary>
               <ChatInterface
                 messages={messages}
-                isStreaming={isStreaming}
+                status={status}
                 currentMessage={currentMessage}
                 setCurrentMessage={setCurrentMessage}
                 handleSendMessage={handleSendMessage}

--- a/apps/web/src/app/embed/[shareToken]/window/page.tsx
+++ b/apps/web/src/app/embed/[shareToken]/window/page.tsx
@@ -23,6 +23,7 @@ export default function EmbedWindowPage() {
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    status,
     messagesEndRef,
     chatbot,
     chatbotLoading,
@@ -72,7 +73,7 @@ export default function EmbedWindowPage() {
         <ErrorBoundary>
           <ChatInterface
             messages={messages}
-            isStreaming={isStreaming}
+            status={status}
             currentMessage={currentMessage}
             setCurrentMessage={setCurrentMessage}
             handleSendMessage={handleSendMessage}

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -14,28 +14,9 @@ import { MessageAvatar } from "@/components/ui/message";
 import { TypingLoader } from "@/components/ui/loader";
 import { RotateCcw, Download } from "lucide-react";
 import { exportChatAsText } from "@/lib/export-chat";
-import { RETRIEVAL_PART_TYPES } from "@/lib/retrieval-tool-names";
-import { describeToolActivity } from "@/server/chat-helpers";
+import { deriveStatusLine } from "@/server/chat-helpers";
+import type { ChatStatus } from "ai";
 import { toast } from "sonner";
-
-/** Derive the live status line client-side (reasoning is never streamed). */
-function deriveStatusLine(
-  last: StudyUIMessage | undefined,
-  isStreaming: boolean,
-): string {
-  if (!isStreaming) return "Thinking…";
-  const parts = last?.role === "assistant" ? last.parts : [];
-  const lastPart = parts[parts.length - 1];
-  if (lastPart && RETRIEVAL_PART_TYPES.has(lastPart.type)) {
-    // Retrieval tool *inputs* stream to the client (only results are filtered
-    // server-side), so the label can name the query/page being fetched.
-    return describeToolActivity(
-      lastPart.type.slice("tool-".length),
-      "input" in lastPart ? lastPart.input : undefined,
-    );
-  }
-  return "Thinking…";
-}
 
 function hasVisibleContent(message: StudyUIMessage | undefined): boolean {
   if (!message || message.role !== "assistant") return false;
@@ -44,7 +25,7 @@ function hasVisibleContent(message: StudyUIMessage | undefined): boolean {
 
 interface ChatInterfaceProps {
   messages: StudyUIMessage[];
-  isStreaming: boolean;
+  status: ChatStatus;
   currentMessage: string;
   setCurrentMessage: (message: string) => void;
   handleSendMessage: (e: React.FormEvent) => void;
@@ -69,7 +50,7 @@ interface ChatInterfaceProps {
 
 export function ChatInterface({
   messages,
-  isStreaming,
+  status,
   currentMessage,
   setCurrentMessage,
   handleSendMessage,
@@ -89,11 +70,12 @@ export function ChatInterface({
   onStudyAttempt,
   studyAttempts,
 }: ChatInterfaceProps) {
+  const isStreaming = status === "submitted" || status === "streaming";
   const lastMessage = messages[messages.length - 1];
   // Show the typing/status indicator while streaming until the assistant
   // message has visible content of its own (text or a rendered study tool).
   const showIndicator = isStreaming && !hasVisibleContent(lastMessage);
-  const statusLine = deriveStatusLine(lastMessage, isStreaming);
+  const statusLine = deriveStatusLine(lastMessage, status);
 
   return (
     <div
@@ -196,10 +178,10 @@ export function ChatInterface({
                       alt="Teach Anything™"
                       imageClassName="grayscale"
                     />
-                    <div className="bg-secondary rounded-xl md:rounded-lg px-3 py-2 md:px-4 md:py-3 w-fit shadow-xs border border-border/50">
+                    <div className="bg-secondary rounded-xl md:rounded-lg px-3 py-2 md:px-4 md:py-3 w-fit min-w-0 max-w-full shadow-xs border border-border/50">
                       <div className="flex items-center gap-2 text-xs text-muted-foreground italic">
                         <TypingLoader size="sm" className="opacity-60" />
-                        <span>{statusLine}</span>
+                        <span className="min-w-0 truncate">{statusLine}</span>
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from "react";
 import { useChat as useAIChat } from "@ai-sdk/react";
-import { DefaultChatTransport } from "ai";
+import { DefaultChatTransport, type ChatStatus } from "ai";
 import { nanoid } from "nanoid";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
@@ -57,6 +57,9 @@ export function useChat(shareToken: string) {
 
   const isStreaming =
     chat.status === "submitted" || chat.status === "streaming";
+  // Annotate against the top-level `ai` package so the hook's inferred return
+  // type doesn't reference @ai-sdk/react's nested copy (TS2742, not portable).
+  const status: ChatStatus = chat.status;
 
   const sendMessage = useCallback(
     (text: string): boolean => {
@@ -102,6 +105,7 @@ export function useChat(shareToken: string) {
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    status,
     handleSendMessage,
     stop: chat.stop,
     resetChat,

--- a/apps/web/src/hooks/useChatbot.ts
+++ b/apps/web/src/hooks/useChatbot.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from "react";
 import { useChat as useAIChat } from "@ai-sdk/react";
-import { DefaultChatTransport } from "ai";
+import { DefaultChatTransport, type ChatStatus } from "ai";
 import { nanoid } from "nanoid";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
@@ -54,6 +54,9 @@ export function useChatbot(
 
   const isStreaming =
     chat.status === "submitted" || chat.status === "streaming";
+  // Annotate against the top-level `ai` package so the hook's inferred return
+  // type doesn't reference @ai-sdk/react's nested copy (TS2742, not portable).
+  const status: ChatStatus = chat.status;
 
   const sendMessage = useCallback(
     (text: string): boolean => {
@@ -99,6 +102,7 @@ export function useChatbot(
     currentMessage,
     setCurrentMessage,
     isStreaming,
+    status,
     handleSendMessage,
     stop: chat.stop,
     resetChat,

--- a/apps/web/src/server/chat-helpers.ts
+++ b/apps/web/src/server/chat-helpers.ts
@@ -1,7 +1,11 @@
+import type { ChatStatus } from "ai";
+import type { StudyUIMessage } from "./chat/study-tools";
+import { RETRIEVAL_PART_TYPES } from "@/lib/retrieval-tool-names";
+
 /**
- * Pure, dependency-free helpers for the chat router. Kept in their own module
- * so they can be unit-tested without importing the streaming / AI-SDK chain
- * that `chat.ts` pulls in.
+ * Pure helpers for the chat router and the chat UI. Kept free of the streaming
+ * / AI-SDK runtime chain so they can be unit-tested in isolation -- the only
+ * imports here are types and a zero-dependency constant set.
  */
 
 /** Clamp a requested max output token count to the supported range (100-4000). */
@@ -61,6 +65,21 @@ export function mergeSources(
 }
 
 /**
+ * Longest a user query is surfaced verbatim in a status label. Queries are
+ * unbounded; past this we truncate with an ellipsis so the live status line
+ * stays a single, stable-width line instead of wrapping and reflowing.
+ */
+const MAX_QUERY_LABEL_CHARS = 48;
+
+function truncateForLabel(text: string): string {
+  // Count by code point (Array.from), not UTF-16 code unit, so truncation never
+  // slices through a surrogate pair (e.g. an emoji) and emits a broken glyph.
+  const chars = Array.from(text);
+  if (chars.length <= MAX_QUERY_LABEL_CHARS) return text;
+  return `${chars.slice(0, MAX_QUERY_LABEL_CHARS).join("").trimEnd()}…`;
+}
+
+/**
  * Map an agentic retrieval tool-call to a human-readable status label shown in
  * the live status line while the model works. Only the action + the
  * user-derived query are surfaced -- never tool RESULT content (which could
@@ -74,7 +93,7 @@ export function describeToolActivity(toolName: string, input: unknown): string {
   switch (toolName) {
     case "search_documents":
       return typeof args.query === "string" && args.query.length > 0
-        ? `Searching documents for “${args.query}”`
+        ? `Searching documents for “${truncateForLabel(args.query)}”`
         : "Searching documents…";
     case "get_page":
       // The client calls this while the tool input is still streaming, so
@@ -89,4 +108,34 @@ export function describeToolActivity(toolName: string, input: unknown): string {
     default:
       return "Working…";
   }
+}
+
+/**
+ * Live status line shown while a turn is in flight, mapped to the real backend
+ * phase so the user sees progress instead of a static loader. Driven by the AI
+ * SDK stream `status` (never inferred from message shape):
+ *  - `submitted`: request accepted; the server is retrieving sources + building
+ *    context before the model starts.
+ *  - `streaming` with an active retrieval tool: name the query/page it fetches.
+ *  - `streaming` otherwise: the model is composing the answer.
+ * The `ready`/`error` branch isn't normally rendered (the indicator hides once
+ * streaming ends) but returns a safe generic label.
+ */
+export function deriveStatusLine(
+  last: StudyUIMessage | undefined,
+  status: ChatStatus,
+): string {
+  if (status === "submitted") return "Searching sources…";
+  if (status !== "streaming") return "Thinking…";
+  const parts = last?.role === "assistant" ? last.parts : [];
+  const lastPart = parts[parts.length - 1];
+  if (lastPart && RETRIEVAL_PART_TYPES.has(lastPart.type)) {
+    // Retrieval tool *inputs* stream to the client (only results are filtered
+    // server-side), so the label can name the query/page being fetched.
+    return describeToolActivity(
+      lastPart.type.slice("tool-".length),
+      "input" in lastPart ? lastPart.input : undefined,
+    );
+  }
+  return "Generating answer…";
 }


### PR DESCRIPTION
## What & why

Closes #402.

While the assistant is generating, the chat UI only showed a static "Thinking…" loader, which feels dead on longer retrieval/streaming turns. This surfaces the pipeline's high-level working step instead — **step labels only, never chain-of-thought** — so the wait reads as progress.

The labels map to the real backend phases the request already goes through:

| Phase | Signal | Label |
| --- | --- | --- |
| Retrieval + context build | `status === "submitted"` | `Searching sources…` |
| Agentic document retrieval | active `search_documents` / `get_page` tool part | `Searching documents for "…"` / `Reading page N…` |
| Answer generation | `streaming`, nothing visible yet | `Generating answer…` |

## How

- **Drive the phase from the AI SDK `chat.status`** (`submitted` vs `streaming`), threaded through `useChat` / `useChatbot` → the chat pages → `ChatInterface`, instead of inferring it from whether an assistant message exists yet. Correct by construction and unit-testable.
- **Extract the pure `deriveStatusLine`** into `server/chat-helpers.ts` (the existing pure-helper module) and cover it with unit tests: submitted / retrieval-tool / generating / ended.
- **Cap agentic query labels** at a code-point-safe length (`Array.from`, so an emoji is never split) so the status line can't blow up, and keep it to a single line (`truncate` + `min-w-0`) to avoid layout reflow on narrow embeds.
- Reuses the existing typing indicator — no visual redesign.

## Verification

- `tsc` (full app), `eslint`, `prettier`: clean
- Unit tests: `chat-helpers` 20/20; full suite 478/478 individual tests pass

Note: verified via type-check + unit tests; not yet exercised against a live model (needs API keys), so the label transitions are covered by tests rather than manual QA.

## Not included (follow-up)

For a chatbot with **no documents**, the pre-stream phase still reads `Searching sources…` even though there's nothing to search — the client has no `hasFiles` signal today (`getByShareToken` doesn't return one). Left out intentionally since it needs a small server→client plumbing change; happy to add if wanted.
