### PR TITLE
docs(landing): update non-profit language with 501(c)(3) and tax-deductible notice

### DIFF
--- a/apps/web/src/components/landing/SupportUsSection.tsx
+++ b/apps/web/src/components/landing/SupportUsSection.tsx
@@ -190,10 +190,14 @@ export default function SupportUsSection() {
             viewport={{ once: true, margin: "-100px" }}
             transition={{ duration: 0.6, delay: 0.5 }}
           >
-            Teach Anything, Inc. is a registered non-profit organization
-            incorporated in the District of Columbia. Our certificate of
-            incorporation is on file in the Washington, D.C. Department of
-            Licensing and Consumer Protection.
+            Teach Anything is a registered 501(c)(3) non-profit organization
+            with the Internal Revenue Service (IRS).{" "}
+            <strong className="font-semibold">
+              Donations are tax-deductible.
+            </strong>{" "}
+            Our organization is incorporated in Washington, D.C., in the U.S.A.
+            Our certificate of incorporation is on file in the Washington, D.C.
+            Department of Licensing and Consumer Protection.
           </motion.p>
 
           {/* Featured In Section */}


### PR DESCRIPTION
Updates the non-profit copy below the DC flag in the landing page Support Us section.

## Change

Replaces the previous incorporation-only language with the new IRS 501(c)(3) copy, with **Donations are tax-deductible.** bolded.

New text:
> Teach Anything is a registered 501(c)(3) non-profit organization with the Internal Revenue Service (IRS). **Donations are tax-deductible.** Our organization is incorporated in Washington, D.C., in the U.S.A. Our certificate of incorporation is on file in the Washington, D.C. Department of Licensing and Consumer Protection.

File: `apps/web/src/components/landing/SupportUsSection.tsx`