### PR TITLE
fix(ci): stop building docs during tests and cache its webfonts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The docs build downloads its webfonts from fonts.gstatic.com to compute
+      # fallback metrics. Astro caches them under node_modules, which `npm ci`
+      # wipes, so every run re-fetched from Google and a rotated font URL took
+      # the whole build down. Restored after `npm ci` for that reason.
+      - name: Restore docs font cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/blume/node_modules/.astro/fonts
+            node_modules/.astro/fonts
+            apps/docs/node_modules/.astro/fonts
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('apps/docs/blume.config.ts', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Check formatting
         run: npm run format:check
 

--- a/turbo.json
+++ b/turbo.json
@@ -70,10 +70,6 @@
       "cache": false,
       "persistent": true
     },
-    "test": {
-      "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
-    },
     "db:generate": {
       "cache": false
     },


### PR DESCRIPTION
Follow-up to the release PR #431 failure. Both issues from that investigation.

## 1. `turbo.json` declared `test` twice

```jsonc
"test": { "outputs": ["coverage/**"] },          // dead — JSON keeps the last key
...
"test": { "dependsOn": ["^build"], "outputs": ["coverage/**"] }
```

JSON keeps the last occurrence, so the first block was silently dead and `dependsOn: ["^build"]` was the config actually in force.

## 2. That dependency made a Google outage able to fail the test check

`^build` builds each package's workspace dependencies. Here it resolved to exactly one thing, `docs#build`:

- `@teachanything/db`, `@teachanything/ai`, `@teachanything/logger` export TypeScript source directly and have **no build script**
- `apps/web` depends on `docs` (`docs: "*"`) for the embed-docs pipeline that serves `/docs`

So every test run built the entire docs site. The docs build downloads its webfonts from `fonts.gstatic.com` to compute fallback metrics (`optimizeFallbacks` → `CapsizeFontMetricsResolver.getMetrics` → fetch). When Google rotated the Geist files, the stale URL 404'd and failed the **test** check, twice on Aug 11, including the 1.33.5 release PR, in both cases *after* all tests had already passed.

Confirmed the mechanism directly: the URL from the failed run returns 404, while the URL Google's CSS API serves now returns 200.

## The fix

**Tests no longer build docs.** The two `test` blocks collapse into one with no `dependsOn`. Tests never touch docs, and the other three packages have nothing to build, so this removes the network dependency from the test check entirely.

**The docs build caches its fonts.** The docs site still builds in the Build workflow, where it belongs. Astro caches downloaded fonts under `node_modules` keyed by a **stable font id, not the rotating URL**, so a warm cache survives a rotation. `npm ci` wipes `node_modules`, which is why the restore step lands after install.

## Verification

- `npm run test --force` (turbo cache bypassed): 3 tasks instead of 4, `docs#build` gone, **724 tests pass** (652 web + 62 ai + 10 db)
- Deleted the font cache dir and rebuilt docs: it repopulated with byte-identical id-named files (`04dd54f8b9dc7022.woff2`, …) despite Google now serving different URLs, which is the property that makes the cache work
- `check-types`, `lint`, `test` all pass via the pre-commit hook

## Note

This makes the *test* check network-independent. The *build* check still needs fonts on a cold cache, which is legitimate for a real build; the cache is what keeps a Google hiccup from breaking it. First run after merge populates the cache.