### PR TITLE
fix(quiz): salvage a quiz the token limit cut off instead of failing

### DIFF
--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -7,6 +7,7 @@ import {
   gradeQuiz,
   initialQuizWidgetState,
   parseQuizFromText,
+  repairQuiz,
   type Quiz,
   type QuizResponse,
 } from "@/lib/quiz";
@@ -256,6 +257,129 @@ describe("initialQuizWidgetState", () => {
       currentIndex: 0,
       selected: [null, null, null],
       finished: false,
+    });
+  });
+});
+
+describe("repairQuiz", () => {
+  const question = (i: number, over = false) => ({
+    question: `Q${i}?`,
+    options: ["A", "B", "C", "D"],
+    correct_index: over ? 9 : i % 4,
+    explanation: `because ${i}`,
+  });
+
+  it("passes an already-valid quiz through unchanged", () => {
+    const quiz = { quiz_title: "T", questions: [question(1)] };
+    expect(repairQuiz(quiz)).toEqual(quiz);
+  });
+
+  it("trims a quiz with more questions than the schema allows", () => {
+    const repaired = repairQuiz({
+      quiz_title: "T",
+      questions: [1, 2, 3, 4, 5, 6, 7].map((i) => question(i)),
+    });
+    expect(repaired?.questions).toHaveLength(5);
+    expect(repaired?.questions[0]?.question).toBe("Q1?");
+  });
+
+  it("drops a question missing its explanation and keeps the rest", () => {
+    const repaired = repairQuiz({
+      quiz_title: "T",
+      questions: [
+        question(1),
+        { question: "Q2?", options: ["A", "B"], correct_index: 0 },
+        question(3),
+      ],
+    });
+    expect(repaired?.questions.map((q) => q.question)).toEqual(["Q1?", "Q3?"]);
+  });
+
+  it("drops a question whose correct_index is out of range", () => {
+    const repaired = repairQuiz({
+      quiz_title: "T",
+      questions: [question(1, true), question(2)],
+    });
+    expect(repaired?.questions.map((q) => q.question)).toEqual(["Q2?"]);
+  });
+
+  it("drops a question with too many options", () => {
+    const repaired = repairQuiz({
+      quiz_title: "T",
+      questions: [
+        { ...question(1), options: ["A", "B", "C", "D", "E"] },
+        question(2),
+      ],
+    });
+    expect(repaired?.questions.map((q) => q.question)).toEqual(["Q2?"]);
+  });
+
+  it("returns null when no question survives", () => {
+    expect(
+      repairQuiz({ quiz_title: "T", questions: [question(1, true)] }),
+    ).toBeNull();
+    expect(repairQuiz({ quiz_title: "T", questions: [] })).toBeNull();
+  });
+
+  it("returns null for input that isn't a quiz at all", () => {
+    expect(repairQuiz(undefined)).toBeNull();
+    expect(repairQuiz(null)).toBeNull();
+    expect(repairQuiz(42)).toBeNull();
+    expect(repairQuiz("not json")).toBeNull();
+    expect(repairQuiz({ quiz_title: "T" })).toBeNull();
+    expect(repairQuiz({ questions: [question(1)] })).toBeNull();
+  });
+
+  it("truncates an over-long title rather than rejecting the quiz", () => {
+    const repaired = repairQuiz({
+      quiz_title: "x".repeat(500),
+      questions: [question(1)],
+    });
+    expect(repaired?.quiz_title).toHaveLength(200);
+  });
+
+  describe("input cut off by the token limit", () => {
+    const full = JSON.stringify({
+      quiz_title: "Shakespeare",
+      questions: [question(1), question(2), question(3)],
+    });
+
+    it("keeps the questions that finished writing", () => {
+      // Cut in the middle of the third question.
+      const cut = full.slice(0, full.indexOf("Q3?") + 1);
+      const repaired = repairQuiz(cut);
+      expect(repaired?.quiz_title).toBe("Shakespeare");
+      expect(repaired?.questions.map((q) => q.question)).toEqual([
+        "Q1?",
+        "Q2?",
+      ]);
+    });
+
+    it("keeps a single completed question", () => {
+      const cut = full.slice(0, full.indexOf("Q2?"));
+      expect(repairQuiz(cut)?.questions).toHaveLength(1);
+    });
+
+    it("returns null when not even one question finished", () => {
+      const cut = full.slice(0, full.indexOf("questions") + 20);
+      expect(repairQuiz(cut)).toBeNull();
+    });
+
+    it("returns null when the title never arrived", () => {
+      const titleLast = JSON.stringify({
+        questions: [question(1)],
+        quiz_title: "Shakespeare",
+      });
+      const cut = titleLast.slice(0, titleLast.indexOf("quiz_title"));
+      expect(repairQuiz(cut)).toBeNull();
+    });
+
+    it("still repairs a complete-but-oversized JSON string", () => {
+      const oversized = JSON.stringify({
+        quiz_title: "T",
+        questions: [1, 2, 3, 4, 5, 6].map((i) => question(i)),
+      });
+      expect(repairQuiz(oversized)?.questions).toHaveLength(5);
     });
   });
 });

