### PR TITLE
docs(instructors): add Choose an open-source LLM page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ teachanything/
 │   │       ├── openrouter-client.ts  # LLM client with streaming
 │   │       ├── rag-service.ts        # RAG pipeline (chunking, embeddings)
 │   │       ├── crawler.ts            # Web crawler (cheerio + Readability)
-│   │       ├── models.ts             # MODEL_REGISTRY (7 models) + EMBEDDING_MODEL
+│   │       ├── models.ts             # MODEL_REGISTRY (6 models) + EMBEDDING_MODEL
 │   │       ├── token-budget.ts       # Priority-based token allocator
 │   │       └── error-utils.ts        # Shared error helpers
 │   └── logger/                    # Shared structured logger (@teachanything/logger)
@@ -376,7 +376,7 @@ Checklist that the hook does NOT enforce — still your responsibility:
 | `packages/db/src/schema.ts`            | Complete database schema                                              |
 | `packages/ai/src/openrouter-client.ts` | LLM client with streaming                                             |
 | `packages/ai/src/rag-service.ts`       | Text extraction, chunking, embeddings                                 |
-| `packages/ai/src/models.ts`            | Centralized MODEL_REGISTRY (7 supported models + embedding config)    |
+| `packages/ai/src/models.ts`            | Centralized MODEL_REGISTRY (6 supported models + embedding config)    |
 | `packages/ai/src/crawler.ts`           | Web crawler (cheerio + Mozilla Readability + robots.txt)              |
 | `packages/ai/src/token-budget.ts`      | Priority-based token allocator                                        |
 | `packages/logger/src/index.ts`         | Shared structured logger                                              |

