### PR TITLE
chore(ci): move CI and engines from Node.js 20 to 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "packageManager": "npm@11.4.2",
   "engines": {
-    "node": ">=20.3"
+    "node": ">=24"
   },
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
Vercel is dropping Node.js 20 on Oct 1 (new builds fail after that). Node 20 is already EOL.

This bumps the repo's own pins:
- `.github/workflows/{test,build,release-please}.yml`: `node-version` 20 -> 24
- root `package.json` engines: `>=20.3` -> `>=24`

Type-check, lint, and all 652 tests pass locally on Node 24.14.0.

Note on Vercel: the deprecation email named the **ai-alexa** project (aialexa.org, last deployed 244 days ago), not Teach Anything. The live project `aialexa-v2-web` is already on 22.x and is not affected by the deadline. Its Node version comes from the dashboard setting, not from this repo (root directory is `apps/web`, which has no `engines` field), so bumping it to 24.x is a separate one-click change.