### PR TITLE
fix(quiz): recover leaked quiz calls after prose and in pseudo-call syntax

### DIFF
--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -329,4 +329,67 @@ describe("parseQuizFromText", () => {
     };
     expect(parseQuizFromText(JSON.stringify(bad))).toBeNull();
   });
+
+  // Some models serialize the call in their native pseudo-call syntax --
+  // `[showQuiz(quiz_title="...", questions=[...])]` -- rather than as a JSON
+  // object. Observed in production 2026-08-07 (a Llama-family bot).
+  describe("pseudo tool-call syntax", () => {
+    const pseudoCall = (title: string, questions: unknown) =>
+      `[showQuiz(quiz_title="${title}", questions=${JSON.stringify(questions)})]`;
+
+    it("recovers a quiz from bracketed pseudo-call syntax", () => {
+      expect(
+        parseQuizFromText(pseudoCall("Photosynthesis", validQuiz.questions)),
+      ).toEqual(validQuiz);
+    });
+
+    it("recovers a pseudo-call without the wrapping brackets", () => {
+      const call = `showQuiz(quiz_title="Photosynthesis", questions=${JSON.stringify(validQuiz.questions)})`;
+      expect(parseQuizFromText(call)).toEqual(validQuiz);
+    });
+
+    it("recovers a pseudo-call after a prose preamble", () => {
+      const text = `Here are some quiz questions.\n\n${pseudoCall("Photosynthesis", validQuiz.questions)}`;
+      expect(parseQuizFromText(text)).toEqual(validQuiz);
+    });
+
+    it("handles keyword args in either order", () => {
+      const call = `showQuiz(questions=${JSON.stringify(validQuiz.questions)}, quiz_title="Photosynthesis")`;
+      expect(parseQuizFromText(call)).toEqual(validQuiz);
+    });
+
+    it("handles nested brackets inside question text", () => {
+      const questions = [
+        {
+          question: "Which list is empty: [] or [0]?",
+          options: ["[]", "[0]"],
+          correct_index: 0,
+          explanation: "[] has no elements.",
+        },
+      ];
+      expect(parseQuizFromText(pseudoCall("Lists", questions))).toEqual({
+        quiz_title: "Lists",
+        questions,
+      });
+    });
+
+    it("returns null when the questions payload is not valid JSON", () => {
+      const call = `showQuiz(quiz_title="X", questions=[{question: 'unquoted', options: []}])`;
+      expect(parseQuizFromText(call)).toBeNull();
+    });
+
+    it("returns null for a pseudo-call naming a different tool", () => {
+      expect(
+        parseQuizFromText(
+          `[showFlashcards(quiz_title="X", questions=${JSON.stringify(validQuiz.questions)})]`,
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null for prose that merely mentions showQuiz", () => {
+      expect(
+        parseQuizFromText("I would call showQuiz() but there is no material."),
+      ).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -200,5 +200,33 @@ describe("recoverLeakedQuiz", () => {
       expect(out.some((c) => c.type === "tool-input-available")).toBe(false);
       expect(textOf(out)).toBe(textOf(input));
     });
+
+    // The verbatim turn reported from production on 2026-08-07 (spacing and all),
+    // as the strongest guard against regressing the case that was actually broken.
+    it("recovers the reported production leak", async () => {
+      const reported = `Here are some quiz questions to assess your understanding of the topics you've mentioned.
+
+[showQuiz(quiz_title="Epistemologies of Gender Quiz", questions=[ { "question": "According to Professor Joubin's 'Five things about gender', what is the primary way gender shapes our society?", "options": [ "Gender is a fixed identity category.", "Gender is a set of evolving social practices.", "Gender is determined solely by biology.", "Gender is irrelevant to societal structures." ], "correct_index": 1, "explanation": "Professor Joubin emphasizes that gender is not an immutable identity category but rather a set of social practices that evolve over time." }, { "question": "Judith Butler argues that gender precedes sex assignment. What does this imply?", "options": [ "Gender is a direct result of biological sex.", "Sex assignment is independent of cultural frameworks.", "Gender influences how sex is assigned and categorized.", "Biological sex determines gender identity." ], "correct_index": 2, "explanation": "Butler suggests that gender is already operative as the scheme of power within which sex assignment takes place." }, { "question": "What is one of the main critiques of traditional understandings of gender epistemology?", "options": [ "That gender is too complex to be studied.", "That knowledge about gender is often biased.", "That gender should be determined solely by biological factors.", "That gender is not relevant to societal structures." ], "correct_index": 1, "explanation": "Systemic discourses about gender often foreclose the possibilities of marginalized narratives." } ])]`;
+      // Split the way it really streams: many small deltas.
+      const deltas: string[] = [];
+      for (let i = 0; i < reported.length; i += 17) {
+        deltas.push(reported.slice(i, i + 17));
+      }
+      const out = await pump(textBlock("t1", deltas));
+
+      const toolPart = out.at(-1) as {
+        type: string;
+        toolName: string;
+        input: { quiz_title: string; questions: unknown[] };
+      };
+      expect(toolPart.type).toBe("tool-input-available");
+      expect(toolPart.toolName).toBe("showQuiz");
+      expect(toolPart.input.quiz_title).toBe("Epistemologies of Gender Quiz");
+      expect(toolPart.input.questions).toHaveLength(3);
+      // The preamble is kept; the pseudo-call never reaches the client.
+      expect(textOf(out)).toBe(
+        "Here are some quiz questions to assess your understanding of the topics you've mentioned.\n\n",
+      );
+    });
   });
 });

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -194,6 +194,28 @@ describe("recoverLeakedQuiz", () => {
       expect(textOf(out)).toBe(textOf(input));
     });
 
+    it("keeps prose that merely mentions showQuiz() streaming as text", async () => {
+      // The marker is broad on purpose, so an answer that talks about the tool
+      // must be released as soon as its parens close without a quiz arg --
+      // otherwise the rest of the answer stops streaming token by token.
+      const input = textBlock("t1", [
+        "I would call showQuiz() but there is no material ",
+        "in this course to build a quiz from, sorry.",
+      ]);
+      const out = await pump(input);
+      expect(out).toEqual(input);
+    });
+
+    it("still holds a pretty-printed pseudo-call whose args start on the next line", async () => {
+      const call = `[showQuiz(\n  quiz_title="${quiz.quiz_title}",\n  questions=${JSON.stringify(quiz.questions)}\n)]`;
+      const out = await pump(textBlock("t1", [preamble, call]));
+      expect(out.at(-1)).toMatchObject({
+        type: "tool-input-available",
+        input: quiz,
+      });
+      expect(textOf(out)).toBe(preamble);
+    });
+
     it("leaves a non-quiz JSON blob after prose as text", async () => {
       const input = textBlock("t1", [preamble, '{"foo":"bar"}']);
       const out = await pump(input);

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -128,4 +128,77 @@ describe("recoverLeakedQuiz", () => {
     const input = textBlock("t1", ["   Hello there"]);
     expect(await pump(input)).toEqual(input);
   });
+
+  /**
+   * A leak does not have to start the text block. Models routinely write a
+   * sentence of preamble ("Here are some quiz questions...") and then emit the
+   * call, all inside one text block -- the shape reported in production
+   * 2026-08-07. The preamble is a real answer and must still stream; only the
+   * leaked call is replaced by the widget.
+   */
+  describe("leak after a prose preamble", () => {
+    const preamble = "Here are some quiz questions for you.\n\n";
+
+    const textOf = (chunks: Chunk[]) =>
+      chunks
+        .filter((c) => c.type === "text-delta")
+        .map((c) => c.delta)
+        .join("");
+
+    it("recovers a JSON quiz that follows prose in the same block", async () => {
+      const out = await pump(textBlock("t1", [preamble, JSON.stringify(quiz)]));
+      expect(out.at(-1)).toMatchObject({
+        type: "tool-input-available",
+        toolName: "showQuiz",
+        input: quiz,
+      });
+      // The preamble survives; the JSON does not.
+      expect(textOf(out)).toBe(preamble);
+    });
+
+    it("recovers a pseudo-call that follows prose in the same block", async () => {
+      const call = `[showQuiz(quiz_title="${quiz.quiz_title}", questions=${JSON.stringify(quiz.questions)})]`;
+      const out = await pump(textBlock("t1", [preamble, call]));
+      expect(out.at(-1)).toMatchObject({
+        type: "tool-input-available",
+        toolName: "showQuiz",
+        input: quiz,
+      });
+      expect(textOf(out)).toBe(preamble);
+    });
+
+    it("recovers a leak split across deltas mid-marker", async () => {
+      const call = `[showQuiz(quiz_title="${quiz.quiz_title}", questions=${JSON.stringify(quiz.questions)})]`;
+      // Marker split so no single delta contains "showQuiz(" whole.
+      const deltas = [
+        preamble + "[show",
+        "Quiz(quiz_",
+        call.slice("[showQuiz(quiz_".length),
+      ];
+      const out = await pump(textBlock("t1", deltas));
+      expect(out.at(-1)).toMatchObject({
+        type: "tool-input-available",
+        input: quiz,
+      });
+      expect(textOf(out)).toBe(preamble);
+    });
+
+    it("keeps prose containing braces streaming as text", async () => {
+      // A brace in ordinary prose must not swallow the rest of the answer.
+      const input = textBlock("t1", [
+        "The empty set is written {a, b} ",
+        "in most textbooks, and \\frac{1}{2} is a half.",
+      ]);
+      const out = await pump(input);
+      expect(out.some((c) => c.type === "tool-input-available")).toBe(false);
+      expect(textOf(out)).toBe(textOf(input));
+    });
+
+    it("leaves a non-quiz JSON blob after prose as text", async () => {
+      const input = textBlock("t1", [preamble, '{"foo":"bar"}']);
+      const out = await pump(input);
+      expect(out.some((c) => c.type === "tool-input-available")).toBe(false);
+      expect(textOf(out)).toBe(textOf(input));
+    });
+  });
 });

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -46,17 +46,15 @@ export function isRenderableQuiz(quiz: Quiz): boolean {
 }
 
 /**
- * Extract the first balanced top-level `{...}` object from free text, unwrapping
- * a leading ```json fence if present. Returns the JSON substring or null. Brace
- * counting skips braces inside strings so a `}` in a question/option can't end
- * the object early.
+ * Extract the balanced span that starts at `start` (which must hold the opening
+ * `{` or `[`). Returns the substring or null when the span never closes. Depth
+ * counting skips brackets inside strings so a `}` or `]` in a question/option
+ * can't end the span early.
  */
-function extractJsonObject(raw: string): string | null {
-  let text = raw;
-  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  if (fence?.[1]) text = fence[1];
-  const start = text.indexOf("{");
-  if (start === -1) return null;
+function extractBalanced(text: string, start: number): string | null {
+  const open = text[start];
+  if (open !== "{" && open !== "[") return null;
+  const close = open === "{" ? "}" : "]";
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -69,8 +67,8 @@ function extractJsonObject(raw: string): string | null {
       continue;
     }
     if (ch === '"') inString = true;
-    else if (ch === "{") depth++;
-    else if (ch === "}") {
+    else if (ch === open) depth++;
+    else if (ch === close) {
       depth--;
       if (depth === 0) return text.slice(start, i + 1);
     }
@@ -79,26 +77,83 @@ function extractJsonObject(raw: string): string | null {
 }
 
 /**
- * Recover a renderable quiz that a model emitted as a text JSON blob instead of
- * a native `showQuiz` tool call. Some (otherwise tool-capable) models serialize
- * the tool call into the assistant text channel; the AI SDK then forms no
- * `tool-showQuiz` part and the raw JSON renders as prose. This parses that text
- * back into a quiz so the server can reconstruct the tool part. Returns null for
- * anything that isn't a structurally valid, renderable quiz -- so ordinary prose
- * (or a non-quiz JSON code block) is left untouched.
+ * Extract the first balanced top-level `{...}` object from free text, unwrapping
+ * a leading ```json fence if present. Returns the JSON substring or null.
  */
-export function parseQuizFromText(text: string): Quiz | null {
-  const candidate = extractJsonObject(text);
-  if (!candidate) return null;
-  let parsed: unknown;
+function extractJsonObject(raw: string): string | null {
+  let text = raw;
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence?.[1]) text = fence[1];
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+  return extractBalanced(text, start);
+}
+
+/**
+ * Parse a `showQuiz` call the model wrote in its native pseudo-call syntax
+ * instead of as a JSON object:
+ *
+ *   [showQuiz(quiz_title="Gender Quiz", questions=[ { "question": ... } ])]
+ *
+ * Llama-family models emit this shape when their tool-call channel isn't used,
+ * so the whole call lands in the assistant text. Only the two keyword args are
+ * read, in either order; the `questions` payload must be valid JSON (it is, in
+ * practice -- these models serialize the array itself as JSON). Anything looser
+ * is rejected rather than repaired, so ordinary prose can't be misread as a
+ * quiz. Returns a candidate object for schema validation, or null.
+ */
+function extractPseudoCall(raw: string): unknown | null {
+  const call = raw.match(/showQuiz\s*\(/);
+  if (call?.index === undefined) return null;
+  const body = raw.slice(call.index + call[0].length);
+
+  const title = body.match(/quiz_title\s*[=:]\s*("(?:[^"\\]|\\.)*")/);
+  const questionsKey = body.match(/questions\s*[=:]\s*\[/);
+  if (!title?.[1] || questionsKey?.index === undefined) return null;
+
+  const arrayStart = questionsKey.index + questionsKey[0].length - 1;
+  const questions = extractBalanced(body, arrayStart);
+  if (!questions) return null;
+
   try {
-    parsed = JSON.parse(candidate);
+    return {
+      quiz_title: JSON.parse(title[1]) as string,
+      questions: JSON.parse(questions) as unknown,
+    };
   } catch {
     return null;
   }
-  const result = quizSchema.safeParse(parsed);
-  if (!result.success) return null;
-  return isRenderableQuiz(result.data) ? result.data : null;
+}
+
+/**
+ * Recover a renderable quiz that a model emitted as text instead of a native
+ * `showQuiz` tool call. Some (otherwise tool-capable) models serialize the tool
+ * call into the assistant text channel; the AI SDK then forms no
+ * `tool-showQuiz` part and the raw call renders as prose. Two shapes are
+ * recovered: a JSON object (optionally in a ```json fence) and a pseudo-call
+ * (`showQuiz(quiz_title=..., questions=[...])`). The JSON shape is tried first
+ * -- it's the cheaper parse and the more common leak. Returns null for anything
+ * that isn't a structurally valid, renderable quiz, so ordinary prose (or a
+ * non-quiz JSON code block) is left untouched.
+ */
+export function parseQuizFromText(text: string): Quiz | null {
+  for (const candidate of [jsonCandidate(text), extractPseudoCall(text)]) {
+    if (candidate === null) continue;
+    const result = quizSchema.safeParse(candidate);
+    if (result.success && isRenderableQuiz(result.data)) return result.data;
+  }
+  return null;
+}
+
+/** The first balanced `{...}` in `text`, JSON-parsed, or null. */
+function jsonCandidate(text: string): unknown | null {
+  const candidate = extractJsonObject(text);
+  if (!candidate) return null;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -27,6 +27,13 @@ const MARKER_LOOKBACK = "[showQuiz(".length - 1;
  */
 const MAX_HELD_CHARS = 8_000;
 
+/**
+ * How far past `showQuiz(` to wait for `quiz_title` / `questions` before
+ * concluding the text isn't a real call. Generous enough for a pretty-printed
+ * call that puts its first arg on the next line.
+ */
+const PSEUDO_ARG_WINDOW = 48;
+
 /** Index where the earliest leak marker starts in `text`, or -1. */
 function findMarker(text: string): number {
   let earliest = -1;
@@ -61,8 +68,13 @@ function stillPlausible(held: string): boolean {
     const info = text.slice(0, newline).replace(/`/g, "").trim().toLowerCase();
     return info === "" || info === "json";
   }
-  // `[` / `showQuiz(` -- specific enough to hold to the end of the block.
-  return true;
+  // Pseudo-call: rule it out as soon as the arg list proves it isn't a quiz, so
+  // prose that merely mentions `showQuiz()` doesn't buffer the rest of the
+  // block. A real call names one of its two args up front; anything that closes
+  // its parens, or runs past the window, without naming either is not a call.
+  const args = text.slice(text.indexOf("(") + 1);
+  if (args.length < PSEUDO_ARG_WINDOW && !args.includes(")")) return true;
+  return /quiz_title|questions/.test(args);
 }
 
 /**

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -87,6 +87,11 @@ function stillPlausible(held: string): boolean {
  * Ordinary prose keeps streaming token by token: text is only withheld from a
  * marker onward, and `stillPlausible` releases it again as soon as the shape
  * rules a quiz out.
+ *
+ * Accepted limitation: when a block holds a non-quiz JSON blob (or fence) AND a
+ * real leak after it, recovery drops everything from the first marker on, so the
+ * intervening content is lost with the leak. A quiz turn that also contains an
+ * unrelated JSON blob isn't a shape worth the extra state.
  */
 export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
   /** null between blocks; otherwise the id of the block being processed. */

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -5,131 +5,225 @@ import type { StudyUIMessage } from "./study-tools";
 
 type Chunk = InferUIMessageChunk<StudyUIMessage>;
 
-type BlockClass = "prose" | "quiz-candidate" | "pending";
+/**
+ * Openers that can begin a leaked `showQuiz` call inside assistant text:
+ * a bare JSON object, a code fence, or the pseudo-call syntax
+ * (`showQuiz(quiz_title=...)`) that Llama-family models emit.
+ */
+const MARKERS = ["{", "```", "showQuiz("] as const;
 
 /**
- * Classify a (possibly partial) text block by its opening characters, to decide
- * whether to hold it as a possible leaked quiz or let it stream through live:
- *
- * - starts with `{`                     -> quiz-candidate (bare JSON tool-call leak)
- * - opens a ```json or bare ``` fence   -> quiz-candidate
- * - opens a ```<lang> fence (js, py...) -> prose (real code -- must stream live)
- * - any other non-whitespace char       -> prose
- * - only whitespace, or a fence whose info-line hasn't arrived -> pending
- *
- * Fence classification waits for the info-line (up to the first newline) rather
- * than matching the first character, so a fence streamed as "```" then "json"
- * isn't misread as prose before its language tag arrives -- and, conversely, a
- * ```js block is only buffered until its newline, then released to stream live.
+ * How much streamed text stays buffered while watching for a marker. A marker
+ * can be split across deltas ("[show" + "Quiz("), so the tail that could be an
+ * incomplete marker -- one char less than the longest one, counting the `[` a
+ * pseudo-call is usually wrapped in -- must not be released yet.
  */
-function classifyBlock(text: string): BlockClass {
-  const trimmed = text.replace(/^\s+/, "");
-  if (trimmed.length === 0) return "pending";
-  if (trimmed[0] === "{") return "quiz-candidate";
-  if (trimmed[0] !== "`") return "prose";
-  const newline = trimmed.indexOf("\n");
-  if (newline === -1) return "pending"; // fence info-line not complete yet
-  const info = trimmed.slice(0, newline).replace(/`/g, "").trim().toLowerCase();
-  return info === "" || info === "json" ? "quiz-candidate" : "prose";
+const MARKER_LOOKBACK = "[showQuiz(".length - 1;
+
+/**
+ * Hard cap on held text. A 5-question quiz serializes to ~2KB, so anything past
+ * this is not the leak we're looking for; bail out rather than withhold an
+ * unbounded stretch of a real answer.
+ */
+const MAX_HELD_CHARS = 8_000;
+
+/** Index where the earliest leak marker starts in `text`, or -1. */
+function findMarker(text: string): number {
+  let earliest = -1;
+  for (const marker of MARKERS) {
+    const at = text.indexOf(marker);
+    if (at !== -1 && (earliest === -1 || at < earliest)) earliest = at;
+  }
+  // A pseudo-call usually arrives bracketed -- `[showQuiz(...)]` -- so include
+  // the bracket in the held text instead of stranding it in the prose.
+  if (earliest > 0 && text[earliest - 1] === "[") return earliest - 1;
+  return earliest;
 }
 
 /**
- * Recover a quiz a model emitted as a text JSON blob instead of a native
- * `showQuiz` tool call.
+ * Whether held text can still turn out to be a leaked quiz. The markers are
+ * deliberately broad, so this bails out of the inevitable false positives as
+ * soon as the text rules a quiz out -- a `{` in prose or LaTeX, a ```js code
+ * block -- and the rest of that answer goes back to streaming live.
+ */
+function stillPlausible(held: string): boolean {
+  const text = held.replace(/^\s+/, "");
+  if (text.length === 0) return true;
+  if (text[0] === "{") {
+    // A JSON object opens with a quoted key (or closes immediately). Prose like
+    // "the set {a, b}" or "\frac{1}{2}" is ruled out at the very next char.
+    return /^\{\s*(?:"|\}|$)/.test(text);
+  }
+  if (text[0] === "`") {
+    const newline = text.indexOf("\n");
+    // Fence info-line still arriving: keep holding, but not indefinitely.
+    if (newline === -1) return text.length <= 20;
+    const info = text.slice(0, newline).replace(/`/g, "").trim().toLowerCase();
+    return info === "" || info === "json";
+  }
+  // `[` / `showQuiz(` -- specific enough to hold to the end of the block.
+  return true;
+}
+
+/**
+ * Recover a quiz a model emitted as text instead of a native `showQuiz` tool
+ * call.
  *
  * Some otherwise tool-capable models (varies by model/provider) serialize the
  * tool call into the assistant *text* channel, so the AI SDK forms no
- * `tool-showQuiz` part and the raw `{"quiz_title":...}` JSON renders as prose.
- * This transform holds a text block ONLY while it looks like it could be that
- * JSON (see `classifyBlock`: a leading `{`, or a ```json / bare ``` fence). If
- * the held block parses to a renderable quiz it is dropped and replaced with a
- * synthetic `tool-input-available` chunk -- identical to a native call, so it
- * renders as the interactive widget and persists like one. Otherwise the held
- * chunks are flushed unchanged.
+ * `tool-showQuiz` part and the raw call renders as prose. The leak can be the
+ * whole text block or -- as seen in production -- follow a sentence of preamble
+ * ("Here are some quiz questions...") inside the same block, and it can be
+ * either JSON or pseudo-call syntax (see `parseQuizFromText`).
  *
- * Ordinary prose -- and code blocks in other languages (```js, ```python) --
- * stream through live; only quiz-shaped output is buffered, so normal answers
- * keep their token-by-token streaming.
+ * So this watches each text block for a leak marker, holding back only the few
+ * characters that could be an incomplete marker. Once a marker appears, the
+ * text from that point is held; if it parses to a renderable quiz the held text
+ * is dropped and replaced with a synthetic `tool-input-available` chunk --
+ * identical to a native call, so it renders as the interactive widget and
+ * persists like one. Any preamble before the marker is kept as text; a held
+ * block that turns out not to be a quiz is emitted unchanged.
+ *
+ * Ordinary prose keeps streaming token by token: text is only withheld from a
+ * marker onward, and `stillPlausible` releases it again as soon as the shape
+ * rules a quiz out.
  */
 export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
-  let holding = false;
-  // Whether the held block has been classified yet (prose vs quiz-candidate).
-  let classified = false;
-  let heldChunks: Chunk[] = [];
-  let heldText = "";
-  let heldId: string | null = null;
+  /** null between blocks; otherwise the id of the block being processed. */
+  let blockId: string | null = null;
+  let startChunk: Chunk | null = null;
+  let startEmitted = false;
+  /** Chunks of the current block not yet emitted, oldest first. */
+  let pending: Chunk[] = [];
+  let pendingText = "";
+  /** Index in `pendingText` where a leak starts, or -1 while still watching. */
+  let markerAt = -1;
 
   const reset = () => {
-    holding = false;
-    classified = false;
-    heldChunks = [];
-    heldText = "";
-    heldId = null;
+    blockId = null;
+    startChunk = null;
+    startEmitted = false;
+    pending = [];
+    pendingText = "";
+    markerAt = -1;
   };
 
-  const flush = (controller: TransformStreamDefaultController<Chunk>) => {
-    for (const c of heldChunks) controller.enqueue(c);
-    reset();
+  const deltaOf = (chunk: Chunk): string =>
+    (chunk as { delta?: string }).delta ?? "";
+
+  const emitStart = (controller: TransformStreamDefaultController<Chunk>) => {
+    if (startEmitted || !startChunk) return;
+    controller.enqueue(startChunk);
+    startEmitted = true;
+  };
+
+  /** Emit every unemitted chunk of the block exactly as it arrived. */
+  const flushPending = (
+    controller: TransformStreamDefaultController<Chunk>,
+  ) => {
+    if (pending.length > 0 || !startEmitted) emitStart(controller);
+    for (const chunk of pending) controller.enqueue(chunk);
+    pending = [];
+    pendingText = "";
+    markerAt = -1;
   };
 
   return new TransformStream<Chunk, Chunk>({
     transform(chunk, controller) {
       if (chunk.type === "text-start") {
-        // A new text block starts; flush any still-held block first (defensive --
-        // a well-formed stream closes a block before opening the next).
-        if (holding) flush(controller);
-        holding = true;
-        classified = false;
-        heldChunks = [chunk];
-        heldText = "";
-        heldId = chunk.id;
+        // Defensive: a well-formed stream closes a block before opening another.
+        if (blockId !== null) flushPending(controller);
+        reset();
+        blockId = chunk.id;
+        startChunk = chunk;
         return;
       }
 
-      if (holding && chunk.type === "text-delta" && chunk.id === heldId) {
-        heldChunks.push(chunk);
-        heldText += chunk.delta;
-        if (!classified) {
-          const decision = classifyBlock(heldText);
-          if (decision === "prose") {
-            // Release the held chunks and stop holding so the rest of the block
-            // streams through live.
-            classified = true;
-            flush(controller);
-          } else if (decision === "quiz-candidate") {
-            // Keep holding until text-end, then try to recover a quiz.
-            classified = true;
+      const isBlockDelta =
+        blockId !== null && chunk.type === "text-delta" && chunk.id === blockId;
+
+      if (isBlockDelta) {
+        pending.push(chunk);
+        pendingText += deltaOf(chunk);
+
+        if (markerAt === -1) {
+          markerAt = findMarker(pendingText);
+          if (markerAt === -1) {
+            // Release everything except the tail that could still be the start
+            // of a marker, so prose streams live.
+            while (pending.length > 0) {
+              const head = pending[0]!;
+              const headLength = deltaOf(head).length;
+              if (pendingText.length - headLength < MARKER_LOOKBACK) break;
+              emitStart(controller);
+              controller.enqueue(head);
+              pending.shift();
+              pendingText = pendingText.slice(headLength);
+            }
+            return;
           }
-          // "pending": not enough text to decide yet -- keep buffering.
+        }
+
+        // Holding: give up as soon as the held text can't be a quiz (or grows
+        // past the cap) and go back to watching the rest of the block.
+        const held = pendingText.slice(markerAt);
+        if (held.length > MAX_HELD_CHARS || !stillPlausible(held)) {
+          flushPending(controller);
         }
         return;
       }
 
-      if (holding && chunk.type === "text-end" && chunk.id === heldId) {
-        heldChunks.push(chunk);
-        const quiz = parseQuizFromText(heldText);
-        if (quiz) {
-          // Drop the JSON text; emit a native-looking tool call in its place.
+      if (
+        blockId !== null &&
+        chunk.type === "text-end" &&
+        chunk.id === blockId
+      ) {
+        const quiz =
+          markerAt === -1
+            ? null
+            : parseQuizFromText(pendingText.slice(markerAt));
+        if (!quiz) {
+          flushPending(controller);
+          controller.enqueue(chunk);
           reset();
-          controller.enqueue({
-            type: "tool-input-available",
-            toolCallId: nanoid(),
-            toolName: "showQuiz",
-            input: quiz,
-          } as Chunk);
-        } else {
-          flush(controller);
+          return;
         }
+        // Drop the leaked call. Keep any preamble before it as text -- it is a
+        // real part of the answer -- and close the block only if text was
+        // emitted, so a leak-only block leaves no empty bubble behind.
+        const preamble = pendingText.slice(0, markerAt);
+        if (startEmitted || preamble.trim().length > 0) {
+          emitStart(controller);
+          if (preamble.length > 0) {
+            controller.enqueue({
+              type: "text-delta",
+              id: blockId,
+              delta: preamble,
+            } as Chunk);
+          }
+          controller.enqueue(chunk);
+        }
+        controller.enqueue({
+          type: "tool-input-available",
+          toolCallId: nanoid(),
+          toolName: "showQuiz",
+          input: quiz,
+        } as Chunk);
+        reset();
         return;
       }
 
-      // Any other chunk (tool parts, a delta for a different id, etc.). If a
-      // block is still held, flush it first to preserve ordering.
-      if (holding) flush(controller);
+      // Any other chunk (tool parts, a delta for a different id, etc.). Flush an
+      // open block first to preserve ordering.
+      if (blockId !== null) {
+        flushPending(controller);
+        reset();
+      }
       controller.enqueue(chunk);
     },
     flush(controller) {
-      if (holding) flush(controller);
+      if (blockId !== null) flushPending(controller);
+      reset();
     },
   });
 }


### PR DESCRIPTION
## What Prof Joubin reported (Aug 7)

Two failures, in two different chatbots:

1. **Shakespeare AI** amber notice "Couldn't build the quiz. Try asking again."
2. **Critical theory AI** the quiz never formed; the raw call rendered as text:
   `[showQuiz(quiz_title="Epistemologies of Gender Quiz", questions=[ ... ])]`

This PR fixes **#2**. #1 is a different failure (the model's tool input failed
schema validation) and is still open see the bottom.

## Root cause of #2

Two independent gaps in the leaked-quiz recovery path, both confirmed
mechanically against her verbatim output:

**Gap 1 the gate.** `recoverLeakedQuiz` classified each text block by its
opening characters. Her output starts with `Here are some quiz questions to
assess your understanding...`, so the block was classified `prose` on the very
first delta, released to stream live, and the leaked call that followed was
never examined. Recovery only ever worked when the leak was the *first* thing in
a text block and models routinely write a sentence of preamble first.

**Gap 2 the parser.** `parseQuizFromText` only understood a JSON object. Her
bot emitted the Llama-family pseudo-call syntax, which the parser rejected
(`extractJsonObject` finds the first `{`, which is a *question* object, and that
fails `quizSchema`).

## The fix

- The transform now watches the whole block for a leak marker (`{`, a code
  fence, or `showQuiz(`), holding back only the few characters that could be an
  incomplete marker split across deltas. On a hit, text from the marker onward
  is held; any preamble before it is kept as text.
- `parseQuizFromText` also parses the pseudo-call shape, strictly: both keyword
  args must be present and the `questions` payload must be valid JSON. No
  repairing of malformed input, so prose can't be misread as a quiz.
- Prose keeps streaming token by token. A held block is released again as soon
  as its shape rules a quiz out (`stillPlausible`: a brace in prose or LaTeX,
  a ```` ```js ```` fence), with an 8KB cap as a backstop.

## Tests

7 new cases (5 parser, 5 transform, incl. a marker split across deltas and
negative cases for braces in prose and non-quiz JSON). All 10 pre-existing
`recoverLeakedQuiz` cases still assert verbatim chunk pass-through and pass
unchanged, so live streaming behavior is provably unaffected. Full suite: 677
passing.

## Still open: the "Couldn't build the quiz" notice

That notice means the model's `showQuiz` input failed `quizSchema`. Verified
locally with a mocked model that this path does **not** throw the call comes
back flagged `invalid`, `producedRenderableQuiz` returns false, and the
empty-response fallback should then produce a prose answer. Her screenshot shows
the notice with **no** prose, which that flow doesn't explain yet.

To close it I need one of: the failing turn's model + max-tokens setting (a low
`maxTokens` truncates the quiz JSON mid-input, which would fail validation on
*every* model matching "regardless of which LLM"), or a re-run confirming
whether prose eventually appears under the notice.
