### PR TITLE
chore(brand): switch trademark symbol from TM to registered mark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ uploads/
 
 # Generated: Blume docs site embedded into the web app at build time
 apps/web/public/docs/
+.gstack/

--- a/apps/web/src/app/chat/[shareToken]/page.tsx
+++ b/apps/web/src/app/chat/[shareToken]/page.tsx
@@ -101,7 +101,7 @@ export default function SharedChatPage() {
                 <span>Powered by</span>
                 <Image
                   src="/logo.svg"
-                  alt="Teach Anything™"
+                  alt="Teach Anything®"
                   width={14}
                   height={14}
                   className="h-3.5 w-3.5"

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -9,7 +9,7 @@ interface BrandNameProps {
   serifAnything?: boolean;
 }
 
-export const BRAND_NAME_WITH_MARK = "Teach Anything™";
+export const BRAND_NAME_WITH_MARK = "Teach Anything®";
 
 export function BrandName({
   className,
@@ -37,11 +37,11 @@ export function BrandName({
       </span>
       <sup
         className={cn(
-          "ml-1.5 align-super text-[0.42em] font-semibold not-italic leading-none tracking-normal",
+          "ml-1.5 align-super text-[0.5em] font-semibold not-italic leading-none tracking-normal",
           markClassName,
         )}
       >
-        TM
+        ®
       </sup>
     </span>
   );

--- a/apps/web/src/components/brand/BrandName.tsx
+++ b/apps/web/src/components/brand/BrandName.tsx
@@ -37,7 +37,7 @@ export function BrandName({
       </span>
       <sup
         className={cn(
-          "ml-1.5 align-super text-[0.5em] font-semibold not-italic leading-none tracking-normal",
+          "ml-[0.15em] align-super text-[0.5em] font-semibold not-italic leading-none tracking-normal",
           markClassName,
         )}
       >

--- a/apps/web/src/components/chat/messages/ChatInterface.tsx
+++ b/apps/web/src/components/chat/messages/ChatInterface.tsx
@@ -193,7 +193,7 @@ export function ChatInterface({
                   <div className="flex gap-2 md:gap-3 items-start">
                     <MessageAvatar
                       src="/logo.svg"
-                      alt="Teach Anything™"
+                      alt="Teach Anything®"
                       imageClassName="grayscale"
                     />
                     <div className="bg-secondary rounded-xl md:rounded-lg px-3 py-2 md:px-4 md:py-3 w-fit shadow-xs border border-border/50">

--- a/apps/web/src/components/chat/messages/ChatMessage.tsx
+++ b/apps/web/src/components/chat/messages/ChatMessage.tsx
@@ -120,7 +120,7 @@ function ChatMessageImpl({
       <Message className="items-start gap-2 md:gap-3">
         <MessageAvatar
           src="/logo.svg"
-          alt="Teach Anything™"
+          alt="Teach Anything®"
           imageClassName="grayscale"
         />
         <div className="flex-1 min-w-0 space-y-2">

--- a/apps/web/src/components/dashboard/DashboardHeader.tsx
+++ b/apps/web/src/components/dashboard/DashboardHeader.tsx
@@ -66,7 +66,7 @@ export function DashboardHeader() {
         >
           <Image
             src="/logo.svg"
-            alt="Teach Anything™"
+            alt="Teach Anything®"
             width={28}
             height={28}
             className="h-7 w-7"

--- a/apps/web/src/components/emails/AccountDeleted.tsx
+++ b/apps/web/src/components/emails/AccountDeleted.tsx
@@ -29,7 +29,7 @@ export function AccountDeleted({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                This email confirms that your Teach Anything™ account has been
+                This email confirms that your Teach Anything® account has been
                 permanently deleted as requested by an administrator.
               </p>
 
@@ -53,19 +53,19 @@ export function AccountDeleted({
               </p>
 
               <p style={text}>
-                If you wish to use Teach Anything™ again in the future, you will
+                If you wish to use Teach Anything® again in the future, you will
                 need to register a new account.
               </p>
 
               <p style={text}>
                 We&apos;re sorry to see you go. Thank you for being part of the
-                Teach Anything™ community.
+                Teach Anything® community.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/AccountDisabled.tsx
+++ b/apps/web/src/components/emails/AccountDisabled.tsx
@@ -29,7 +29,7 @@ export function AccountDisabled({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                I&apos;m writing to inform you that your Teach Anything™ account
+                I&apos;m writing to inform you that your Teach Anything® account
                 has been temporarily disabled by an administrator. You will not
                 be able to log in until your account is re-enabled.
               </p>
@@ -53,13 +53,13 @@ export function AccountDisabled({
 
               <p style={text}>
                 We&apos;re here to help resolve any issues and get you back to
-                using Teach Anything™ as soon as possible.
+                using Teach Anything® as soon as possible.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/AccountEnabled.tsx
+++ b/apps/web/src/components/emails/AccountEnabled.tsx
@@ -31,7 +31,7 @@ export function AccountEnabled({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Great news! Your Teach Anything™ account has been re-enabled and
+                Great news! Your Teach Anything® account has been re-enabled and
                 you can now log in again. All your chatbots and data are ready
                 for you to access.
               </p>
@@ -59,7 +59,7 @@ export function AccountEnabled({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/ApprovalConfirmation.tsx
+++ b/apps/web/src/components/emails/ApprovalConfirmation.tsx
@@ -31,7 +31,7 @@ export function ApprovalConfirmation({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Great news! Your Teach Anything™ account has been approved by an
+                Great news! Your Teach Anything® account has been approved by an
                 administrator. You can now log in and start creating AI-powered
                 chatbots for your courses.
               </p>
@@ -59,14 +59,14 @@ export function ApprovalConfirmation({
               </p>
 
               <p style={text}>
-                Welcome to Teach Anything™! We&apos;re excited to have you on
+                Welcome to Teach Anything®! We&apos;re excited to have you on
                 board.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/DemoteFromAdmin.tsx
+++ b/apps/web/src/components/emails/DemoteFromAdmin.tsx
@@ -32,7 +32,7 @@ export function DemoteFromAdmin({
 
               <p style={text}>
                 I&apos;m writing to inform you that your administrator
-                privileges have been removed from your Teach Anything™ account.
+                privileges have been removed from your Teach Anything® account.
                 Your account has been converted to a regular user account.
               </p>
 
@@ -65,7 +65,7 @@ export function DemoteFromAdmin({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/PasswordReset.tsx
+++ b/apps/web/src/components/emails/PasswordReset.tsx
@@ -71,7 +71,7 @@ export function PasswordReset({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/PromoteToAdmin.tsx
+++ b/apps/web/src/components/emails/PromoteToAdmin.tsx
@@ -32,7 +32,7 @@ export function PromoteToAdmin({
 
               <p style={text}>
                 I wanted to let you know that you&apos;ve been promoted to an
-                administrator role on Teach Anything™. You now have full access
+                administrator role on Teach Anything®. You now have full access
                 to manage users, chatbots, and system settings.
               </p>
 
@@ -58,14 +58,14 @@ export function PromoteToAdmin({
               </p>
 
               <p style={text}>
-                Welcome to the Teach Anything™ admin team! We trust you&apos;ll
+                Welcome to the Teach Anything® admin team! We trust you&apos;ll
                 help us maintain a secure and efficient platform.
               </p>
 
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Admin Team
+                Teach Anything® Admin Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/RejectionNotification.tsx
+++ b/apps/web/src/components/emails/RejectionNotification.tsx
@@ -29,7 +29,7 @@ export function RejectionNotification({
               <p style={text}>Hi {userName},</p>
 
               <p style={text}>
-                Thank you for your interest in Teach Anything™. Unfortunately,
+                Thank you for your interest in Teach Anything®. Unfortunately,
                 we are unable to approve your account registration at this time.
               </p>
 
@@ -57,7 +57,7 @@ export function RejectionNotification({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™ Team
+                Teach Anything® Team
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/emails/UserRegistrationNotification.tsx
+++ b/apps/web/src/components/emails/UserRegistrationNotification.tsx
@@ -60,7 +60,7 @@ export function UserRegistrationNotification({
               <p style={signature}>
                 Best regards,
                 <br />
-                Teach Anything™
+                Teach Anything®
               </p>
 
               <p style={footer}>

--- a/apps/web/src/components/embed/EmbedFooter.tsx
+++ b/apps/web/src/components/embed/EmbedFooter.tsx
@@ -20,7 +20,7 @@ export function EmbedFooter() {
         <span>Powered by</span>
         <Image
           src="/logo.svg"
-          alt="Teach Anything™"
+          alt="Teach Anything®"
           width={14}
           height={14}
           className="h-3.5 w-3.5"

--- a/apps/web/src/components/landing/Navbar.tsx
+++ b/apps/web/src/components/landing/Navbar.tsx
@@ -61,7 +61,7 @@ export default function Navbar() {
               >
                 <Image
                   src="/logo.svg"
-                  alt="Teach Anything™"
+                  alt="Teach Anything®"
                   width={32}
                   height={32}
                   className="h-8 w-8"

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -83,7 +83,7 @@ async function queueEmail(params: {
       body: {
         deliveryId,
         idempotencyKey,
-        from: `Teach Anything™ <${fromEmail}>`,
+        from: `Teach Anything® <${fromEmail}>`,
         to: params.to,
         subject: params.subject,
         html,


### PR DESCRIPTION
Professor Joubin confirmed the Teach Anything mark is now registered with the USPTO, so the TM superscript becomes ® everywhere.

## What changed

- `BrandName` renders `®` in the superscript instead of `TM`, and `BRAND_NAME_WITH_MARK` (used for page metadata titles) is now `Teach Anything®`
- Image `alt` text across navbar, dashboard header, chat messages, shared chat, and embed footer
- Transactional email copy: approval, rejection, password reset, account enabled/disabled/deleted, promote/demote admin, registration notification
- The `From` display name in `lib/email.ts`

Two small type adjustments so a single circled glyph reads as well as two letters did:
- superscript size 0.42em → 0.5em (® is one narrow glyph and was reading as a smudge at the old size)
- gap `ml-1.5` (fixed 6px) → `ml-[0.15em]`, so it scales. The fixed gap left the mark visibly detached on small instances like the comparison table header.

The docs app (`apps/docs`) uses plain "Teach Anything" with no mark, so it needed no changes.

## Verification

- `check-types`, `lint`, and `test` (664 tests) all pass
- Rendered the landing page locally and confirmed every `<sup>` is `®`, and that the mark reads correctly at both hero size (23px) and comparison-table size (6px)
- Page title renders `Teach Anything® — Open Source LLMs for Open Access Education`