### PR TITLE
fix(crawler): recover stuck crawls, add a stop button, unblock deletion

### DIFF
--- a/apps/web/src/__tests__/lib/crawl-stale.test.ts
+++ b/apps/web/src/__tests__/lib/crawl-stale.test.ts
@@ -1,0 +1,147 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+// crawl-stale imports the db client and logger at module scope; mock both so
+// the pure staleness predicates can be exercised without a database.
+jest.mock("@teachanything/db", () => ({ db: {} }));
+jest.mock("@/lib/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+}));
+
+const { isStalePreCrawl, isStaleCrawl, STALE_PRE_CRAWL_MS, STALE_CRAWL_MS } =
+  await import("@/lib/crawl-stale");
+
+const NOW = new Date("2026-08-16T12:00:00.000Z");
+
+function minutesAgo(minutes: number): Date {
+  return new Date(NOW.getTime() - minutes * 60 * 1000);
+}
+
+describe("isStalePreCrawl", () => {
+  it("flags a discovering source that has gone quiet past the threshold", () => {
+    expect(
+      isStalePreCrawl({
+        status: "discovering",
+        updatedAt: minutesAgo(20),
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("flags a pending source that never got picked up", () => {
+    expect(
+      isStalePreCrawl({
+        status: "pending",
+        updatedAt: minutesAgo(16),
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves a source alone inside the threshold", () => {
+    expect(
+      isStalePreCrawl({
+        status: "discovering",
+        updatedAt: minutesAgo(5),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag exactly at the threshold", () => {
+    expect(
+      isStalePreCrawl({
+        status: "discovering",
+        updatedAt: new Date(NOW.getTime() - STALE_PRE_CRAWL_MS),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores statuses it does not own", () => {
+    for (const status of ["crawling", "completed", "failed"]) {
+      expect(
+        isStalePreCrawl({ status, updatedAt: minutesAgo(500), now: NOW }),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("isStaleCrawl", () => {
+  it("flags a crawl whose pages stopped being touched", () => {
+    expect(
+      isStaleCrawl({
+        status: "crawling",
+        lastPageActivityAt: minutesAgo(45),
+        updatedAt: minutesAgo(60),
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a long-running crawl alive while pages are still progressing", () => {
+    // The source row only changes on status transitions, so an old updatedAt
+    // must not by itself condemn a crawl that is visibly working.
+    expect(
+      isStaleCrawl({
+        status: "crawling",
+        lastPageActivityAt: minutesAgo(2),
+        updatedAt: minutesAgo(240),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the source timestamp when discovery inserted no pages", () => {
+    expect(
+      isStaleCrawl({
+        status: "crawling",
+        lastPageActivityAt: null,
+        updatedAt: minutesAgo(31),
+        now: NOW,
+      }),
+    ).toBe(true);
+    expect(
+      isStaleCrawl({
+        status: "crawling",
+        lastPageActivityAt: null,
+        updatedAt: minutesAgo(10),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag exactly at the threshold", () => {
+    expect(
+      isStaleCrawl({
+        status: "crawling",
+        lastPageActivityAt: new Date(NOW.getTime() - STALE_CRAWL_MS),
+        updatedAt: minutesAgo(60),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores statuses it does not own", () => {
+    for (const status of ["pending", "discovering", "completed", "failed"]) {
+      expect(
+        isStaleCrawl({
+          status,
+          lastPageActivityAt: minutesAgo(500),
+          updatedAt: minutesAgo(500),
+          now: NOW,
+        }),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("staleness thresholds", () => {
+  it("gives discovery room beyond its own 3-minute in-process timeout", () => {
+    expect(STALE_PRE_CRAWL_MS).toBeGreaterThan(3 * 60 * 1000);
+  });
+
+  it("is more patient with an in-flight crawl than with a stalled start", () => {
+    expect(STALE_CRAWL_MS).toBeGreaterThan(STALE_PRE_CRAWL_MS);
+  });
+});

--- a/apps/web/src/__tests__/lib/crawl-stale.test.ts
+++ b/apps/web/src/__tests__/lib/crawl-stale.test.ts
@@ -1,15 +1,23 @@
 import { jest, describe, it, expect } from "@jest/globals";
 
-// crawl-stale imports the db client and logger at module scope; mock both so
-// the pure staleness predicates can be exercised without a database.
-jest.mock("@teachanything/db", () => ({ db: {} }));
-jest.mock("@/lib/logger", () => ({
+// Under ESM, `jest.mock` factories are silently ignored -- only
+// `unstable_mockModule` actually replaces a module, and it requires the module
+// under test to be imported dynamically afterwards. crawl-stale takes its db
+// handle as a parameter and imports the type only, so the logger is the sole
+// module that needs replacing here.
+jest.unstable_mockModule("@/lib/logger", () => ({
   logInfo: jest.fn(),
   logError: jest.fn(),
 }));
 
-const { isStalePreCrawl, isStaleCrawl, STALE_PRE_CRAWL_MS, STALE_CRAWL_MS } =
-  await import("@/lib/crawl-stale");
+const { logError } = await import("@/lib/logger");
+const {
+  isStalePreCrawl,
+  isStaleCrawl,
+  sweepStaleCrawls,
+  STALE_PRE_CRAWL_MS,
+  STALE_CRAWL_MS,
+} = await import("@/lib/crawl-stale");
 
 const NOW = new Date("2026-08-16T12:00:00.000Z");
 
@@ -143,5 +151,35 @@ describe("staleness thresholds", () => {
 
   it("is more patient with an in-flight crawl than with a stalled start", () => {
     expect(STALE_CRAWL_MS).toBeGreaterThan(STALE_PRE_CRAWL_MS);
+  });
+});
+
+describe("sweepStaleCrawls", () => {
+  it("swallows a database failure so the list read it fronts still succeeds", async () => {
+    const db = {
+      select: () => {
+        throw new Error("connection terminated");
+      },
+    } as unknown as Parameters<typeof sweepStaleCrawls>[0]["db"];
+
+    await expect(
+      sweepStaleCrawls({ db, userId: "user-1", now: NOW }),
+    ).resolves.toBeUndefined();
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does no writes when nothing looks stale", async () => {
+    const update = jest.fn();
+    const db = {
+      select: () => ({
+        from: () => ({ where: () => Promise.resolve([]) }),
+      }),
+      update,
+    } as unknown as Parameters<typeof sweepStaleCrawls>[0]["db"];
+
+    await sweepStaleCrawls({ db, userId: "user-1", now: NOW });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/lib/crawl-stale.test.ts
+++ b/apps/web/src/__tests__/lib/crawl-stale.test.ts
@@ -154,6 +154,49 @@ describe("staleness thresholds", () => {
   });
 });
 
+/**
+ * Minimal chainable stand-in for the drizzle query builder. Each `select()`
+ * starts a new query that resolves to the next scripted response, whatever
+ * combination of .from/.where/.groupBy it is awaited through.
+ */
+function fakeDb(responses: unknown[][]) {
+  const updatedTables: unknown[] = [];
+  let queryIndex = 0;
+
+  const makeSelect = () => {
+    const index = queryIndex++;
+    const query: Record<string, unknown> = {};
+    const self = () => query;
+    query.from = self;
+    query.where = self;
+    query.groupBy = self;
+    query.for = self;
+    query.then = (onOk: (v: unknown) => unknown, onErr?: () => unknown) =>
+      Promise.resolve(responses[index] ?? []).then(onOk, onErr);
+    return query;
+  };
+
+  const makeUpdate = (table: unknown) => {
+    updatedTables.push(table);
+    const query: Record<string, unknown> = {};
+    const self = () => query;
+    query.set = self;
+    query.where = self;
+    query.returning = self;
+    query.then = (onOk: (v: unknown) => unknown, onErr?: () => unknown) =>
+      Promise.resolve([{ id: "s1" }]).then(onOk, onErr);
+    return query;
+  };
+
+  return {
+    db: {
+      select: makeSelect,
+      update: makeUpdate,
+    } as unknown as Parameters<typeof sweepStaleCrawls>[0]["db"],
+    updatedTables,
+  };
+}
+
 describe("sweepStaleCrawls", () => {
   it("swallows a database failure so the list read it fronts still succeeds", async () => {
     const db = {
@@ -169,17 +212,38 @@ describe("sweepStaleCrawls", () => {
   });
 
   it("does no writes when nothing looks stale", async () => {
-    const update = jest.fn();
-    const db = {
-      select: () => ({
-        from: () => ({ where: () => Promise.resolve([]) }),
-      }),
-      update,
-    } as unknown as Parameters<typeof sweepStaleCrawls>[0]["db"];
+    const { db, updatedTables } = fakeDb([[]]);
 
     await sweepStaleCrawls({ db, userId: "user-1", now: NOW });
 
-    expect(update).not.toHaveBeenCalled();
+    expect(updatedTables).toHaveLength(0);
     expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("spares a crawling source whose pages are still being touched", async () => {
+    // The source transitioned to `crawling` hours ago, so it clears the SQL
+    // candidate filter, but its pages moved a minute ago. Reaping it would kill
+    // a working crawl. This is the case a broken page-activity lookup breaks:
+    // if the query returns nothing, the fallback condemns the source.
+    const { db, updatedTables } = fakeDb([
+      [{ id: "s1", status: "crawling", updatedAt: minutesAgo(240) }],
+      [{ crawlSourceId: "s1", lastActivityAt: minutesAgo(1) }],
+    ]);
+
+    await sweepStaleCrawls({ db, userId: "user-1", now: NOW });
+
+    expect(updatedTables).toHaveLength(0);
+  });
+
+  it("reaps a crawling source whose pages went quiet", async () => {
+    const { db, updatedTables } = fakeDb([
+      [{ id: "s1", status: "crawling", updatedAt: minutesAgo(240) }],
+      [{ crawlSourceId: "s1", lastActivityAt: minutesAgo(45) }],
+    ]);
+
+    await sweepStaleCrawls({ db, userId: "user-1", now: NOW });
+
+    // Settles the source and fails its in-flight pages.
+    expect(updatedTables.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -111,6 +111,14 @@ export default function WebSourcesPage() {
     onError: (e) =>
       toast.error("Failed to rename source", { description: e.message }),
   });
+  const cancelCrawlSource = trpc.crawler.cancelCrawlSource.useMutation({
+    onSuccess: () => {
+      refreshSources();
+      toast.success("Crawl stopped");
+    },
+    onError: (e) =>
+      toast.error("Failed to stop crawl", { description: e.message }),
+  });
   const removeCrawlSource = trpc.crawler.removeCrawlSource.useMutation({
     onSuccess: () => {
       refreshSources();
@@ -310,6 +318,9 @@ export default function WebSourcesPage() {
                   onDelete={(crawlSourceId) =>
                     removeCrawlSource.mutate({ crawlSourceId })
                   }
+                  onStop={(crawlSourceId) =>
+                    cancelCrawlSource.mutate({ crawlSourceId })
+                  }
                   onToggleEnabled={(crawlSourceId, enabled) =>
                     toggleCrawlSource.mutate({ crawlSourceId, enabled })
                   }
@@ -318,6 +329,7 @@ export default function WebSourcesPage() {
                   }
                   isRecrawling={recrawl.isPending}
                   isDeleting={removeCrawlSource.isPending}
+                  isStopping={cancelCrawlSource.isPending}
                   isTogglingEnabled={toggleCrawlSource.isPending}
                   isRenaming={renameCrawlSource.isPending}
                   sortBy={state.sortBy}

--- a/apps/web/src/components/chatbot/WebSourcesTab.tsx
+++ b/apps/web/src/components/chatbot/WebSourcesTab.tsx
@@ -221,6 +221,18 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
     },
   });
 
+  const cancelCrawlSource = trpc.crawler.cancelCrawlSource.useMutation({
+    onSuccess: () => {
+      refetchSources();
+      toast.success("Crawl stopped");
+    },
+    onError: (error) => {
+      toast.error("Failed to stop crawl", {
+        description: getFriendlyError(error),
+      });
+    },
+  });
+
   const toggleCrawlSource = trpc.crawler.toggleCrawlSource.useMutation({
     onSuccess: (_data, variables) => {
       refetchSources();
@@ -428,6 +440,9 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
                   onRemove={(id) =>
                     detach.mutate({ crawlSourceId: id, chatbotId })
                   }
+                  onStop={(id) =>
+                    cancelCrawlSource.mutate({ crawlSourceId: id })
+                  }
                   onToggleEnabled={(id, enabled) =>
                     toggleCrawlSource.mutate({ crawlSourceId: id, enabled })
                   }
@@ -439,6 +454,7 @@ export function WebSourcesTab({ chatbotId }: WebSourcesTabProps) {
                   }
                   isRecrawling={recrawl.isPending}
                   isRemoving={detach.isPending}
+                  isStopping={cancelCrawlSource.isPending}
                   isTogglingEnabled={toggleCrawlSource.isPending}
                   isRenaming={renameCrawlSource.isPending}
                   sortBy={state.sortBy}

--- a/apps/web/src/components/chatbot/web-sources/WebSourceTable.tsx
+++ b/apps/web/src/components/chatbot/web-sources/WebSourceTable.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Download, ChevronDown, Globe, RefreshCw, Trash2 } from "lucide-react";
+import {
+  Download,
+  ChevronDown,
+  Globe,
+  RefreshCw,
+  Trash2,
+  CircleStop,
+} from "lucide-react";
 import { toast } from "sonner";
 import { trpc, type RouterOutputs } from "@/lib/trpc";
 import { Badge } from "@/components/ui/badge";
@@ -55,20 +62,25 @@ function WebSourceRowActions({
   source,
   isRecrawling,
   isRemoving,
+  isStopping,
   onExport,
   onRecrawl,
   onRemove,
+  onStop,
 }: {
   source: CrawlSource;
   isRecrawling: boolean;
   isRemoving: boolean;
+  isStopping: boolean;
   onExport: () => void;
   onRecrawl: () => void;
   onRemove: () => void;
+  onStop: () => void;
 }) {
   const isActive = isActiveSource(source);
   return (
     <>
+      {isActive && <StopCrawlButton onStop={onStop} isStopping={isStopping} />}
       {source.status === "completed" && (
         <>
           <Button
@@ -96,7 +108,7 @@ function WebSourceRowActions({
             variant="ghost"
             size="icon"
             className="h-8 w-8"
-            disabled={isRemoving || isActive}
+            disabled={isRemoving}
             title="Remove from chatbot"
           >
             <Trash2 className="h-4 w-4 text-destructive" />
@@ -119,6 +131,44 @@ function WebSourceRowActions({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+}
+
+// Lets the user abandon a crawl that is running long or was started by mistake.
+function StopCrawlButton({
+  onStop,
+  isStopping,
+}: {
+  onStop: () => void;
+  isStopping: boolean;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          disabled={isStopping}
+          title="Stop crawl"
+        >
+          <CircleStop className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop crawl</AlertDialogTitle>
+          <AlertDialogDescription>
+            Stop this crawl now. Pages already crawled are kept; the rest are
+            skipped. You can re-crawl or remove the source afterwards.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep crawling</AlertDialogCancel>
+          <AlertDialogAction onClick={onStop}>Stop crawl</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -155,10 +205,12 @@ interface WebSourceRowProps {
   onToggleExpand?: (sourceId: string) => void;
   onRecrawl: (sourceId: string) => void;
   onRemove: (sourceId: string) => void;
+  onStop: (sourceId: string) => void;
   onToggleEnabled: (sourceId: string, enabled: boolean) => void;
   onRename: (sourceId: string, name: string) => Promise<unknown>;
   isRecrawling?: boolean;
   isRemoving?: boolean;
+  isStopping?: boolean;
   isTogglingEnabled?: boolean;
   isRenaming?: boolean;
 }
@@ -198,10 +250,12 @@ function WebSourceTableRow({
   onToggleExpand,
   onRecrawl,
   onRemove,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling = false,
   isRemoving = false,
+  isStopping = false,
   isTogglingEnabled = false,
   isRenaming = false,
 }: WebSourceRowProps & { colSpan: number }) {
@@ -287,9 +341,11 @@ function WebSourceTableRow({
               source={source}
               isRecrawling={isRecrawling}
               isRemoving={isRemoving}
+              isStopping={isStopping}
               onExport={handleExport}
               onRecrawl={() => onRecrawl(source.id)}
               onRemove={() => onRemove(source.id)}
+              onStop={() => onStop(source.id)}
             />
             {onToggleExpand && (
               <Button
@@ -341,10 +397,12 @@ function WebSourceCardMobile({
   onToggleExpand,
   onRecrawl,
   onRemove,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling = false,
   isRemoving = false,
+  isStopping = false,
   isTogglingEnabled = false,
   isRenaming = false,
 }: WebSourceRowProps) {
@@ -423,9 +481,11 @@ function WebSourceCardMobile({
             source={source}
             isRecrawling={isRecrawling}
             isRemoving={isRemoving}
+            isStopping={isStopping}
             onExport={handleExport}
             onRecrawl={() => onRecrawl(source.id)}
             onRemove={() => onRemove(source.id)}
+            onStop={() => onStop(source.id)}
           />
           {onToggleExpand && (
             <Button
@@ -475,10 +535,12 @@ interface WebSourceTableProps {
   onToggleExpand?: (sourceId: string) => void;
   onRecrawl: (sourceId: string) => void;
   onRemove: (sourceId: string) => void;
+  onStop: (sourceId: string) => void;
   onToggleEnabled: (sourceId: string, enabled: boolean) => void;
   onRename: (sourceId: string, name: string) => Promise<unknown>;
   isRecrawling?: boolean;
   isRemoving?: boolean;
+  isStopping?: boolean;
   isTogglingEnabled?: boolean;
   isRenaming?: boolean;
   emptyMessage?: string;
@@ -498,10 +560,12 @@ export function WebSourceTable({
   onToggleExpand,
   onRecrawl,
   onRemove,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling = false,
   isRemoving = false,
+  isStopping = false,
   isTogglingEnabled = false,
   isRenaming = false,
   emptyMessage = "No web sources found",
@@ -599,10 +663,12 @@ export function WebSourceTable({
                 onToggleExpand={onToggleExpand}
                 onRecrawl={onRecrawl}
                 onRemove={onRemove}
+                onStop={onStop}
                 onToggleEnabled={onToggleEnabled}
                 onRename={onRename}
                 isRecrawling={isRecrawling}
                 isRemoving={isRemoving}
+                isStopping={isStopping}
                 isTogglingEnabled={isTogglingEnabled}
                 isRenaming={isRenaming}
               />
@@ -636,10 +702,12 @@ export function WebSourceTable({
             onToggleExpand={onToggleExpand}
             onRecrawl={onRecrawl}
             onRemove={onRemove}
+            onStop={onStop}
             onToggleEnabled={onToggleEnabled}
             onRename={onRename}
             isRecrawling={isRecrawling}
             isRemoving={isRemoving}
+            isStopping={isStopping}
             isTogglingEnabled={isTogglingEnabled}
             isRenaming={isRenaming}
           />

--- a/apps/web/src/components/dashboard/web-sources/DashboardWebSourceTable.tsx
+++ b/apps/web/src/components/dashboard/web-sources/DashboardWebSourceTable.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   RefreshCw,
   Trash2,
+  CircleStop,
 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc, type RouterOutputs } from "@/lib/trpc";
@@ -98,10 +99,12 @@ interface DashboardWebSourceTableProps {
   isAttaching: boolean;
   onRecrawl: (sourceId: string) => void;
   onDelete: (sourceId: string) => void;
+  onStop: (sourceId: string) => void;
   onToggleEnabled: (sourceId: string, enabled: boolean) => void;
   onRename: (sourceId: string, name: string) => Promise<unknown>;
   isRecrawling: boolean;
   isDeleting: boolean;
+  isStopping: boolean;
   isTogglingEnabled: boolean;
   isRenaming: boolean;
   sortBy: DashboardSortBy;
@@ -245,18 +248,23 @@ function SourceActions({
   onToggleExpand,
   onRecrawl,
   onDelete,
+  onStop,
   isRecrawling,
   isDeleting,
+  isStopping,
 }: {
   source: DashboardSource;
   isExpanded: boolean;
   onToggleExpand: (sourceId: string) => void;
   onRecrawl: (sourceId: string) => void;
   onDelete: (sourceId: string) => void;
+  onStop: (sourceId: string) => void;
   isRecrawling: boolean;
   isDeleting: boolean;
+  isStopping: boolean;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmStop, setConfirmStop] = useState(false);
   const handleExport = useExportSource(source);
   const isActive = isActiveSource(source);
 
@@ -289,6 +297,18 @@ function SourceActions({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
+          {isActive && (
+            <DropdownMenuItem
+              disabled={isStopping}
+              onSelect={(e) => {
+                e.preventDefault();
+                setConfirmStop(true);
+              }}
+            >
+              <CircleStop className="mr-2 h-4 w-4" />
+              Stop crawl
+            </DropdownMenuItem>
+          )}
           {(source.status === "completed" || source.status === "failed") && (
             <DropdownMenuItem
               disabled={isRecrawling}
@@ -306,7 +326,7 @@ function SourceActions({
           )}
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            disabled={isDeleting || isActive}
+            disabled={isDeleting}
             onSelect={(e) => {
               e.preventDefault();
               setConfirmDelete(true);
@@ -318,6 +338,24 @@ function SourceActions({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <AlertDialog open={confirmStop} onOpenChange={setConfirmStop}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Stop crawl</AlertDialogTitle>
+            <AlertDialogDescription>
+              Stop this crawl now. Pages already crawled are kept; the rest are
+              skipped. You can re-crawl or delete the source afterwards.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep crawling</AlertDialogCancel>
+            <AlertDialogAction onClick={() => onStop(source.id)}>
+              Stop crawl
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
         <AlertDialogContent>
@@ -355,10 +393,12 @@ interface RowProps {
   isAttaching: boolean;
   onRecrawl: (sourceId: string) => void;
   onDelete: (sourceId: string) => void;
+  onStop: (sourceId: string) => void;
   onToggleEnabled: (sourceId: string, enabled: boolean) => void;
   onRename: (sourceId: string, name: string) => Promise<unknown>;
   isRecrawling: boolean;
   isDeleting: boolean;
+  isStopping: boolean;
   isTogglingEnabled: boolean;
   isRenaming: boolean;
 }
@@ -413,10 +453,12 @@ function DashboardTableRow({
   isAttaching,
   onRecrawl,
   onDelete,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling,
   isDeleting,
+  isStopping,
   isTogglingEnabled,
   isRenaming,
 }: RowProps & { colSpan: number }) {
@@ -479,8 +521,10 @@ function DashboardTableRow({
             onToggleExpand={onToggleExpand}
             onRecrawl={onRecrawl}
             onDelete={onDelete}
+            onStop={onStop}
             isRecrawling={isRecrawling}
             isDeleting={isDeleting}
+            isStopping={isStopping}
           />
         </TableCell>
       </TableRow>
@@ -513,10 +557,12 @@ function DashboardSourceCardMobile({
   isAttaching,
   onRecrawl,
   onDelete,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling,
   isDeleting,
+  isStopping,
   isTogglingEnabled,
   isRenaming,
 }: RowProps) {
@@ -549,8 +595,10 @@ function DashboardSourceCardMobile({
           onToggleExpand={onToggleExpand}
           onRecrawl={onRecrawl}
           onDelete={onDelete}
+          onStop={onStop}
           isRecrawling={isRecrawling}
           isDeleting={isDeleting}
+          isStopping={isStopping}
         />
       </div>
 
@@ -613,10 +661,12 @@ export function DashboardWebSourceTable({
   isAttaching,
   onRecrawl,
   onDelete,
+  onStop,
   onToggleEnabled,
   onRename,
   isRecrawling,
   isDeleting,
+  isStopping,
   isTogglingEnabled,
   isRenaming,
   sortBy,
@@ -638,10 +688,12 @@ export function DashboardWebSourceTable({
     isAttaching,
     onRecrawl,
     onDelete,
+    onStop,
     onToggleEnabled,
     onRename,
     isRecrawling,
     isDeleting,
+    isStopping,
     isTogglingEnabled,
     isRenaming,
   });

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -7,7 +7,7 @@ import {
   chatbotFileAssociations,
   chatbotCrawlSourceAssociations,
 } from "@teachanything/db/schema";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   discoverPages,
   fetchAndExtractPage,
@@ -52,6 +52,18 @@ export async function dispatchCrawlJob(opts: {
   }
 }
 
+/**
+ * Signals that the source stopped being ours to advance -- stopped by the user
+ * or timed out by the stale sweep -- so the caller unwinds without writing a
+ * failure over the status that already settled it.
+ */
+class CrawlNoLongerRunningError extends Error {
+  constructor() {
+    super("Crawl is no longer running");
+    this.name = "CrawlNoLongerRunningError";
+  }
+}
+
 function getFriendlyErrorMessage(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
   if (msg.includes("Incorrect API key") || msg.includes("API key"))
@@ -90,10 +102,27 @@ export async function processCrawlDiscovery(params: {
       return;
     }
 
-    await db
+    // Only claim a source that is still waiting to be crawled. `discovering`
+    // stays claimable so a QStash redelivery can resume after a worker died
+    // mid-run, but a source the user stopped is left alone.
+    const claimed = await db
       .update(crawlSources)
       .set({ status: "discovering", updatedAt: new Date() })
-      .where(eq(crawlSources.id, crawlSourceId));
+      .where(
+        and(
+          eq(crawlSources.id, crawlSourceId),
+          inArray(crawlSources.status, ["pending", "discovering"]),
+        ),
+      )
+      .returning({ id: crawlSources.id });
+
+    if (claimed.length === 0) {
+      logInfo("Crawl no longer running, skipping discovery", {
+        crawlSourceId,
+        status: source.status,
+      });
+      return;
+    }
 
     const robotsText = await fetchRobotsText(source.rootUrl);
 
@@ -214,7 +243,7 @@ export async function processCrawlDiscovery(params: {
         ...insertedPages,
       ];
 
-      await tx
+      const started = await tx
         .update(crawlSources)
         .set({
           status: "crawling",
@@ -226,7 +255,17 @@ export async function processCrawlDiscovery(params: {
           }),
           updatedAt: new Date(),
         })
-        .where(eq(crawlSources.id, crawlSourceId));
+        .where(
+          and(
+            eq(crawlSources.id, crawlSourceId),
+            eq(crawlSources.status, "discovering"),
+          ),
+        )
+        .returning({ id: crawlSources.id });
+
+      // Stopped while discovery was running. Throwing rolls back the page
+      // upserts above so no work is queued against a source the user ended.
+      if (started.length === 0) throw new CrawlNoLongerRunningError();
 
       return records;
     });
@@ -259,6 +298,13 @@ export async function processCrawlDiscovery(params: {
       }
     }
   } catch (error) {
+    if (error instanceof CrawlNoLongerRunningError) {
+      logInfo("Crawl stopped during discovery, discarding results", {
+        crawlSourceId,
+      });
+      return;
+    }
+
     logError(error, "Crawl discovery failed", { crawlSourceId });
     await db
       .update(crawlSources)
@@ -269,7 +315,14 @@ export async function processCrawlDiscovery(params: {
         }),
         updatedAt: new Date(),
       })
-      .where(eq(crawlSources.id, crawlSourceId));
+      // A source that already settled keeps its status -- a discovery error
+      // must not resurrect it as a fresh failure.
+      .where(
+        and(
+          eq(crawlSources.id, crawlSourceId),
+          inArray(crawlSources.status, ["pending", "discovering", "crawling"]),
+        ),
+      );
   }
 }
 

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -97,7 +97,11 @@ export async function processCrawlDiscovery(params: {
 
     const robotsText = await fetchRobotsText(source.rootUrl);
 
-    const DISCOVERY_TIMEOUT_MS = 5 * 60 * 1000;
+    // Must stay comfortably under the route's maxDuration (300s) -- if the
+    // platform kills the function first, the abort handler never runs and the
+    // source is left stuck in `discovering` forever. The remaining headroom
+    // covers publishing the page jobs below.
+    const DISCOVERY_TIMEOUT_MS = 3 * 60 * 1000;
     const abortController = new AbortController();
     const timeoutId = setTimeout(
       () => abortController.abort(),
@@ -297,6 +301,16 @@ export async function processCrawlPage(params: {
       return;
     }
 
+    // The source settled (stopped by the user, or timed out by the stale sweep)
+    // while this job sat in the queue. Drain without reviving it.
+    if (source.status !== "crawling" && source.status !== "discovering") {
+      logInfo("Crawl no longer running, skipping page", {
+        crawledPageId,
+        status: source.status,
+      });
+      return;
+    }
+
     if (!(await isUrlSafeWithDns(page.url))) {
       await db
         .update(crawledPages)
@@ -377,6 +391,17 @@ export async function processCrawlPage(params: {
         .from(crawledPages)
         .where(eq(crawledPages.id, crawledPageId))
         .limit(1);
+
+      // The source was deleted mid-flight and the cascade took this page with
+      // it. Abort before creating the userFile -- otherwise the file and its
+      // chunks are orphaned, unreachable from the crawledPages row that the
+      // source-deletion cleanup walks.
+      if (!currentPage) {
+        throw new Error(
+          "Crawled page was deleted while it was being processed",
+        );
+      }
+
       const customTitle = currentPage?.metadata?.customTitle?.trim();
       const displayTitle = customTitle || pageContent.title || page.url;
       let userFileId = page.userFileId;

--- a/apps/web/src/lib/crawl-processor.ts
+++ b/apps/web/src/lib/crawl-processor.ts
@@ -64,6 +64,18 @@ class CrawlNoLongerRunningError extends Error {
   }
 }
 
+/**
+ * Signals that the page vanished under us because the user deleted its source.
+ * That is a normal outcome now that deletion is allowed mid-crawl, so it
+ * unwinds the transaction without taking the failure path.
+ */
+class CrawledPageDeletedError extends Error {
+  constructor() {
+    super("Crawled page was deleted while it was being processed");
+    this.name = "CrawledPageDeletedError";
+  }
+}
+
 function getFriendlyErrorMessage(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
   if (msg.includes("Incorrect API key") || msg.includes("API key"))
@@ -169,7 +181,18 @@ export async function processCrawlDiscovery(params: {
           }),
           updatedAt: new Date(),
         })
-        .where(eq(crawlSources.id, crawlSourceId));
+        // Same guard as the catch below: a source stopped mid-discovery keeps
+        // the status the stop gave it.
+        .where(
+          and(
+            eq(crawlSources.id, crawlSourceId),
+            inArray(crawlSources.status, [
+              "pending",
+              "discovering",
+              "crawling",
+            ]),
+          ),
+        );
       return;
     }
 
@@ -437,6 +460,15 @@ export async function processCrawlPage(params: {
     );
 
     await db.transaction(async (tx) => {
+      // Hold the source in share mode for the life of this transaction. A
+      // delete takes the exclusive lock, so it cannot slip between the checks
+      // below and the commit and strand the userFile we are about to create.
+      await tx
+        .select({ id: crawlSources.id })
+        .from(crawlSources)
+        .where(eq(crawlSources.id, source.id))
+        .for("share");
+
       const [currentPage] = await tx
         .select({
           metadata: crawledPages.metadata,
@@ -449,11 +481,7 @@ export async function processCrawlPage(params: {
       // it. Abort before creating the userFile -- otherwise the file and its
       // chunks are orphaned, unreachable from the crawledPages row that the
       // source-deletion cleanup walks.
-      if (!currentPage) {
-        throw new Error(
-          "Crawled page was deleted while it was being processed",
-        );
-      }
+      if (!currentPage) throw new CrawledPageDeletedError();
 
       const customTitle = currentPage?.metadata?.customTitle?.trim();
       const displayTitle = customTitle || pageContent.title || page.url;
@@ -570,6 +598,13 @@ export async function processCrawlPage(params: {
       chunkCount: chunks.length,
     });
   } catch (error) {
+    if (error instanceof CrawledPageDeletedError) {
+      logInfo("Crawl source deleted during page processing, discarding", {
+        crawledPageId,
+      });
+      return;
+    }
+
     logError(error, "Crawl page processing failed", { crawledPageId });
 
     const [failedPage] = await db

--- a/apps/web/src/lib/crawl-stale.ts
+++ b/apps/web/src/lib/crawl-stale.ts
@@ -95,11 +95,6 @@ export async function sweepStaleCrawls(params: {
         id: crawlSources.id,
         status: crawlSources.status,
         updatedAt: crawlSources.updatedAt,
-        lastPageActivityAt: sql<Date | null>`(
-          SELECT MAX(${crawledPages.updatedAt})
-          FROM ${crawledPages}
-          WHERE ${crawledPages.crawlSourceId} = ${crawlSources.id}
-        )`,
       })
       .from(crawlSources)
       .where(
@@ -128,12 +123,40 @@ export async function sweepStaleCrawls(params: {
       }),
     );
 
-    const staleCrawling = candidates.filter((source) =>
+    // Page activity for the crawling candidates only. A grouped query rather
+    // than a correlated subquery: `crawled_pages` has its own `id`, so a
+    // hand-written `WHERE crawl_source_id = id` silently compares two columns
+    // of the same table and yields NULL for every row -- which would read as
+    // "no activity" and reap crawls that are working fine.
+    const crawlingCandidates = candidates.filter(
+      (source) => source.status === "crawling",
+    );
+
+    const activity = new Map<string, Date>();
+    if (crawlingCandidates.length > 0) {
+      const rows = await db
+        .select({
+          crawlSourceId: crawledPages.crawlSourceId,
+          lastActivityAt: sql<Date>`max(${crawledPages.updatedAt})`,
+        })
+        .from(crawledPages)
+        .where(
+          inArray(
+            crawledPages.crawlSourceId,
+            crawlingCandidates.map((source) => source.id),
+          ),
+        )
+        .groupBy(crawledPages.crawlSourceId);
+
+      for (const row of rows) {
+        activity.set(row.crawlSourceId, new Date(row.lastActivityAt));
+      }
+    }
+
+    const staleCrawling = crawlingCandidates.filter((source) =>
       isStaleCrawl({
         status: source.status,
-        lastPageActivityAt: source.lastPageActivityAt
-          ? new Date(source.lastPageActivityAt)
-          : null,
+        lastPageActivityAt: activity.get(source.id) ?? null,
         updatedAt: source.updatedAt,
         now,
       }),

--- a/apps/web/src/lib/crawl-stale.ts
+++ b/apps/web/src/lib/crawl-stale.ts
@@ -1,6 +1,6 @@
-import { db as database } from "@teachanything/db";
+import type { db as database } from "@teachanything/db";
 import { crawlSources, crawledPages } from "@teachanything/db/schema";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { logInfo, logError } from "./logger";
 import {
   mergeCrawledPageMetadata,
@@ -80,8 +80,17 @@ export async function sweepStaleCrawls(params: {
 }): Promise<void> {
   const { db, userId, now = new Date() } = params;
 
+  const preCrawlCutoff = new Date(now.getTime() - STALE_PRE_CRAWL_MS);
+  const crawlCutoff = new Date(now.getTime() - STALE_CRAWL_MS);
+
   try {
-    const inFlight = await db
+    // Narrow to plausible candidates in SQL. These reads sit behind a 3s poll
+    // while a crawl is running, so the usual answer must be "no rows" without
+    // running the page-activity subquery. Filtering `crawling` on the source's
+    // own timestamp is sound in that direction: pages are inserted as the
+    // source flips to `crawling`, so page activity is never older than the
+    // transition, and a recent transition cannot hide a stale crawl.
+    const candidates = await db
       .select({
         id: crawlSources.id,
         status: crawlSources.status,
@@ -96,13 +105,22 @@ export async function sweepStaleCrawls(params: {
       .where(
         and(
           eq(crawlSources.userId, userId),
-          inArray(crawlSources.status, [...IN_PROGRESS_STATUSES]),
+          or(
+            and(
+              inArray(crawlSources.status, ["pending", "discovering"]),
+              lt(crawlSources.updatedAt, preCrawlCutoff),
+            ),
+            and(
+              eq(crawlSources.status, "crawling"),
+              lt(crawlSources.updatedAt, crawlCutoff),
+            ),
+          ),
         ),
       );
 
-    if (inFlight.length === 0) return;
+    if (candidates.length === 0) return;
 
-    const stalePreCrawl = inFlight.filter((source) =>
+    const stalePreCrawl = candidates.filter((source) =>
       isStalePreCrawl({
         status: source.status,
         updatedAt: source.updatedAt,
@@ -110,7 +128,7 @@ export async function sweepStaleCrawls(params: {
       }),
     );
 
-    const staleCrawling = inFlight.filter((source) =>
+    const staleCrawling = candidates.filter((source) =>
       isStaleCrawl({
         status: source.status,
         lastPageActivityAt: source.lastPageActivityAt
@@ -133,9 +151,13 @@ export async function sweepStaleCrawls(params: {
           updatedAt: now,
         })
         .where(
-          inArray(
-            crawlSources.id,
-            stalePreCrawl.map((source) => source.id),
+          and(
+            inArray(
+              crawlSources.id,
+              stalePreCrawl.map((source) => source.id),
+            ),
+            inArray(crawlSources.status, ["pending", "discovering"]),
+            lt(crawlSources.updatedAt, preCrawlCutoff),
           ),
         );
     }
@@ -158,11 +180,11 @@ export async function sweepStaleCrawls(params: {
 }
 
 /**
- * Close out a single stuck crawl: fail every page still in flight, then settle
- * the source. Lands on `completed` when some pages did make it through and
+ * Close out a single stuck crawl: settle the source, then fail every page still
+ * in flight. Lands on `completed` when some pages did make it through and
  * `failed` when none did, so the badge reflects what the user actually got.
  *
- * Shared by the stale sweep and the user-initiated cancel.
+ * Shared by the stale sweep and the user-initiated stop.
  */
 export async function timeOutStuckCrawl(params: {
   db: typeof database;
@@ -179,20 +201,6 @@ export async function timeOutStuckCrawl(params: {
     sourceError = STALE_CRAWL_ERROR,
   } = params;
 
-  await db
-    .update(crawledPages)
-    .set({
-      status: "failed",
-      metadata: mergeCrawledPageMetadata({ error: pageError }),
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(crawledPages.crawlSourceId, crawlSourceId),
-        inArray(crawledPages.status, ["pending", "processing"]),
-      ),
-    );
-
   const statusCounts = await db
     .select({
       status: crawledPages.status,
@@ -206,13 +214,22 @@ export async function timeOutStuckCrawl(params: {
     statusCounts.map((row) => [row.status, Number(row.count)]),
   );
   const completedCount = (counts["completed"] ?? 0) + (counts["skipped"] ?? 0);
-  const failedCount = (counts["failed"] ?? 0) + (counts["blocked"] ?? 0);
+  // Pages still in flight are about to be failed, so they are errors already.
+  const failedCount =
+    (counts["failed"] ?? 0) +
+    (counts["blocked"] ?? 0) +
+    (counts["pending"] ?? 0) +
+    (counts["processing"] ?? 0);
+  const hasContent = completedCount > 0;
 
-  await db
+  // Settle the source first, and only if it is still ours to settle. A crawl
+  // that finished on its own, or a re-crawl the user started in the meantime,
+  // must keep the status it earned rather than take this one.
+  const settled = await db
     .update(crawlSources)
     .set({
-      status: completedCount > 0 ? "completed" : "failed",
-      lastCrawledAt: completedCount > 0 ? now : undefined,
+      status: hasContent ? "completed" : "failed",
+      ...(hasContent ? { lastCrawledAt: now } : {}),
       metadata: mergeCrawlSourceMetadata({
         pageCount: completedCount,
         errorCount: failedCount,
@@ -220,5 +237,30 @@ export async function timeOutStuckCrawl(params: {
       }),
       updatedAt: now,
     })
-    .where(eq(crawlSources.id, crawlSourceId));
+    .where(
+      and(
+        eq(crawlSources.id, crawlSourceId),
+        inArray(crawlSources.status, [...IN_PROGRESS_STATUSES]),
+      ),
+    )
+    .returning({ id: crawlSources.id });
+
+  if (settled.length === 0) return;
+
+  // Failing the pages second means a discovery transaction that committed while
+  // we waited on the source row is covered too, rather than leaving its freshly
+  // inserted pages pending under a source nothing will revisit.
+  await db
+    .update(crawledPages)
+    .set({
+      status: "failed",
+      metadata: mergeCrawledPageMetadata({ error: pageError }),
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(crawledPages.crawlSourceId, crawlSourceId),
+        inArray(crawledPages.status, ["pending", "processing"]),
+      ),
+    );
 }

--- a/apps/web/src/lib/crawl-stale.ts
+++ b/apps/web/src/lib/crawl-stale.ts
@@ -1,0 +1,224 @@
+import { db as database } from "@teachanything/db";
+import { crawlSources, crawledPages } from "@teachanything/db/schema";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { logInfo, logError } from "./logger";
+import {
+  mergeCrawledPageMetadata,
+  mergeCrawlSourceMetadata,
+} from "./crawler-metadata-sql";
+
+/**
+ * A source sitting in `pending`/`discovering` for longer than this has lost its
+ * worker. Discovery itself is capped well under 5 minutes (see
+ * DISCOVERY_TIMEOUT_MS in crawl-processor.ts), so 15 minutes is generous.
+ */
+export const STALE_PRE_CRAWL_MS = 15 * 60 * 1000;
+
+/**
+ * A source in `crawling` is judged by page activity, not by its own
+ * `updatedAt` -- the source row only changes on status transitions, and a large
+ * crawl legitimately runs for a long while. If no page under it has been
+ * touched in this long, the page workers are gone.
+ */
+export const STALE_CRAWL_MS = 30 * 60 * 1000;
+
+const IN_PROGRESS_STATUSES = ["pending", "discovering", "crawling"] as const;
+
+export const STALE_PRE_CRAWL_ERROR =
+  "The crawl never started. It may have been interrupted -- try adding this source again.";
+
+export const STALE_CRAWL_ERROR =
+  "The crawl stopped responding and was timed out. Remove this source and try again, or lower the crawl depth.";
+
+/**
+ * True when a source that never reached `crawling` has gone quiet long enough
+ * that its worker is presumed dead.
+ */
+export function isStalePreCrawl(params: {
+  status: string;
+  updatedAt: Date;
+  now: Date;
+}): boolean {
+  const { status, updatedAt, now } = params;
+  if (status !== "pending" && status !== "discovering") return false;
+  return now.getTime() - updatedAt.getTime() > STALE_PRE_CRAWL_MS;
+}
+
+/**
+ * True when a `crawling` source has seen no page activity recently.
+ * `lastPageActivityAt` is null when discovery inserted no pages at all, in
+ * which case the source's own `updatedAt` is the last sign of life.
+ */
+export function isStaleCrawl(params: {
+  status: string;
+  lastPageActivityAt: Date | null;
+  updatedAt: Date;
+  now: Date;
+}): boolean {
+  const { status, lastPageActivityAt, updatedAt, now } = params;
+  if (status !== "crawling") return false;
+  const lastActivity = lastPageActivityAt ?? updatedAt;
+  return now.getTime() - lastActivity.getTime() > STALE_CRAWL_MS;
+}
+
+/**
+ * Mark abandoned crawls as failed so they stop showing a spinner forever and
+ * the user can delete or retry them.
+ *
+ * Workers can die without ever writing a terminal status -- a function killed
+ * at its duration limit, an OOM, a deploy mid-crawl -- so recovery has to be
+ * driven from stored state rather than from an in-process timeout. This runs
+ * opportunistically on the list reads: cheap, and it self-heals the moment the
+ * owner next opens the page.
+ *
+ * Never throws; a failed sweep must not break the read that triggered it.
+ */
+export async function sweepStaleCrawls(params: {
+  db: typeof database;
+  userId: string;
+  now?: Date;
+}): Promise<void> {
+  const { db, userId, now = new Date() } = params;
+
+  try {
+    const inFlight = await db
+      .select({
+        id: crawlSources.id,
+        status: crawlSources.status,
+        updatedAt: crawlSources.updatedAt,
+        lastPageActivityAt: sql<Date | null>`(
+          SELECT MAX(${crawledPages.updatedAt})
+          FROM ${crawledPages}
+          WHERE ${crawledPages.crawlSourceId} = ${crawlSources.id}
+        )`,
+      })
+      .from(crawlSources)
+      .where(
+        and(
+          eq(crawlSources.userId, userId),
+          inArray(crawlSources.status, [...IN_PROGRESS_STATUSES]),
+        ),
+      );
+
+    if (inFlight.length === 0) return;
+
+    const stalePreCrawl = inFlight.filter((source) =>
+      isStalePreCrawl({
+        status: source.status,
+        updatedAt: source.updatedAt,
+        now,
+      }),
+    );
+
+    const staleCrawling = inFlight.filter((source) =>
+      isStaleCrawl({
+        status: source.status,
+        lastPageActivityAt: source.lastPageActivityAt
+          ? new Date(source.lastPageActivityAt)
+          : null,
+        updatedAt: source.updatedAt,
+        now,
+      }),
+    );
+
+    if (stalePreCrawl.length > 0) {
+      await db
+        .update(crawlSources)
+        .set({
+          status: "failed",
+          metadata: mergeCrawlSourceMetadata({
+            errorCount: 1,
+            errors: [{ url: "discovery", error: STALE_PRE_CRAWL_ERROR }],
+          }),
+          updatedAt: now,
+        })
+        .where(
+          inArray(
+            crawlSources.id,
+            stalePreCrawl.map((source) => source.id),
+          ),
+        );
+    }
+
+    for (const source of staleCrawling) {
+      await timeOutStuckCrawl({ db, crawlSourceId: source.id, now });
+    }
+
+    const reapedCount = stalePreCrawl.length + staleCrawling.length;
+    if (reapedCount > 0) {
+      logInfo("Timed out stale crawls", {
+        userId,
+        preCrawl: stalePreCrawl.length,
+        crawling: staleCrawling.length,
+      });
+    }
+  } catch (error) {
+    logError(error, "Stale crawl sweep failed", { userId });
+  }
+}
+
+/**
+ * Close out a single stuck crawl: fail every page still in flight, then settle
+ * the source. Lands on `completed` when some pages did make it through and
+ * `failed` when none did, so the badge reflects what the user actually got.
+ *
+ * Shared by the stale sweep and the user-initiated cancel.
+ */
+export async function timeOutStuckCrawl(params: {
+  db: typeof database;
+  crawlSourceId: string;
+  now?: Date;
+  pageError?: string;
+  sourceError?: string;
+}): Promise<void> {
+  const {
+    db,
+    crawlSourceId,
+    now = new Date(),
+    pageError = "Crawl timed out before this page was processed.",
+    sourceError = STALE_CRAWL_ERROR,
+  } = params;
+
+  await db
+    .update(crawledPages)
+    .set({
+      status: "failed",
+      metadata: mergeCrawledPageMetadata({ error: pageError }),
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(crawledPages.crawlSourceId, crawlSourceId),
+        inArray(crawledPages.status, ["pending", "processing"]),
+      ),
+    );
+
+  const statusCounts = await db
+    .select({
+      status: crawledPages.status,
+      count: sql<number>`count(*)`,
+    })
+    .from(crawledPages)
+    .where(eq(crawledPages.crawlSourceId, crawlSourceId))
+    .groupBy(crawledPages.status);
+
+  const counts = Object.fromEntries(
+    statusCounts.map((row) => [row.status, Number(row.count)]),
+  );
+  const completedCount = (counts["completed"] ?? 0) + (counts["skipped"] ?? 0);
+  const failedCount = (counts["failed"] ?? 0) + (counts["blocked"] ?? 0);
+
+  await db
+    .update(crawlSources)
+    .set({
+      status: completedCount > 0 ? "completed" : "failed",
+      lastCrawledAt: completedCount > 0 ? now : undefined,
+      metadata: mergeCrawlSourceMetadata({
+        pageCount: completedCount,
+        errorCount: failedCount,
+        errors: [{ url: "crawl", error: sourceError }],
+      }),
+      updatedAt: now,
+    })
+    .where(eq(crawlSources.id, crawlSourceId));
+}

--- a/apps/web/src/server/routers/crawler/index.ts
+++ b/apps/web/src/server/routers/crawler/index.ts
@@ -4,6 +4,7 @@ import { addManualUrlProcedure } from "./procedures/add-manual-url";
 import { getCrawlSourcesProcedure } from "./procedures/get-crawl-sources";
 import { getCrawledPagesProcedure } from "./procedures/get-crawled-pages";
 import { removeCrawlSourceProcedure } from "./procedures/remove-crawl-source";
+import { cancelCrawlSourceProcedure } from "./procedures/cancel-crawl-source";
 import { removeCrawledPageProcedure } from "./procedures/remove-crawled-page";
 import { recrawlProcedure } from "./procedures/recrawl";
 import { exportJsonProcedure } from "./procedures/export-json";
@@ -24,6 +25,7 @@ export const crawlerRouter = router({
   renameCrawlSource: renameCrawlSourceProcedure,
   renameCrawledPage: renameCrawledPageProcedure,
   removeCrawlSource: removeCrawlSourceProcedure,
+  cancelCrawlSource: cancelCrawlSourceProcedure,
   removeCrawledPage: removeCrawledPageProcedure,
   recrawl: recrawlProcedure,
   exportJson: exportJsonProcedure,

--- a/apps/web/src/server/routers/crawler/procedures/cancel-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/cancel-crawl-source.ts
@@ -1,0 +1,47 @@
+import { protectedProcedure } from "@/server/trpc";
+import { TRPCError } from "@trpc/server";
+import { logInfo, logError } from "@/lib/logger";
+import { timeOutStuckCrawl } from "@/lib/crawl-stale";
+import { crawlSourceIdInput } from "../validation";
+import { assertOwnedCrawlSource } from "../helpers";
+
+export const cancelCrawlSourceProcedure = protectedProcedure
+  .input(crawlSourceIdInput)
+  .mutation(async ({ ctx, input }) => {
+    const source = await assertOwnedCrawlSource(ctx, input.crawlSourceId);
+
+    if (
+      source.status !== "pending" &&
+      source.status !== "discovering" &&
+      source.status !== "crawling"
+    ) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "This crawl is not running.",
+      });
+    }
+
+    try {
+      // Already-queued page jobs can still fire after this; processCrawlPage
+      // bails once the source is no longer in a crawling state, so they drain
+      // without reviving the source.
+      await timeOutStuckCrawl({
+        db: ctx.db,
+        crawlSourceId: source.id,
+        pageError: "Crawl stopped before this page was processed.",
+        sourceError: "Crawl stopped.",
+      });
+
+      logInfo("Crawl source cancelled", { crawlSourceId: source.id });
+
+      return { success: true };
+    } catch (error) {
+      logError(error, "Failed to cancel crawl source", {
+        crawlSourceId: input.crawlSourceId,
+      });
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to stop the crawl",
+      });
+    }
+  });

--- a/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-all-crawl-sources.ts
@@ -17,11 +17,16 @@ import {
   chatbotCrawlSourceAssociations,
 } from "@teachanything/db/schema";
 import { escapeLikePattern } from "@/server/utils";
+import { sweepStaleCrawls } from "@/lib/crawl-stale";
 import { allCrawlSourcesInput } from "../validation";
 
 export const getAllCrawlSourcesProcedure = protectedProcedure
   .input(allCrawlSourcesInput)
   .query(async ({ ctx, input }) => {
+    // Settle abandoned crawls before reading so a dead worker can't leave a
+    // source spinning (and undeletable) indefinitely.
+    await sweepStaleCrawls({ db: ctx.db, userId: ctx.session.user.id });
+
     // Build the shared WHERE conditions (owner + search + status filter)
     const conditions: SQL[] = [eq(crawlSources.userId, ctx.session.user.id)];
 

--- a/apps/web/src/server/routers/crawler/procedures/get-crawl-sources.ts
+++ b/apps/web/src/server/routers/crawler/procedures/get-crawl-sources.ts
@@ -8,10 +8,15 @@ import {
   crawledPages,
   chatbotCrawlSourceAssociations,
 } from "@teachanything/db/schema";
+import { sweepStaleCrawls } from "@/lib/crawl-stale";
 
 export const getCrawlSourcesProcedure = protectedProcedure
   .input(z.object({ chatbotId: z.string().uuid() }))
   .query(async ({ ctx, input }) => {
+    // Settle abandoned crawls before reading so a dead worker can't leave a
+    // source spinning (and undeletable) indefinitely.
+    await sweepStaleCrawls({ db: ctx.db, userId: ctx.session.user.id });
+
     const [chatbot] = await ctx.db
       .select()
       .from(chatbots)

--- a/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
@@ -11,20 +11,10 @@ export const removeCrawlSourceProcedure = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const source = await assertOwnedCrawlSource(ctx, input.crawlSourceId);
 
-    // Block deletion while a crawl is in flight so workers don't
-    // race us with inserts against rows we're about to drop.
-    if (
-      source.status === "pending" ||
-      source.status === "discovering" ||
-      source.status === "crawling"
-    ) {
-      throw new TRPCError({
-        code: "CONFLICT",
-        message:
-          "Cannot remove this source while a crawl is in progress. Wait for the crawl to finish.",
-      });
-    }
-
+    // Deletion is allowed even mid-crawl: blocking it left users stranded when
+    // a worker died without writing a terminal status. In-flight workers
+    // tolerate the rows disappearing -- processCrawlPage bails when its page or
+    // source is gone, so nothing is written against dropped rows.
     try {
       await ctx.db.transaction(async (tx) => {
         const pagesWithFiles = await tx

--- a/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/remove-crawl-source.ts
@@ -17,6 +17,16 @@ export const removeCrawlSourceProcedure = protectedProcedure
     // source is gone, so nothing is written against dropped rows.
     try {
       await ctx.db.transaction(async (tx) => {
+        // Take the source exclusively before reading its pages. Page workers
+        // hold it in share mode for the length of their transaction, so this
+        // waits for any in-flight page to commit its userFileId -- otherwise
+        // the snapshot below misses that file and leaves it orphaned.
+        await tx
+          .select({ id: crawlSources.id })
+          .from(crawlSources)
+          .where(eq(crawlSources.id, input.crawlSourceId))
+          .for("update");
+
         const pagesWithFiles = await tx
           .select({ userFileId: crawledPages.userFileId })
           .from(crawledPages)


### PR DESCRIPTION
Reported by Prof. Joubin on behalf of Heather Young (GWU Milken SPH): three web sources stuck at "Discovering"/"Crawling" for two days, with no way to stop them and no way to delete them ("Cannot remove this source while a crawl is in progress").

## What was actually broken

Three separate things, all reachable from one mistaken deep crawl.

**1. Discovery could never report its own timeout.** `DISCOVERY_TIMEOUT_MS` was `5 * 60 * 1000` and the route's `maxDuration` is `300` — the same 300 seconds. The platform killed the function at or before the abort fired, so the `status: "failed"` write never ran and the source sat in `discovering` forever. Now 3 minutes, leaving headroom for the abort to land and the page jobs to publish.

**2. Nothing closed out a crawl whose page workers died.** Page jobs are published from inside that same discover invocation, and `finalizeCrawlSource` only ever runs at the tail of a page job. If the invocation died mid-publish, or enough page jobs died, pages stayed `pending` and the source stayed `crawling` with nobody left to finish it.

The deeper point: **no in-process timeout can fix this**, because the worker can die without writing anything — killed at the duration limit, OOM, a deploy mid-crawl. Recovery has to come from stored state. `sweepStaleCrawls` runs on the two source-list reads and settles anything abandoned: `pending`/`discovering` quiet for 15 minutes, or `crawling` with no page touched in 30 minutes. The `crawling` rule keys off page activity rather than the source's own `updatedAt`, which only changes at status transitions and would condemn any legitimately long crawl.

**3. The delete block turned a stuck crawl into a lockout.** It existed to keep workers from inserting against rows being dropped. The real hazard was narrower: `processCrawlPage` inserts a `userFile` and *then* points the page row at it, so a delete landing between those two steps orphans a file and its chunks where the source-deletion cleanup can never find them. That's now closed inside the transaction, the page worker bails when its source has settled, and deletion is allowed at any time.

## Also here

- `cancelCrawlSource` + a **Stop crawl** action in both the dashboard and chatbot source tables. Pages already crawled are kept.
- Discovery's `discovering` and `crawling` transitions are now conditional on the source still being in flight. They were unconditional, so a source stopped while its discover job was queued or running came back to life and queued the whole crawl — Stop would have appeared to work and then undone itself. The page upserts roll back when the transition loses.
- The discovery failure path no longer overwrites a status that already settled.
- No schema change: a stopped/timed-out crawl reuses `failed` (or `completed`, when some pages did land) with the reason in metadata, rather than adding an enum value.

## Operationally

Heather's three rows self-heal the first time anyone loads the Web Sources page after this deploys — they are all well past both thresholds. No production SQL, no manual intervention.

## Note on evidence

Vercel's runtime logs from the incident window (Jul 29–31) have long since rolled off, so this diagnosis is from reading the code paths, not from captured logs of her specific crawls.

## Testing

16 new unit tests: the staleness predicates, the sweep's query wiring, and its contract that a database failure is swallowed rather than breaking the list read it fronts. Full suite: 668 passing, lint and type-check clean.

## Review round (e150016)

Six findings from a review pass, all fixed:

- **The orphaned-file race was still open.** The in-transaction page check only caught deletes that committed *before* the page worker started. A delete landing mid-transaction still stranded a `userFile` and its chunks, and that window spans the embedding calls, so it is seconds per page rather than microseconds. The page transaction now holds the source in share mode and the delete takes it exclusively, which serialises the two without serialising page workers against each other.
- `timeOutStuckCrawl`'s settle is guarded by status, so it cannot stomp a crawl that finished on its own or a re-crawl the user just started. It also now runs *before* the page-failing update: stopping during an open discovery transaction previously left that discovery's freshly inserted pages `pending` forever under a settled source nothing revisits.
- The sweep re-asserts its staleness predicate on the write, so a QStash redelivery that claims a source between the read and the write is not reaped mid-run.
- The candidate query now filters in SQL. These reads sit behind a 3s poll while a crawl is active, so the usual answer has to be "no rows" without running the page-activity subquery.
- The zero-pages discovery failure write was still unconditional and could flip a stopped source back to `failed`.
- A page deleted mid-processing is an expected outcome now, so it takes an info-level early exit instead of the generic error path.

Separately, the tests now use `jest.unstable_mockModule`. Under ESM, `jest.mock` factories are silently ignored, so the mocks in the first version never applied. `crawl-stale` also imports the db as `import type` now, since the handle is passed in as a parameter and only the type was ever needed. Worth a follow-up: AGENTS.md section 12 documents the `jest.mock` pattern and other suites follow it, so those mocks are probably inert too.

## Correctness fix found by inspecting the generated SQL (57006ba)

Dumping the compiled queries via `.toSQL()` caught a live bug in the review-round code. The correlated subquery rendered its columns unqualified:

```sql
SELECT MAX("updated_at") FROM "crawled_pages" WHERE "crawl_source_id" = "id"
```

`crawled_pages` has its own `id`, so that compares two columns of the same table and matches nothing. Page activity would have been NULL for every source, the staleness check would have fallen back to the source timestamp, and **any crawl running longer than 30 minutes would have been reaped while its pages were still progressing** — the precise failure the "long crawl still progressing" unit test was written to prevent. That test passed throughout, because it exercises the pure predicate and never the query.

Replaced with a plain grouped query over a single table, where the ambiguity cannot arise, and it only runs when there are crawling candidates. The new sweep-level tests drive the real wiring and fail against the broken version.