--- a/apps/web/src/__tests__/server/chat/repair-quiz-parts.test.ts
+++ b/apps/web/src/__tests__/server/chat/repair-quiz-parts.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  repairQuizToolParts,
+  closeTruncatedQuizInputs,
+} from "@/server/chat/repair-quiz-parts";
+
+type Chunk = Record<string, unknown>;
+
+async function pump(chunks: Chunk[]): Promise<Chunk[]> {
+  const stream = repairQuizToolParts();
+  const writer = stream.writable.getWriter();
+  const out: Chunk[] = [];
+  const drained = (async () => {
+    const reader = stream.readable.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out.push(value as Chunk);
+    }
+  })();
+  for (const chunk of chunks) await writer.write(chunk as never);
+  await writer.close();
+  await drained;
+  return out;
+}
+
+const question = (i: number) => ({
+  question: `Q${i}?`,
+  options: ["A", "B", "C", "D"],
+  correct_index: 1,
+  explanation: `because ${i}`,
+});
+
+describe("repairQuizToolParts", () => {
+  it("turns a truncated input error into a shorter quiz", async () => {
+    const full = JSON.stringify({
+      quiz_title: "Shakespeare",
+      questions: [question(1), question(2), question(3)],
+    });
+    const out = await pump([
+      {
+        type: "tool-input-error",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: full.slice(0, full.indexOf("Q3?") + 1),
+        errorText: "JSON parsing failed",
+      },
+      { type: "tool-output-error", toolCallId: "c1", errorText: "boom" },
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      type: "tool-input-available",
+      toolCallId: "c1",
+      toolName: "showQuiz",
+    });
+    const input = out[0]!.input as { questions: unknown[] };
+    expect(input.questions).toHaveLength(2);
+  });
+
+  it("trims an over-long quiz that failed schema validation", async () => {
+    const out = await pump([
+      {
+        type: "tool-input-error",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: {
+          quiz_title: "T",
+          questions: [1, 2, 3, 4, 5, 6, 7].map(question),
+        },
+        errorText: "Type validation failed",
+      },
+      { type: "tool-output-error", toolCallId: "c1", errorText: "boom" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect((out[0]!.input as { questions: unknown[] }).questions).toHaveLength(
+      5,
+    );
+  });
+
+  it("repairs an accepted-but-unrenderable quiz in place", async () => {
+    // Structurally valid, so it arrives as input-available, but the second
+    // question's correct_index points past its options.
+    const out = await pump([
+      {
+        type: "tool-input-available",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: {
+          quiz_title: "T",
+          questions: [question(1), { ...question(2), correct_index: 9 }],
+        },
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe("tool-input-available");
+    const input = out[0]!.input as { questions: Array<{ question: string }> };
+    expect(input.questions.map((q) => q.question)).toEqual(["Q1?"]);
+  });
+
+  it("leaves a renderable quiz untouched", async () => {
+    const input = [
+      {
+        type: "tool-input-available",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: { quiz_title: "T", questions: [question(1)] },
+      },
+    ];
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("leaves an unsalvageable error pair alone so the notice still shows", async () => {
+    const input = [
+      {
+        type: "tool-input-error",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: '{"quiz_ti',
+        errorText: "JSON parsing failed",
+      },
+      { type: "tool-output-error", toolCallId: "c1", errorText: "boom" },
+    ];
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("does not touch other tools' chunks", async () => {
+    const input = [
+      {
+        type: "tool-input-error",
+        toolCallId: "s1",
+        toolName: "search_documents",
+        input: "{broken",
+        errorText: "nope",
+      },
+      { type: "tool-output-error", toolCallId: "s1", errorText: "nope" },
+      { type: "text-delta", id: "t1", delta: "hello" },
+    ];
+    expect(await pump(input)).toEqual(input);
+  });
+
+  it("keeps a nested brace inside a question when salvaging", async () => {
+    const full = JSON.stringify({
+      quiz_title: "Sets",
+      questions: [
+        {
+          question: "Is {} the empty set?",
+          options: ["Yes", "No"],
+          correct_index: 0,
+          explanation: "It is {}.",
+        },
+        { ...question(2), question: "cut off here" },
+      ],
+    });
+    const out = await pump([
+      {
+        type: "tool-input-error",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: full.slice(0, full.indexOf("cut off") + 4),
+        errorText: "JSON parsing failed",
+      },
+    ]);
+    const input = out[0]!.input as { questions: Array<{ question: string }> };
+    expect(input.questions.map((q) => q.question)).toEqual([
+      "Is {} the empty set?",
+    ]);
+  });
+
+  it("only drops the output error of the call it repaired", async () => {
+    const out = await pump([
+      {
+        type: "tool-input-error",
+        toolCallId: "c1",
+        toolName: "showQuiz",
+        input: { quiz_title: "T", questions: [question(1), question(2)] },
+        errorText: "boom",
+      },
+      { type: "tool-output-error", toolCallId: "other", errorText: "keep me" },
+      { type: "tool-output-error", toolCallId: "c1", errorText: "drop me" },
+    ]);
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-available",
+      "tool-output-error",
+    ]);
+    expect(out[1]).toMatchObject({ toolCallId: "other" });
+  });
+});
+
+describe("closeTruncatedQuizInputs", () => {
+  const full = JSON.stringify({
+    quiz_title: "Shakespeare",
+    questions: [question(1), question(2), question(3)],
+  });
+
+  it("resolves a cut-off input to the questions that finished", () => {
+    const closing = closeTruncatedQuizInputs(
+      new Map([["c1", full.slice(0, full.indexOf("Q3?") + 1)]]),
+      [],
+    );
+    expect(closing).toHaveLength(1);
+    expect(closing[0]).toMatchObject({
+      type: "tool-input-available",
+      toolCallId: "c1",
+      toolName: "showQuiz",
+    });
+  });
+
+  it("resolves an input with nothing salvageable to an error", () => {
+    const closing = closeTruncatedQuizInputs(
+      new Map([["c1", '{"quiz_ti']]),
+      [],
+    );
+    expect(closing[0]).toMatchObject({
+      type: "tool-output-error",
+      toolCallId: "c1",
+    });
+  });
+
+  it("ignores inputs that completed as real tool calls", () => {
+    expect(closeTruncatedQuizInputs(new Map([["c1", full]]), ["c1"])).toEqual(
+      [],
+    );
+  });
+
+  /**
+   * The invariant that matters: a part left in `input-streaming` renders as a
+   * skeleton that spins for the rest of the session, so every started input must
+   * come back either resolved or errored, never nothing.
+   */
+  it("never leaves a started input unresolved", () => {
+    const partials = new Map([
+      ["done", full],
+      ["salvageable", full.slice(0, full.indexOf("Q2?") + 1)],
+      ["hopeless", "{"],
+      ["empty", ""],
+    ]);
+    const closing = closeTruncatedQuizInputs(partials, ["done"]);
+    expect(closing.map((c) => c.toolCallId).sort()).toEqual([
+      "empty",
+      "hopeless",
+      "salvageable",
+    ]);
+    expect(closing.every((c) => c.type !== undefined)).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/server/chat/study-tools.test.ts
+++ b/apps/web/src/__tests__/server/chat/study-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "@jest/globals";
-import { studyTools, producedRenderableQuiz } from "@/server/chat/study-tools";
+import {
+  studyTools,
+  producedRenderableQuiz,
+  maxQuestionsForBudget,
+  buildStudyToolsAddendum,
+} from "@/server/chat/study-tools";
 
 describe("studyTools", () => {
   it("registers showQuiz with the quiz schema and no execute", () => {
@@ -44,6 +49,57 @@ describe("producedRenderableQuiz", () => {
     ).toBe(true);
   });
 
+  it("counts a call whose input only needs repair to render", () => {
+    // The client repairs these on the way to the browser (repairQuizToolParts),
+    // so the student does get a quiz and the fallback must stay off.
+    expect(
+      producedRenderableQuiz([
+        {
+          toolName: "showQuiz",
+          invalid: true,
+          input: {
+            quiz_title: "T",
+            questions: Array(7).fill({
+              question: "Q?",
+              options: ["A", "B"],
+              correct_index: 0,
+              explanation: "x",
+            }),
+          },
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("counts a call whose input was cut off after one question", () => {
+    const full = JSON.stringify({
+      quiz_title: "T",
+      questions: [
+        {
+          question: "Q1?",
+          options: ["A", "B"],
+          correct_index: 0,
+          explanation: "x",
+        },
+        {
+          question: "Q2?",
+          options: ["A", "B"],
+          correct_index: 0,
+          explanation: "x",
+        },
+      ],
+    });
+    expect(
+      producedRenderableQuiz([
+        {
+          toolName: "showQuiz",
+          invalid: true,
+          input: full.slice(0, full.indexOf("Q2?")),
+        },
+      ]),
+    ).toBe(true);
+  });
+
   it("does NOT count a showQuiz call whose input failed validation", () => {
     // The SDK returns a schema-invalid tool call with `invalid: true`; it shows
     // the student an error, not a quiz, so it must not suppress the fallback.
@@ -74,5 +130,43 @@ describe("producedRenderableQuiz", () => {
         { toolName: "showQuiz", invalid: false, input: quizInput() },
       ]),
     ).toBe(true);
+  });
+});
+
+describe("maxQuestionsForBudget", () => {
+  it("allows the full quiz when the budget is roomy", () => {
+    expect(maxQuestionsForBudget(2000)).toBe(5);
+    expect(maxQuestionsForBudget(4000)).toBe(5);
+    expect(maxQuestionsForBudget(1000)).toBe(5);
+  });
+
+  it("scales down as the reply limit tightens", () => {
+    expect(maxQuestionsForBudget(800)).toBe(4);
+    expect(maxQuestionsForBudget(500)).toBe(2);
+  });
+
+  it("never asks for fewer than one question", () => {
+    // 100 is the floor clampMaxTokens allows; a quiz can't really fit, but the
+    // model must still be asked for something rather than zero questions.
+    expect(maxQuestionsForBudget(100)).toBe(1);
+    expect(maxQuestionsForBudget(0)).toBe(1);
+  });
+});
+
+describe("buildStudyToolsAddendum", () => {
+  it("tells the model the question budget", () => {
+    expect(buildStudyToolsAddendum(500)).toContain("at most 2 questions");
+    expect(buildStudyToolsAddendum(2000)).toContain("at most 5 questions");
+  });
+
+  it("uses the singular for a one-question budget", () => {
+    expect(buildStudyToolsAddendum(150)).toContain("at most 1 question,");
+  });
+
+  it("still tells the model to call the tool rather than write prose", () => {
+    expect(buildStudyToolsAddendum(2000)).toContain("showQuiz");
+    expect(buildStudyToolsAddendum(2000)).toContain(
+      "do not write the quiz out as prose",
+    );
   });
 });

--- a/apps/web/src/__tests__/server/chat/truncated-quiz-stream.test.ts
+++ b/apps/web/src/__tests__/server/chat/truncated-quiz-stream.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "@jest/globals";
+import { streamText, createUIMessageStream } from "ai";
+import { MockLanguageModelV3, convertArrayToReadableStream } from "ai/test";
+import { studyTools, type StudyUIMessage } from "@/server/chat/study-tools";
+import { stripRetrievalOutputs } from "@/server/chat/stream-filter";
+import { recoverLeakedQuiz } from "@/server/chat/recover-quiz";
+import {
+  repairQuizToolParts,
+  closeTruncatedQuizInputs,
+} from "@/server/chat/repair-quiz-parts";
+
+const QUIZ = {
+  quiz_title: "Shakespeare",
+  questions: [1, 2, 3].map((i) => ({
+    question: `Q${i}?`,
+    options: ["A", "B", "C", "D"],
+    correct_index: 1,
+    explanation: `because ${i}`,
+  })),
+};
+
+/** The quiz as the model would stream it, cut off inside the third question. */
+const PARTIAL = JSON.stringify(QUIZ).slice(
+  0,
+  JSON.stringify(QUIZ).indexOf("Q3?") + 1,
+);
+
+/**
+ * Replica of the `execute` wiring in `stream-chat.ts`: the same transform
+ * pipeline, the same `onChunk` accumulation, and the same post-await writes,
+ * with a mocked model whose quiz input is cut off mid-write.
+ *
+ * This covers the one seam the unit tests can't reach -- chunk ORDER. The
+ * closing `tool-input-available` is written after `await primary.text`, while
+ * the part's own `tool-input-start` / `tool-input-delta` chunks travel through
+ * three transforms. With `writer.merge` those two paths run concurrently, and
+ * the closing chunk was measured landing *before* the deltas it closes (at 60
+ * deltas), which would leave the client re-opening the part as
+ * `input-streaming` -- the eternal skeleton this feature exists to kill.
+ * Draining the source (see `forward`) is what makes the order deterministic.
+ */
+async function runCutOffTurn(deltaCount: number) {
+  const deltas: string[] = [];
+  const size = Math.ceil(PARTIAL.length / deltaCount);
+  for (let i = 0; i < PARTIAL.length; i += size) {
+    deltas.push(PARTIAL.slice(i, i + size));
+  }
+
+  const stream = createUIMessageStream<StudyUIMessage>({
+    onError: (error) => String(error),
+    execute: async ({ writer }) => {
+      const partialQuizInput = new Map<string, string>();
+      const primary = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "t1" },
+              { type: "text-delta", id: "t1", delta: "Here is your quiz." },
+              { type: "text-end", id: "t1" },
+              { type: "tool-input-start", id: "c1", toolName: "showQuiz" },
+              ...deltas.map((delta) => ({
+                type: "tool-input-delta",
+                id: "c1",
+                delta,
+              })),
+              {
+                type: "finish",
+                finishReason: "length",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ] as never),
+          }),
+        }),
+        tools: studyTools,
+        prompt: "quiz me",
+        onChunk({ chunk }) {
+          if (
+            chunk.type === "tool-input-start" &&
+            chunk.toolName === "showQuiz"
+          ) {
+            partialQuizInput.set(chunk.id, "");
+          } else if (chunk.type === "tool-input-delta") {
+            const written = partialQuizInput.get(chunk.id);
+            if (written !== undefined) {
+              partialQuizInput.set(chunk.id, written + chunk.delta);
+            }
+          }
+        },
+      });
+
+      // Drained, not merged -- see `forward` in stream-chat.ts. Merging here
+      // reproduces the inversion this test exists to catch.
+      const source = primary
+        .toUIMessageStream<StudyUIMessage>({
+          sendReasoning: false,
+          sendFinish: false,
+          onError: (error) => String(error),
+        })
+        .pipeThrough(stripRetrievalOutputs())
+        .pipeThrough(repairQuizToolParts())
+        .pipeThrough(recoverLeakedQuiz());
+      const reader = source.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        writer.write(value);
+      }
+
+      const [, steps] = await Promise.all([primary.text, primary.steps]);
+      const closing = closeTruncatedQuizInputs(
+        partialQuizInput,
+        steps.flatMap((s) => (s.toolCalls ?? []).map((t) => t.toolCallId)),
+      );
+      for (const chunk of closing) writer.write(chunk);
+      writer.write({ type: "finish", finishReason: "length" } as never);
+    },
+  });
+
+  const out: Array<Record<string, unknown>> = [];
+  const outReader = stream.getReader();
+  for (;;) {
+    const { done, value } = await outReader.read();
+    if (done) break;
+    out.push(value as Record<string, unknown>);
+  }
+  return out;
+}
+
+describe("a quiz cut off at the token limit, end to end", () => {
+  // A handful of delta counts: the risk is the closing write overtaking chunks
+  // still sitting in transform buffers, and the tail is exactly where the cut
+  // happens, so vary how much is in flight when generation stops.
+  for (const deltaCount of [1, 3, 12, 60]) {
+    it(`resolves the skeleton after its own chunks (${deltaCount} deltas)`, async () => {
+      const out = await runCutOffTurn(deltaCount);
+      const types = out.map((c) => c.type);
+
+      const lastDelta = types.lastIndexOf("tool-input-delta");
+      const available = types.indexOf("tool-input-available");
+      const finish = types.lastIndexOf("finish");
+
+      expect(lastDelta).toBeGreaterThanOrEqual(0);
+      expect(available).toBeGreaterThan(lastDelta);
+      expect(finish).toBeGreaterThan(available);
+
+      // Nothing may follow that re-opens the part.
+      expect(types.slice(available).includes("tool-input-start")).toBe(false);
+
+      const part = out[available] as { toolCallId: string; input: unknown };
+      expect(part.toolCallId).toBe("c1");
+      expect((part.input as { questions: unknown[] }).questions).toHaveLength(
+        2,
+      );
+    });
+  }
+
+  it("keeps the prose the model wrote before the quiz", async () => {
+    const out = await runCutOffTurn(3);
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.delta)
+      .join("");
+    expect(text).toBe("Here is your quiz.");
+  });
+});

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -1,16 +1,16 @@
 import { z } from "zod";
 import { mcQuestionSchema, type MCQuestion } from "@/lib/questions";
 
-/**
- * A multiple-choice quiz rendered as an interactive widget. Used as the
- * `inputSchema` of the `showQuiz` tool, so the model fills this in directly.
- */
 /** Most questions a quiz may carry. Also the ceiling `repairQuiz` trims to. */
 export const MAX_QUIZ_QUESTIONS = 5;
 
 /** Longest quiz title. See the note on `quizSchema.quiz_title`. */
 export const MAX_QUIZ_TITLE_LENGTH = 200;
 
+/**
+ * A multiple-choice quiz rendered as an interactive widget. Used as the
+ * `inputSchema` of the `showQuiz` tool, so the model fills this in directly.
+ */
 export const quizSchema = z.object({
   // Bounded: the title is echoed into the professor dashboard, exports, and
   // (sanitized) the model results note, so an unbounded student-steerable

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -5,12 +5,18 @@ import { mcQuestionSchema, type MCQuestion } from "@/lib/questions";
  * A multiple-choice quiz rendered as an interactive widget. Used as the
  * `inputSchema` of the `showQuiz` tool, so the model fills this in directly.
  */
+/** Most questions a quiz may carry. Also the ceiling `repairQuiz` trims to. */
+export const MAX_QUIZ_QUESTIONS = 5;
+
+/** Longest quiz title. See the note on `quizSchema.quiz_title`. */
+export const MAX_QUIZ_TITLE_LENGTH = 200;
+
 export const quizSchema = z.object({
   // Bounded: the title is echoed into the professor dashboard, exports, and
   // (sanitized) the model results note, so an unbounded student-steerable
   // string is both a UI and prompt-size hazard.
-  quiz_title: z.string().min(1).max(200),
-  questions: z.array(mcQuestionSchema).min(1).max(5),
+  quiz_title: z.string().min(1).max(MAX_QUIZ_TITLE_LENGTH),
+  questions: z.array(mcQuestionSchema).min(1).max(MAX_QUIZ_QUESTIONS),
 });
 
 export type QuizQuestion = MCQuestion;
@@ -143,6 +149,92 @@ export function parseQuizFromText(text: string): Quiz | null {
     if (result.success && isRenderableQuiz(result.data)) return result.data;
   }
   return null;
+}
+
+/**
+ * Salvage a quiz from tool input the model never finished writing. A low
+ * `maxTokens` on the chatbot cuts generation off mid-JSON, which leaves either
+ * an unparseable input string or (when the args were streamed) no tool call at
+ * all -- both of which the student sees as a failure even though the questions
+ * that did arrive are perfectly good.
+ *
+ * So take the title and every question object that closed, and drop the one that
+ * was still being written. Requires the title to have arrived: it is normally
+ * the first key, and inventing one would put words in the professor's mouth.
+ */
+function salvageTruncatedQuiz(text: string): unknown | null {
+  const title = text.match(/"quiz_title"\s*:\s*("(?:[^"\\]|\\.)*")/);
+  const questionsKey = text.search(/"questions"\s*:\s*\[/);
+  if (!title?.[1] || questionsKey === -1) return null;
+
+  const questions: unknown[] = [];
+  let cursor = text.indexOf("[", questionsKey) + 1;
+  for (;;) {
+    const objectStart = text.indexOf("{", cursor);
+    if (objectStart === -1) break;
+    const object = extractBalanced(text, objectStart);
+    if (!object) break; // the question that was cut off mid-write
+    try {
+      questions.push(JSON.parse(object));
+    } catch {
+      break;
+    }
+    cursor = objectStart + object.length;
+  }
+  if (questions.length === 0) return null;
+
+  try {
+    return { quiz_title: JSON.parse(title[1]) as string, questions };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Coerce whatever the model produced into a renderable quiz, dropping the parts
+ * that can't render, or null when nothing usable is left.
+ *
+ * Tool input reaches us in three broken shapes, and all three currently show the
+ * student "Couldn't build the quiz" even when most of the quiz is fine:
+ *
+ * - more questions than the schema allows (trimmed to `MAX_QUIZ_QUESTIONS`)
+ * - individual malformed questions: missing explanation, too many options, a
+ *   `correct_index` past the last option (dropped, the rest kept)
+ * - input cut off mid-write by the token limit (see `salvageTruncatedQuiz`),
+ *   arriving either as an unparseable string or as accumulated partial text
+ *
+ * A quiz that is already valid passes through unchanged, so callers can use this
+ * as the single "can the client render this?" predicate.
+ */
+export function repairQuiz(input: unknown): Quiz | null {
+  const candidate =
+    typeof input === "string"
+      ? (jsonCandidate(input) ?? salvageTruncatedQuiz(input))
+      : input;
+  if (typeof candidate !== "object" || candidate === null) return null;
+
+  const { quiz_title: title, questions } = candidate as {
+    quiz_title?: unknown;
+    questions?: unknown;
+  };
+  if (typeof title !== "string" || title.trim().length === 0) return null;
+  if (!Array.isArray(questions)) return null;
+
+  const usable = questions
+    .filter((question) => {
+      const parsed = mcQuestionSchema.safeParse(question);
+      return (
+        parsed.success && parsed.data.correct_index < parsed.data.options.length
+      );
+    })
+    .slice(0, MAX_QUIZ_QUESTIONS);
+  if (usable.length === 0) return null;
+
+  const result = quizSchema.safeParse({
+    quiz_title: title.slice(0, MAX_QUIZ_TITLE_LENGTH),
+    questions: usable,
+  });
+  return result.success && isRenderableQuiz(result.data) ? result.data : null;
 }
 
 /** The first balanced `{...}` in `text`, JSON-parsed, or null. */

--- a/apps/web/src/server/chat/repair-quiz-parts.ts
+++ b/apps/web/src/server/chat/repair-quiz-parts.ts
@@ -4,30 +4,6 @@ import type { StudyUIMessage } from "./study-tools";
 
 type Chunk = InferUIMessageChunk<StudyUIMessage>;
 
-/**
- * Salvage a `showQuiz` tool call the AI SDK rejected, or accepted in a shape the
- * widget can't render, on its way to the browser.
- *
- * A chatbot's `maxTokens` caps the whole turn, so a low setting cuts the quiz off
- * mid-write: the input then fails validation and arrives as `tool-input-error` +
- * `tool-output-error`, which the client renders as "Couldn't build the quiz" even
- * though the questions that finished are fine. The same notice appears when the
- * model writes more questions than the schema allows or botches one question.
- *
- * `repairQuiz` keeps what can render, so those turns become a shorter quiz
- * instead of an error. Two shapes are rewritten:
- *
- * - `tool-input-error` (validation rejected the input) becomes a normal
- *   `tool-input-available` carrying the repaired quiz, and the paired
- *   `tool-output-error` is dropped so the client doesn't flip the part back to
- *   an error state.
- * - `tool-input-available` whose input is structurally valid but unrenderable
- *   (an out-of-range `correct_index`) keeps its chunk, with the repaired input.
- *
- * Input that can't be salvaged passes through untouched and still shows the
- * error notice, and `producedRenderableQuiz` reaches the same verdict from the
- * same `repairQuiz` call, so the server still runs the prose fallback for it.
- */
 /** A chunk that closes out a `showQuiz` input the model never finished. */
 export type ClosingQuizChunk =
   | {
@@ -75,6 +51,30 @@ export function closeTruncatedQuizInputs(
   return closing;
 }
 
+/**
+ * Salvage a `showQuiz` tool call the AI SDK rejected, or accepted in a shape the
+ * widget can't render, on its way to the browser.
+ *
+ * A chatbot's `maxTokens` caps the whole turn, so a low setting cuts the quiz off
+ * mid-write: the input then fails validation and arrives as `tool-input-error` +
+ * `tool-output-error`, which the client renders as "Couldn't build the quiz" even
+ * though the questions that finished are fine. The same notice appears when the
+ * model writes more questions than the schema allows or botches one question.
+ *
+ * `repairQuiz` keeps what can render, so those turns become a shorter quiz
+ * instead of an error. Two shapes are rewritten:
+ *
+ * - `tool-input-error` (validation rejected the input) becomes a normal
+ *   `tool-input-available` carrying the repaired quiz, and the paired
+ *   `tool-output-error` is dropped so the client doesn't flip the part back to
+ *   an error state.
+ * - `tool-input-available` whose input is structurally valid but unrenderable
+ *   (an out-of-range `correct_index`) keeps its chunk, with the repaired input.
+ *
+ * Input that can't be salvaged passes through untouched and still shows the
+ * error notice, and `producedRenderableQuiz` reaches the same verdict from the
+ * same `repairQuiz` call, so the server still runs the prose fallback for it.
+ */
 export function repairQuizToolParts(): TransformStream<Chunk, Chunk> {
   /** Tool call ids whose input error was replaced with a repaired quiz. */
   const repaired = new Set<string>();

--- a/apps/web/src/server/chat/repair-quiz-parts.ts
+++ b/apps/web/src/server/chat/repair-quiz-parts.ts
@@ -1,0 +1,130 @@
+import type { InferUIMessageChunk } from "ai";
+import { isRenderableQuiz, repairQuiz, type Quiz } from "@/lib/quiz";
+import type { StudyUIMessage } from "./study-tools";
+
+type Chunk = InferUIMessageChunk<StudyUIMessage>;
+
+/**
+ * Salvage a `showQuiz` tool call the AI SDK rejected, or accepted in a shape the
+ * widget can't render, on its way to the browser.
+ *
+ * A chatbot's `maxTokens` caps the whole turn, so a low setting cuts the quiz off
+ * mid-write: the input then fails validation and arrives as `tool-input-error` +
+ * `tool-output-error`, which the client renders as "Couldn't build the quiz" even
+ * though the questions that finished are fine. The same notice appears when the
+ * model writes more questions than the schema allows or botches one question.
+ *
+ * `repairQuiz` keeps what can render, so those turns become a shorter quiz
+ * instead of an error. Two shapes are rewritten:
+ *
+ * - `tool-input-error` (validation rejected the input) becomes a normal
+ *   `tool-input-available` carrying the repaired quiz, and the paired
+ *   `tool-output-error` is dropped so the client doesn't flip the part back to
+ *   an error state.
+ * - `tool-input-available` whose input is structurally valid but unrenderable
+ *   (an out-of-range `correct_index`) keeps its chunk, with the repaired input.
+ *
+ * Input that can't be salvaged passes through untouched and still shows the
+ * error notice, and `producedRenderableQuiz` reaches the same verdict from the
+ * same `repairQuiz` call, so the server still runs the prose fallback for it.
+ */
+/** A chunk that closes out a `showQuiz` input the model never finished. */
+export type ClosingQuizChunk =
+  | {
+      type: "tool-input-available";
+      toolCallId: string;
+      toolName: "showQuiz";
+      input: Quiz;
+    }
+  | { type: "tool-output-error"; toolCallId: string; errorText: string };
+
+/**
+ * Close out every `showQuiz` input that started streaming but never became a
+ * tool call, which is what the token limit cutting the model off mid-input looks
+ * like: the SDK forms no tool call (nothing lands in `steps`), while the client
+ * is left holding a part stuck in `input-streaming` -- the "Building your
+ * quiz..." skeleton -- that would spin for the rest of the session.
+ *
+ * Each one resolves to the questions that finished writing, or to an error when
+ * none did, so the skeleton always becomes either a quiz or the notice.
+ */
+export function closeTruncatedQuizInputs(
+  partialInputs: ReadonlyMap<string, string>,
+  completedToolCallIds: readonly string[],
+): ClosingQuizChunk[] {
+  const completed = new Set(completedToolCallIds);
+  const closing: ClosingQuizChunk[] = [];
+  for (const [toolCallId, partial] of partialInputs) {
+    if (completed.has(toolCallId)) continue;
+    const quiz = repairQuiz(partial);
+    closing.push(
+      quiz
+        ? {
+            type: "tool-input-available",
+            toolCallId,
+            toolName: "showQuiz",
+            input: quiz,
+          }
+        : {
+            type: "tool-output-error",
+            toolCallId,
+            errorText: "Quiz input was cut off before any question completed",
+          },
+    );
+  }
+  return closing;
+}
+
+export function repairQuizToolParts(): TransformStream<Chunk, Chunk> {
+  /** Tool call ids whose input error was replaced with a repaired quiz. */
+  const repaired = new Set<string>();
+
+  return new TransformStream<Chunk, Chunk>({
+    transform(chunk, controller) {
+      const part = chunk as {
+        type: string;
+        toolCallId?: string;
+        toolName?: string;
+        input?: unknown;
+      };
+
+      if (part.type === "tool-input-error" && part.toolName === "showQuiz") {
+        const quiz = repairQuiz(part.input);
+        if (quiz && part.toolCallId) {
+          repaired.add(part.toolCallId);
+          controller.enqueue({
+            type: "tool-input-available",
+            toolCallId: part.toolCallId,
+            toolName: "showQuiz",
+            input: quiz,
+          } as Chunk);
+          return;
+        }
+      }
+
+      // The error that follows a rejected input, for a call we just repaired.
+      if (
+        part.type === "tool-output-error" &&
+        part.toolCallId &&
+        repaired.has(part.toolCallId)
+      ) {
+        repaired.delete(part.toolCallId);
+        return;
+      }
+
+      if (
+        part.type === "tool-input-available" &&
+        part.toolName === "showQuiz" &&
+        !isRenderableQuiz(part.input as Quiz)
+      ) {
+        const quiz = repairQuiz(part.input);
+        if (quiz) {
+          controller.enqueue({ ...part, input: quiz } as Chunk);
+          return;
+        }
+      }
+
+      controller.enqueue(chunk);
+    },
+  });
+}

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -5,6 +5,7 @@ import {
   hasToolCall,
   createUIMessageStream,
   createUIMessageStreamResponse,
+  type InferUIMessageChunk,
 } from "ai";
 import { eq, and, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -96,6 +97,36 @@ export function newSessionId(): string {
  * internal timeout fires before Vercel kills the function, giving `onFinish`
  * time to persist the partial turn. */
 const STREAM_TIMEOUT_MS = 290_000;
+
+/**
+ * Forward every chunk of `source` to the response, in order, and resolve once it
+ * is drained. Chunks still stream live -- each is written the moment it arrives.
+ *
+ * This is deliberately not `writer.merge`. Merging returns immediately and lets
+ * the pump forward chunks concurrently with the rest of `execute`, so a write
+ * made after `await primary.text` can overtake chunks still in flight. That is
+ * not hypothetical: with a quiz cut off at the token limit, the tail of the
+ * stream IS that quiz's `tool-input-delta` chunks, and the closing
+ * `tool-input-available` written afterwards was observed landing *before* them,
+ * which re-opens the very "Building your quiz..." skeleton it exists to resolve.
+ * The same inversion applies to the trailing `finish` chunk that carries sources
+ * and the truncation notice. Draining here makes those writes strictly last.
+ */
+async function forward(
+  writer: { write: (chunk: InferUIMessageChunk<StudyUIMessage>) => void },
+  source: ReadableStream<InferUIMessageChunk<StudyUIMessage>>,
+): Promise<void> {
+  const reader = source.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      writer.write(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
 
 export async function streamChat(params: {
   chatbot: typeof chatbots.$inferSelect;
@@ -425,7 +456,8 @@ export async function streamChat(params: {
       // JSON blob (instead of a native showQuiz call) into a real tool part, so
       // it renders as the widget rather than raw JSON. Only quiz-shaped text is
       // buffered; ordinary answers still stream live. See recoverLeakedQuiz.
-      writer.merge(
+      await forward(
+        writer,
         modelCanUseTools
           ? primaryUiStream.pipeThrough(recoverLeakedQuiz())
           : primaryUiStream,
@@ -508,15 +540,18 @@ export async function streamChat(params: {
           maxOutputTokens,
           abortSignal,
         });
-        writer.merge(
-          fallback.toUIMessageStream<StudyUIMessage>({
-            sendReasoning: false,
-            sendStart: false,
-            sendFinish: false,
-            onError: onStreamError,
-          }),
-        );
         try {
+          // Drained rather than merged, so the trailing `finish` chunk (sources,
+          // truncation notice) cannot overtake the answer's last tokens.
+          await forward(
+            writer,
+            fallback.toUIMessageStream<StudyUIMessage>({
+              sendReasoning: false,
+              sendStart: false,
+              sendFinish: false,
+              onError: onStreamError,
+            }),
+          );
           await fallback.text;
           finishReason = await fallback.finishReason;
         } catch {

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -34,7 +34,7 @@ import { logInfo, logError, logWarn } from "@/lib/logger";
 import {
   studyTools,
   producedRenderableQuiz,
-  STUDY_TOOLS_SYSTEM_ADDENDUM,
+  buildStudyToolsAddendum,
   type StudyUIMessage,
   type StudyMessageMetadata,
 } from "./study-tools";
@@ -48,6 +48,10 @@ import {
 } from "./ui-messages";
 import { stripRetrievalOutputs } from "./stream-filter";
 import { recoverLeakedQuiz } from "./recover-quiz";
+import {
+  repairQuizToolParts,
+  closeTruncatedQuizInputs,
+} from "./repair-quiz-parts";
 import { ChatRequestError } from "./request";
 import { buildStudyResultsNote } from "@/server/study/model-note";
 
@@ -296,7 +300,9 @@ export async function streamChat(params: {
     studyResponsesByToolCallId,
   );
 
-  const studyAddendum = modelCanUseTools ? STUDY_TOOLS_SYSTEM_ADDENDUM : "";
+  const studyAddendum = modelCanUseTools
+    ? buildStudyToolsAddendum(maxOutputTokens)
+    : "";
   const primarySystemPrompt =
     (useRetrievalTools
       ? chatbot.systemPrompt +
@@ -370,6 +376,12 @@ export async function streamChat(params: {
     originalMessages: uiMessages,
     onError: onStreamError,
     execute: async ({ writer }) => {
+      // Partial `showQuiz` input, accumulated per tool call id. `maxTokens` caps
+      // the whole turn, so a low setting can cut the model off mid-input; when
+      // the args were streamed the SDK then forms no tool call at all, leaving
+      // `steps` empty, so this is the only record of what the model wrote.
+      const partialQuizInput = new Map<string, string>();
+
       // Primary turn: retrieval + study tools (or study-only / none).
       const primary = streamText({
         model: aiClient.getModel(modelId),
@@ -383,6 +395,19 @@ export async function streamChat(params: {
         temperature,
         maxOutputTokens,
         abortSignal,
+        onChunk({ chunk }) {
+          if (
+            chunk.type === "tool-input-start" &&
+            chunk.toolName === "showQuiz"
+          ) {
+            partialQuizInput.set(chunk.id, "");
+          } else if (chunk.type === "tool-input-delta") {
+            const written = partialQuizInput.get(chunk.id);
+            if (written !== undefined) {
+              partialQuizInput.set(chunk.id, written + chunk.delta);
+            }
+          }
+        },
       });
 
       const primaryUiStream = primary
@@ -391,7 +416,11 @@ export async function streamChat(params: {
           sendFinish: false,
           onError: onStreamError,
         })
-        .pipeThrough(stripRetrievalOutputs());
+        .pipeThrough(stripRetrievalOutputs())
+        // Salvage a quiz the SDK rejected (input cut off at maxTokens, too many
+        // questions, one botched question) into the questions that do render,
+        // instead of showing the student an error. See repairQuizToolParts.
+        .pipeThrough(repairQuizToolParts());
       // Study-tool-capable turns: reconstruct a quiz the model leaked as a text
       // JSON blob (instead of a native showQuiz call) into a real tool part, so
       // it renders as the widget rather than raw JSON. Only quiz-shaped text is
@@ -418,10 +447,29 @@ export async function streamChat(params: {
       const doneInput = doneCall?.input as { answer?: unknown } | undefined;
       const doneAnswer =
         typeof doneInput?.answer === "string" ? doneInput.answer : undefined;
-      // Only a schema-valid showQuiz call counts as a visible answer; an
-      // `invalid: true` call renders as an error, so it must not suppress the
+      // Only a quiz the client can render (as written, or after repair) counts
+      // as a visible answer; one that renders as an error must not suppress the
       // fallback below.
       const producedQuiz = producedRenderableQuiz(allToolCalls);
+
+      // A quiz input the token limit cut off mid-write leaves the client with a
+      // "Building your quiz..." skeleton and nothing in `steps`. Resolve every
+      // such part to the questions that finished, or to an error when none did.
+      const closing = closeTruncatedQuizInputs(
+        partialQuizInput,
+        allToolCalls.map((tc) => tc.toolCallId),
+      );
+      let salvagedTruncatedQuiz = false;
+      for (const chunk of closing) {
+        writer.write(chunk);
+        salvagedTruncatedQuiz ||= chunk.type === "tool-input-available";
+        logWarn(
+          chunk.type === "tool-input-available"
+            ? "Quiz input truncated; salvaged the completed questions"
+            : "Quiz input truncated with nothing to salvage",
+          { chatbotId: chatbot.id, modelId, maxOutputTokens },
+        );
+      }
 
       // If the model answered only through the `done` tool (no free text),
       // surface that answer as a text part so it renders and persists as text.
@@ -435,7 +483,8 @@ export async function streamChat(params: {
       const hasVisibleAnswer =
         Boolean(primaryText.trim()) ||
         Boolean(doneAnswer?.trim()) ||
-        producedQuiz;
+        producedQuiz ||
+        salvagedTruncatedQuiz;
 
       let finishReason = await primary.finishReason;
 

--- a/apps/web/src/server/chat/study-tools.ts
+++ b/apps/web/src/server/chat/study-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import type { UIMessage, InferUITools, UIDataTypes } from "ai";
-import { quizSchema, isRenderableQuiz, type Quiz } from "@/lib/quiz";
+import { quizSchema, repairQuiz, MAX_QUIZ_QUESTIONS } from "@/lib/quiz";
 
 /**
  * Render-only study tools. Each tool's `inputSchema` IS the widget payload;
@@ -20,21 +20,47 @@ export const studyTools = {
   }),
 } as const;
 
-/** Appended to the chatbot's system prompt so the model knows the tools exist. */
-export const STUDY_TOOLS_SYSTEM_ADDENDUM = `
+/** Rough output cost of one generated question: 4 options plus an explanation. */
+const TOKENS_PER_QUESTION = 150;
 
-You can render interactive study tools. When the student asks to be quizzed on a topic, call the \`showQuiz\` tool and fill it with well-formed questions based on the course material above - do not write the quiz out as prose. If the student is only asking a question, answer normally without calling a tool.`;
+/** Output tokens to leave for the quiz title and JSON scaffolding. */
+const QUIZ_OVERHEAD_TOKENS = 120;
 
 /**
- * True if the model produced a *renderable* quiz: a `showQuiz` tool call whose
- * input passed schema validation AND whose `correct_index` values are all in
- * range. When input validation fails, the AI SDK still returns the call in
- * `steps`, but flagged `invalid: true`; an out-of-range `correct_index` is
- * structurally valid (so not flagged) but still unrenderable (see
- * `isRenderableQuiz`). In both cases the client shows an error notice, not a
- * quiz, so the call must NOT count as a visible answer -- otherwise the
- * empty-response fallback is suppressed and the student is left with the error
- * and no prose answer / retry.
+ * How many questions actually fit in a turn's output budget.
+ *
+ * A chatbot's `maxTokens` caps the whole reply, tool input included, so a
+ * professor who set a small limit gets a quiz that stops mid-question: the input
+ * then fails validation and the student sees an error. The model can't know the
+ * limit, so tell it. `repairQuiz` still salvages a quiz that overruns anyway --
+ * this just stops most of them from overrunning in the first place.
+ */
+export function maxQuestionsForBudget(maxOutputTokens: number): number {
+  const affordable = Math.floor(
+    (maxOutputTokens - QUIZ_OVERHEAD_TOKENS) / TOKENS_PER_QUESTION,
+  );
+  return Math.min(MAX_QUIZ_QUESTIONS, Math.max(1, affordable));
+}
+
+/** Appended to the chatbot's system prompt so the model knows the tools exist. */
+export function buildStudyToolsAddendum(maxOutputTokens: number): string {
+  const maxQuestions = maxQuestionsForBudget(maxOutputTokens);
+  return `
+
+You can render interactive study tools. When the student asks to be quizzed on a topic, call the \`showQuiz\` tool and fill it with well-formed questions based on the course material above - do not write the quiz out as prose. Keep the quiz to at most ${maxQuestions} ${maxQuestions === 1 ? "question" : "questions"}, each with up to 4 options and a one- or two-sentence explanation, so the whole quiz fits within this chatbot's reply limit. If the student is only asking a question, answer normally without calling a tool.`;
+}
+
+/**
+ * True if a `showQuiz` call in `toolCalls` will actually render for the student,
+ * either as the model wrote it or after `repairQuiz` drops the unusable parts
+ * (too many questions, a malformed question, input cut off by the token limit).
+ *
+ * This gates the empty-response fallback, so it has to agree with what the
+ * client ends up showing: `repairQuizToolParts` runs the same pure `repairQuiz`
+ * over the same input on its way to the browser, so the two decisions cannot
+ * disagree. A call that survives neither path renders as an error notice and
+ * must NOT count as a visible answer, or the fallback is suppressed and the
+ * student is left with the error and no answer at all.
  */
 export function producedRenderableQuiz(
   toolCalls: ReadonlyArray<{
@@ -44,10 +70,7 @@ export function producedRenderableQuiz(
   }>,
 ): boolean {
   return toolCalls.some(
-    (tc) =>
-      tc.toolName === "showQuiz" &&
-      !tc.invalid &&
-      isRenderableQuiz(tc.input as Quiz),
+    (tc) => tc.toolName === "showQuiz" && repairQuiz(tc.input) !== null,
   );
 }
 


### PR DESCRIPTION
Follows #432, which is now merged. Rebased onto main, so this diff is only the salvage work.

## The problem

A chatbot's max tokens caps the whole reply, tool input included. Set it low and the quiz gets cut off mid-write, which today just fails. Reproduced both shapes with a mocked model (`ai/test`):

| Shape | What the SDK does | What the student sees today |
|---|---|---|
| Streamed args (common) | forms **no tool call at all**, `steps` is empty | "Building your quiz..." skeleton that **spins for the rest of the session** |
| Atomic args | input fails validation, `tool-input-error` | "Couldn't build the quiz. Try asking again." |

The eternal skeleton is a shipped bug independent of the token limit: any started `showQuiz` input that never completes leaves the part in `input-streaming` forever. The server can't even see it, `steps` has nothing.

## The fix: keep what renders

**`repairQuiz(input)`** takes anything the model produced (object or raw string) and returns the renderable quiz inside it, or null:

- trims past the 5-question ceiling (the runaway 10-question quiz that fails the schema outright)
- drops individual bad questions: missing explanation, too many options, out-of-range `correct_index`
- rebuilds a truncated input from the questions that finished writing, dropping the one mid-write
- requires the title and at least one surviving question, else null. It repairs, it does not invent.

**`repairQuizToolParts()`** applies it on the way to the browser: a rejected input becomes a normal `tool-input-available` (and the paired `tool-output-error` is dropped so the client doesn't flip back to an error), and an accepted-but-unrenderable input is repaired in place.

**`closeTruncatedQuizInputs()`** plus `onChunk` accumulation in `stream-chat.ts` handles the streamed case: the server buffers partial `showQuiz` input per tool call id, then resolves every id that never became a tool call, to a quiz or to an error. The invariant, with a test: no started input is ever left unresolved, so the skeleton always becomes something.

**`producedRenderableQuiz()`** now asks the same `repairQuiz` whether the student will actually see a quiz. Same pure function, same input, so the server's fallback decision cannot disagree with what the browser was sent. No shared state, no ordering race.

## Prevention

The system addendum now tells the model how many questions fit in this bot's reply limit (`maxQuestionsForBudget`: 5 at 1000+ tokens, 2 at 500, floor of 1). Most turns then never overrun. Salvage stays as the backstop.

## Notes

- The "cut off at the token limit" notice still renders under a shortened quiz, so the professor sees why it was short and can raise max tokens.
- Unsalvageable input still shows the amber notice and still gets the prose fallback. Nothing silently swallows a failure.
- 34 new tests (repair matrix, both truncation shapes, the no-dangling-part invariant, budget scaling). Full suite 713 passing, types and lint clean.

## Why not a retry

Re-running the turn with a bigger cap costs a second full generation exactly when the budget is tightest, and it would not fix the eternal skeleton, since the stale part stays on screen above the new answer. Salvage costs zero extra model calls.

## One more bug this turned up: chunk ordering

The closing chunk is written after `await primary.text`, while the part's own `tool-input-start` / `tool-input-delta` chunks travel through three transforms. `writer.merge` runs those concurrently, and at 60 deltas the closing chunk was measured landing **two positions before the last delta it closes**. The client would re-open the part as `input-streaming` and spin the exact skeleton this PR removes, and `onFinish` would persist the same corruption.

So each model stream is now drained (`forward`) rather than merged. Chunks still go out the moment they arrive, so streaming is unchanged, but every post-await write is strictly ordered after the model's own output. That also closes a latent version of the same bug on the trailing `finish` chunk, which carries the sources and the truncation notice.

The end-to-end test replicates the execute wiring over a mocked cut-off stream at 1, 3, 12, and 60 deltas. It fails against `writer.merge` and passes drained.