--- a/apps/docs/docs/instructors/choose-a-model.mdx
+++ b/apps/docs/docs/instructors/choose-a-model.mdx
@@ -1,0 +1,70 @@
+---
+title: Choose an open-source LLM
+description: Teach Anything runs on open-source LLMs. Here is what each one is good at, so you can pick the model that fits your subject.
+sidebar:
+  label: Choose an LLM
+  icon: cpu
+---
+
+Teach Anything runs entirely on **open-source large language models** — the "engines" that write your assistant's answers. You are never locked into one vendor's model, and you can switch between them at any time from your assistant's settings.
+
+Each model has its own strengths. Depending on your subject matter, you can choose a model that is best tailored to your domain and goals.
+
+## The models we offer
+
+<CardGroup cols={2}>
+  <Card title="Mistral Large 3 (France)" icon="languages">
+    Best-in-class multilingual conversation ability. Rather than relying on a
+    bolt-on translation layer, it is trained on integrated multilingual
+    datasets. It responds in the same language as the student's query.
+  </Card>
+  <Card title="GPT-OSS 120B (OpenAI)" icon="brain">
+    Strong general reasoning and good at following instructions.
+  </Card>
+  <Card title="Llama 4 Maverick (Meta)" icon="scroll-text">
+    Huge context window — best for very long documents.
+  </Card>
+  <Card title="Qwen 3 235B (Alibaba's Qwen team)" icon="sigma">
+    Suitable for STEM subjects and math.
+  </Card>
+  <Card title="Llama 3.3 70B (Meta)" icon="check">
+    A dependable all-rounder. This is our default model.
+  </Card>
+  <Card title="DeepSeek V3.2 (DeepSeek)" icon="code">
+    Excels at complex reasoning and coding.
+  </Card>
+</CardGroup>
+
+## Picking one
+
+Give each model a try. You can easily switch among them at any time, and nothing else about your assistant changes when you do — your materials, instructions, and conversations all stay put.
+
+<Steps>
+  <Step title="Open your assistant's settings">
+    From your [dashboard](https://teachanything.ai/dashboard), open the
+    assistant you want to change.
+  </Step>
+  <Step title="Pick a model from the LLM list">
+    Models are grouped by the organization that built them.
+  </Step>
+  <Step title="Ask it a few of your course's typical questions">
+    Compare the answers side by side. If the new model isn't an improvement,
+    switch back — the change takes effect right away.
+  </Step>
+</Steps>
+
+:::tip[When in doubt, stay on the default]
+Llama 3.3 70B is a well-rounded choice that works for most courses. Reach for a
+different model when you have a specific reason: teaching in a language other
+than English, working with very long documents, or covering heavy math or code.
+:::
+
+Teach Anything will continue to expand and update our offering of open-source LLMs.
+
+<Card
+  title="Next: Customize your assistant"
+  href="/instructors/customize"
+  icon="sliders"
+>
+  Tune the instructions, temperature, answer length, and source citations.
+</Card>

--- a/apps/docs/docs/instructors/choose-a-model.mdx
+++ b/apps/docs/docs/instructors/choose-a-model.mdx
@@ -13,27 +13,53 @@ Each model has its own strengths. Depending on your subject matter, you can choo
 ## The models we offer
 
 <CardGroup cols={2}>
-  <Card title="Mistral Large 3 (France)" icon="languages">
+  <Card
+    title="Mistral Large 3 (France)"
+    icon="languages"
+    href="https://mistral.ai/news/mistral-3/"
+  >
     Best-in-class multilingual conversation ability. Rather than relying on a
     bolt-on translation layer, it is trained on integrated multilingual
     datasets. It responds in the same language as the student's query.
   </Card>
-  <Card title="GPT-OSS 120B (OpenAI)" icon="brain">
+  <Card
+    title="GPT-OSS 120B (OpenAI)"
+    icon="brain"
+    href="https://openai.com/index/introducing-gpt-oss/"
+  >
     Strong general reasoning and good at following instructions.
   </Card>
-  <Card title="Llama 4 Maverick (Meta)" icon="scroll-text">
+  <Card
+    title="Llama 4 Maverick (Meta)"
+    icon="scroll-text"
+    href="https://ai.meta.com/blog/llama-4-multimodal-intelligence/"
+  >
     Huge context window — best for very long documents.
   </Card>
-  <Card title="Qwen 3 235B (Alibaba's Qwen team)" icon="sigma">
+  <Card
+    title="Qwen 3 235B (Alibaba's Qwen team)"
+    icon="sigma"
+    href="https://qwen-3.com/en"
+  >
     Suitable for STEM subjects and math.
   </Card>
-  <Card title="Llama 3.3 70B (Meta)" icon="check">
+  <Card
+    title="Llama 3.3 70B (Meta)"
+    icon="check"
+    href="https://developer.meta.com/ai/docs/model-cards-and-prompt-formats/llama3_3/"
+  >
     A dependable all-rounder. This is our default model.
   </Card>
-  <Card title="DeepSeek V3.2 (DeepSeek)" icon="code">
+  <Card
+    title="DeepSeek V3.2 (DeepSeek)"
+    icon="code"
+    href="https://api-docs.deepseek.com/news/news251201/"
+  >
     Excels at complex reasoning and coding.
   </Card>
 </CardGroup>
+
+Each card links to the model maker's own announcement if you want to read more.
 
 ## Picking one
 
@@ -58,6 +84,12 @@ Llama 3.3 70B is a well-rounded choice that works for most courses. Reach for a
 different model when you have a specific reason: teaching in a language other
 than English, working with very long documents, or covering heavy math or code.
 :::
+
+## Going deeper
+
+If you're interested, you can explore independent [technical analyses of open-source LLMs](https://artificialanalysis.ai/models/open-source), which benchmark these models side by side on quality, speed, and cost.
+
+Prof. Joubin also writes about model choice on her Substack: [More open-source LLMs to choose from](https://ajoubin.substack.com/p/more-open-source-llms-to-choose-from).
 
 Teach Anything will continue to expand and update our offering of open-source LLMs.
 

--- a/apps/docs/docs/instructors/choose-a-model.mdx
+++ b/apps/docs/docs/instructors/choose-a-model.mdx
@@ -39,7 +39,7 @@ Each model has its own strengths. Depending on your subject matter, you can choo
   <Card
     title="Qwen 3 235B (Alibaba's Qwen team)"
     icon="sigma"
-    href="https://qwen-3.com/en"
+    href="https://qwen.ai/blog?id=qwen3"
   >
     Suitable for STEM subjects and math.
   </Card>

--- a/apps/docs/docs/instructors/customize.mdx
+++ b/apps/docs/docs/instructors/customize.mdx
@@ -22,7 +22,7 @@ Rewrite the instructions whenever answers aren't landing the way you want. It's 
 
 ## Choosing a model
 
-The **LLM** is the engine that writes the answers. We offer multiple open-access
+The **LLM** is the engine that writes the answers. We offer several open-source
 LLMs, and they all work the same way from your point of view — you don't need to
 know the technical differences.
 
@@ -36,6 +36,15 @@ know the technical differences.
     It's a safe experiment — nothing else changes.
   </Card>
 </CardGroup>
+
+<Card
+  title="Choose an open-source LLM"
+  href="/instructors/choose-a-model"
+  icon="cpu"
+>
+  What each model is good at — multilingual, STEM, long documents, coding — so
+  you can match one to your subject.
+</Card>
 
 ## Temperature and max tokens
 

--- a/apps/docs/docs/instructors/index.mdx
+++ b/apps/docs/docs/instructors/index.mdx
@@ -12,6 +12,8 @@ This guide walks you through building an AI teaching assistant for your course, 
 
 Think of your assistant as a tutor who has read all of your course materials and nothing else. When a student asks a question, it looks through your files, finds the relevant parts, and writes an answer that points back to the exact source. It won't make things up from the open internet, and it will tell students where each answer came from.
 
+Every model behind that assistant is **open source**, and you choose which one your course runs on — a multilingual model, one built for STEM, one for very long documents. See [Choose an open-source LLM](/instructors/choose-a-model).
+
 <Steps>
   <Step title="Request an instructor account">
     Accounts are approved by an administrator to keep the platform limited to

--- a/apps/docs/docs/instructors/meta.ts
+++ b/apps/docs/docs/instructors/meta.ts
@@ -10,6 +10,7 @@ export default defineMeta({
     "upload-materials",
     "add-website-content",
     "attach-materials",
+    "choose-a-model",
     "customize",
     "share-and-embed",
     "review-conversations",


### PR DESCRIPTION
Requested by Prof. Joubin: open source and model choice are the main selling point, but the docs had almost nothing on it (one thin section buried in Customize).

## What's here

- **New page** `/docs/instructors/choose-a-model` — "Choose an open-source LLM", using Prof. Joubin's copy from her Substack post. Six cards, one per model, each linking to the maker's own announcement.
- **Sidebar** — slotted between Attach materials and Customize, labeled "Choose an LLM".
- **Customize page** — the existing "Choosing a model" section now links out to the full page.
- **Instructors index** — added an open-source line to "The big picture" so the selling point shows up early.
- **Further reading** — Artificial Analysis open-source leaderboard + Prof. Joubin's Substack post.
- **AGENTS.md** — stale "MODEL_REGISTRY (7 models)" corrected to 6.

## Model list verified against code

All six models match `MODEL_REGISTRY` in `packages/ai/src/models.ts` exactly — nothing to add or remove. All are tool-capable, so `ChatbotSettings.tsx` surfaces every one of them. Llama 3.3 70B confirmed as `DEFAULT_MODEL`, matching the "our default model" line.

| Docs | Registry ID |
|---|---|
| Mistral Large 3 | `mistralai/mistral-large-2512` |
| GPT-OSS 120B | `openai/gpt-oss-120b` |
| Llama 4 Maverick | `meta-llama/llama-4-maverick` |
| Qwen 3 235B | `qwen/qwen3-235b-a22b-2507` |
| Llama 3.3 70B | `meta-llama/llama-3.3-70b-instruct` (default) |
| DeepSeek V3.2 | `deepseek/deepseek-v3.2` |

## Notes

- The Qwen card links to `qwen-3.com`, which is a third-party aggregator rather than Alibaba's official page. Happy to swap it for `https://qwenlm.github.io/blog/qwen3/`.
- Docs build is clean (20 pages); type-check, lint, and tests pass.