### PR TITLE
fix(quiz): accept the answer field models actually emit, and tell the model what was missed

### DIFF
--- a/apps/web/src/__tests__/lib/answer-aliases.test.ts
+++ b/apps/web/src/__tests__/lib/answer-aliases.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "@jest/globals";
+import { coerceCorrectIndex } from "@/lib/questions";
+import { repairQuiz } from "@/lib/quiz";
+
+const OPTIONS = ["Alpha", "Bravo", "Charlie", "Delta"];
+const base = { question: "Q?", options: OPTIONS, explanation: "because" };
+
+const indexOf = (question: unknown) =>
+  (question as { correct_index?: unknown }).correct_index;
+
+/**
+ * Measured against the live model registry on 2026-08-17: GPT-OSS 120B never
+ * emits `correct_index`, substituting `answer`, `correct_option`, or
+ * `correct_option_index`. Every other field is correct, so the quiz is fine and
+ * only the answer key is named wrong.
+ */
+describe("coerceCorrectIndex", () => {
+  it("leaves a question that already has correct_index alone", () => {
+    const q = { ...base, correct_index: 2 };
+    expect(coerceCorrectIndex(q)).toBe(q);
+  });
+
+  it("resolves a letter answer (the shape GPT-OSS emits most)", () => {
+    expect(indexOf(coerceCorrectIndex({ ...base, answer: "B" }))).toBe(1);
+    expect(indexOf(coerceCorrectIndex({ ...base, answer: "C)" }))).toBe(2);
+    expect(indexOf(coerceCorrectIndex({ ...base, answer: "(D)" }))).toBe(3);
+    expect(indexOf(coerceCorrectIndex({ ...base, answer: "a." }))).toBe(0);
+  });
+
+  it("resolves an answer that repeats the option text", () => {
+    expect(
+      indexOf(coerceCorrectIndex({ ...base, correct_option: "Charlie" })),
+    ).toBe(2);
+    expect(
+      indexOf(coerceCorrectIndex({ ...base, correct_answer: " Bravo " })),
+    ).toBe(1);
+  });
+
+  it("resolves a numeric alias as the 0-based index the schema asked for", () => {
+    expect(
+      indexOf(coerceCorrectIndex({ ...base, correct_option_index: 1 })),
+    ).toBe(1);
+    expect(indexOf(coerceCorrectIndex({ ...base, answer_index: "3" }))).toBe(3);
+  });
+
+  it("reads a number equal to the option count as 1-based", () => {
+    // 4 options, so index 4 cannot be 0-based; the only coherent reading is the
+    // 4th option. Any in-range value stays 0-based.
+    expect(indexOf(coerceCorrectIndex({ ...base, answer_index: 4 }))).toBe(3);
+  });
+
+  it("prefers exact option text over a letter reading", () => {
+    // Options that are themselves labelled: "B" must not beat an exact match.
+    const labelled = ["A) one", "B) two", "C) three"];
+    expect(
+      indexOf(
+        coerceCorrectIndex({
+          ...base,
+          options: labelled,
+          answer: "C) three",
+        }),
+      ),
+    ).toBe(2);
+  });
+
+  it("leaves the question unchanged when nothing resolves", () => {
+    const vague = { ...base, answer: "the second one" };
+    expect(indexOf(coerceCorrectIndex(vague))).toBeUndefined();
+    expect(
+      indexOf(coerceCorrectIndex({ ...base, answer: "Z" })),
+    ).toBeUndefined();
+    expect(coerceCorrectIndex(null)).toBeNull();
+    expect(coerceCorrectIndex("nope")).toBe("nope");
+  });
+});
+
+describe("repairQuiz with a mis-named answer field", () => {
+  it("repairs the exact payload GPT-OSS 120B produced in production", () => {
+    const raw = {
+      quiz_title: "The Tempest & Disability Theory",
+      questions: [
+        {
+          question: "Caliban is often read through a disability lens as?",
+          options: [
+            "A) The noble savage whose body is merely different",
+            "B) A physically disabled 'other' whose marginalization reflects societal attitudes",
+            "C) A purely comic character",
+            "D) A symbol of pure evil",
+          ],
+          answer: "B",
+          explanation: "Disability scholars read Caliban's otherness this way.",
+        },
+        {
+          question: "The social model of disability argues that:",
+          options: [
+            "Disability is purely medical.",
+            "Societal barriers, not impairments, disable people.",
+          ],
+          correct_option: "Societal barriers, not impairments, disable people.",
+          explanation: "That is the social model.",
+        },
+      ],
+    };
+    const repaired = repairQuiz(raw);
+    expect(repaired?.questions.map((q) => q.correct_index)).toEqual([1, 1]);
+    expect(repaired?.quiz_title).toBe("The Tempest & Disability Theory");
+  });
+
+  it("still drops a question whose answer field cannot be resolved", () => {
+    const repaired = repairQuiz({
+      quiz_title: "T",
+      questions: [
+        { ...base, answer: "somewhere in the middle" },
+        { ...base, answer: "A" },
+      ],
+    });
+    expect(repaired?.questions).toHaveLength(1);
+    expect(repaired?.questions[0]?.correct_index).toBe(0);
+  });
+});

--- a/apps/web/src/__tests__/server/study/handlers.test.ts
+++ b/apps/web/src/__tests__/server/study/handlers.test.ts
@@ -101,3 +101,89 @@ describe("showQuiz handler labels + summaries (model note inputs)", () => {
     );
   });
 });
+
+describe("showQuiz handler.summarizeResponseForModel (detailed)", () => {
+  const handler = STUDY_TOOL_HANDLERS.showQuiz!;
+  const quiz = {
+    quiz_title: "T",
+    questions: [
+      {
+        question: "First question?",
+        options: ["right", "wrong"],
+        correct_index: 0,
+        explanation: "x",
+      },
+      {
+        question: "Second question?",
+        options: ["nope", "yes"],
+        correct_index: 1,
+        explanation: "x",
+      },
+    ],
+  };
+
+  it("names what the student got wrong, so the model can review it", () => {
+    const summary = handler.summarizeResponseForModel(
+      { score: 1, total: 2, answers: [1, 1] },
+      quiz,
+      true,
+    );
+    expect(summary).toContain("scored 1/2");
+    expect(summary).toContain("First question?");
+    expect(summary).toContain('they chose "wrong"');
+    expect(summary).toContain('correct was "right"');
+    // The question they got right is not echoed: it needs no remediation.
+    expect(summary).not.toContain("Second question?");
+  });
+
+  it("stays score-only when nothing was missed", () => {
+    expect(
+      handler.summarizeResponseForModel(
+        { score: 2, total: 2, answers: [0, 1] },
+        quiz,
+        true,
+      ),
+    ).toBe("scored 2/2");
+  });
+
+  it("stays score-only when detail is not requested", () => {
+    expect(
+      handler.summarizeResponseForModel(
+        { score: 0, total: 2, answers: [1, 0] },
+        quiz,
+        false,
+      ),
+    ).toBe("scored 0/2");
+  });
+
+  it("falls back to the score when the shown input isn't a quiz", () => {
+    expect(
+      handler.summarizeResponseForModel(
+        { score: 1, total: 2, answers: [1, 1] },
+        { not: "a quiz" },
+        true,
+      ),
+    ).toBe("scored 1/2");
+  });
+
+  it("clips long question and option text so the prompt stays bounded", () => {
+    const long = {
+      quiz_title: "T",
+      questions: [
+        {
+          question: "Q".repeat(300),
+          options: ["A".repeat(300), "B".repeat(300)],
+          correct_index: 0,
+          explanation: "x",
+        },
+      ],
+    };
+    const summary = handler.summarizeResponseForModel(
+      { score: 0, total: 1, answers: [1] },
+      long,
+      true,
+    );
+    expect(summary.length).toBeLessThan(400);
+    expect(summary).toContain("…");
+  });
+});

--- a/apps/web/src/__tests__/server/study/model-note.test.ts
+++ b/apps/web/src/__tests__/server/study/model-note.test.ts
@@ -94,3 +94,57 @@ describe("buildStudyResultsNote", () => {
     expect(note).toContain("attempt 13 scored 12/13"); // latest kept
   });
 });
+
+describe("buildStudyResultsNote attempt detail", () => {
+  const quiz = {
+    quiz_title: "Tempest",
+    questions: [
+      {
+        question: "First question?",
+        options: ["right", "wrong"],
+        correct_index: 0,
+        explanation: "x",
+      },
+    ],
+  };
+  const history = [
+    {
+      id: "m1",
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool-showQuiz",
+          toolCallId: "c1",
+          state: "output-available",
+          output: "rendered",
+          input: quiz,
+        },
+      ],
+    },
+  ] as never;
+
+  it("details only the latest attempt, keeping earlier ones score-only", () => {
+    const note = buildStudyResultsNote(
+      history,
+      new Map([
+        [
+          "c1",
+          [
+            {
+              toolName: "showQuiz",
+              response: { score: 0, total: 1, answers: [1] },
+            },
+            {
+              toolName: "showQuiz",
+              response: { score: 0, total: 1, answers: [1] },
+            },
+          ],
+        ],
+      ]),
+    );
+    // Two attempts, but only one spelled-out miss: the most recent.
+    expect(note).toContain("attempt 1 scored 0/1;");
+    expect(note.match(/they chose/g)).toHaveLength(1);
+    expect(note).toContain("attempt 2 scored 0/1; missed");
+  });
+});

--- a/apps/web/src/lib/questions.ts
+++ b/apps/web/src/lib/questions.ts
@@ -26,3 +26,76 @@ export const mcQuestionSchema = z.object({
 });
 
 export type MCQuestion = z.infer<typeof mcQuestionSchema>;
+
+/**
+ * Field names models reach for instead of `correct_index`, most specific first.
+ * Measured against the live registry on 2026-08-17: five of the six models emit
+ * `correct_index` as instructed, but GPT-OSS 120B never does. Across six runs it
+ * used `answer: "B"` (three times), `correct_option: "<full option text>"`, and
+ * `correct_option_index: 1` -- every other field was correct, so the quiz was
+ * fine and only the answer key was named wrong.
+ */
+const ANSWER_ALIASES = [
+  "correct_index",
+  "correct_option_index",
+  "answer_index",
+  "correctIndex",
+  "correct_option",
+  "correct_answer",
+  "answer",
+] as const;
+
+/**
+ * Resolve an alias's value to an option index, or null when it can't be pinned
+ * down. Only unambiguous readings are accepted:
+ *
+ * - a number is taken as the 0-based index the schema asked for, except when it
+ *   is exactly `options.length`, which can only have been 1-based
+ * - a string matching an option exactly is that option
+ * - a bare letter label ("B", "B)", "(B)", "B.") is its position in the alphabet
+ */
+function resolveAnswerIndex(value: unknown, options: unknown[]): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value === options.length && value > 0 ? value - 1 : value;
+  }
+  if (typeof value !== "string") return null;
+  const answer = value.trim();
+  if (answer.length === 0) return null;
+
+  const exact = options.findIndex(
+    (option) => typeof option === "string" && option.trim() === answer,
+  );
+  if (exact !== -1) return exact;
+
+  if (/^\d+$/.test(answer)) {
+    const parsed = Number(answer);
+    return parsed === options.length && parsed > 0 ? parsed - 1 : parsed;
+  }
+
+  const letter = answer.match(/^\(?([A-Za-z])[).:]?$/);
+  if (letter?.[1]) {
+    const index = letter[1].toUpperCase().charCodeAt(0) - "A".charCodeAt(0);
+    if (index >= 0 && index < options.length) return index;
+  }
+  return null;
+}
+
+/**
+ * Fill in `correct_index` from whichever answer field the model actually used.
+ * Returns the question unchanged when it already has one, or when no alias
+ * resolves -- the caller still validates, so an unresolvable question is dropped
+ * rather than guessed at.
+ */
+export function coerceCorrectIndex(question: unknown): unknown {
+  if (typeof question !== "object" || question === null) return question;
+  const q = question as Record<string, unknown>;
+  if (typeof q.correct_index === "number") return question;
+
+  const options = Array.isArray(q.options) ? q.options : [];
+  for (const alias of ANSWER_ALIASES) {
+    if (!(alias in q)) continue;
+    const index = resolveAnswerIndex(q[alias], options);
+    if (index !== null) return { ...q, correct_index: index };
+  }
+  return question;
+}

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { mcQuestionSchema, type MCQuestion } from "@/lib/questions";
+import {
+  mcQuestionSchema,
+  coerceCorrectIndex,
+  type MCQuestion,
+} from "@/lib/questions";
 
 /** Most questions a quiz may carry. Also the ceiling `repairQuiz` trims to. */
 export const MAX_QUIZ_QUESTIONS = 5;
@@ -221,12 +225,16 @@ export function repairQuiz(input: unknown): Quiz | null {
   if (!Array.isArray(questions)) return null;
 
   const usable = questions
-    .filter((question) => {
-      const parsed = mcQuestionSchema.safeParse(question);
-      return (
-        parsed.success && parsed.data.correct_index < parsed.data.options.length
-      );
-    })
+    // Models routinely name the answer field something other than
+    // `correct_index`; fill it in before validating (see coerceCorrectIndex).
+    .map(coerceCorrectIndex)
+    .map((question) => mcQuestionSchema.safeParse(question))
+    .filter(
+      (parsed) =>
+        parsed.success &&
+        parsed.data.correct_index < parsed.data.options.length,
+    )
+    .map((parsed) => parsed.data)
     .slice(0, MAX_QUIZ_QUESTIONS);
   if (usable.length === 0) return null;
 

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -55,6 +55,7 @@ import {
 } from "./repair-quiz-parts";
 import { ChatRequestError } from "./request";
 import { buildStudyResultsNote } from "@/server/study/model-note";
+import { repairQuiz } from "@/lib/quiz";
 
 import { isRetrievalToolPart } from "@/lib/retrieval-tool-names";
 
@@ -426,6 +427,20 @@ export async function streamChat(params: {
         temperature,
         maxOutputTokens,
         abortSignal,
+        // Fix a `showQuiz` call the model got structurally wrong BEFORE the SDK
+        // rejects it. Repairing later (in the stream) is too late in two ways:
+        // the student briefly sees the error notice, and the model is handed a
+        // tool error, so it retries and the turn renders a second quiz.
+        experimental_repairToolCall: async ({ toolCall }) => {
+          if (toolCall.toolName !== "showQuiz") return null;
+          const quiz = repairQuiz(toolCall.input);
+          if (!quiz) return null;
+          logWarn("Repaired a malformed showQuiz call", {
+            chatbotId: chatbot.id,
+            modelId,
+          });
+          return { ...toolCall, input: JSON.stringify(quiz) };
+        },
         onChunk({ chunk }) {
           if (
             chunk.type === "tool-input-start" &&

--- a/apps/web/src/server/study/handlers.ts
+++ b/apps/web/src/server/study/handlers.ts
@@ -24,13 +24,33 @@ export interface StudyToolHandler {
   /**
    * One-line summary of a single stored response for the model, e.g.
    * "scored 3/5". Used to tell the model how the student did so it can react.
+   *
+   * `shownInput` is the tool input the student answered, passed so a summary can
+   * name what was actually missed rather than only a score. `detailed` asks for
+   * that longer form; callers pass it for the most recent attempt only, since
+   * every attempt lands in the system prompt of every later turn.
    */
-  summarizeResponseForModel(response: unknown): string;
+  summarizeResponseForModel(
+    response: unknown,
+    shownInput?: unknown,
+    detailed?: boolean,
+  ): string;
   /**
    * Optional human label derived from the shown input (e.g. a quiz title), used
    * in the model results note. Falls back to the tool name.
    */
   labelForModel?(shownInput: unknown): string | undefined;
+}
+
+/**
+ * Cap one question/option echoed into the model note. Model-generated and
+ * student-steerable text lands in the system prompt of every later turn, so it
+ * is collapsed to one line and bounded, same reasoning as `labelForModel`.
+ */
+function clip(text: unknown, max = 80): string {
+  if (typeof text !== "string") return "?";
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max)}…`;
 }
 
 const quizHandler: StudyToolHandler = {
@@ -49,13 +69,42 @@ const quizHandler: StudyToolHandler = {
     }
     return gradeQuiz(quiz.data, answers as number[]);
   },
-  summarizeResponseForModel(response) {
+  summarizeResponseForModel(response, shownInput, detailed) {
     // Null-safe: the handler always stores an object today, but this reads a
     // raw jsonb column -- a throw here would take down the whole chat turn.
-    const r = (response ?? {}) as { score?: unknown; total?: unknown };
+    const r = (response ?? {}) as {
+      score?: unknown;
+      total?: unknown;
+      answers?: unknown;
+    };
     const score = typeof r.score === "number" ? r.score : "?";
     const total = typeof r.total === "number" ? r.total : "?";
-    return `scored ${score}/${total}`;
+    const summary = `scored ${score}/${total}`;
+    if (!detailed) return summary;
+
+    // Name what the student actually got wrong, so the model can review those
+    // questions instead of answering "I don't know what you picked". Only the
+    // misses are listed: the correct ones need no remediation and every
+    // character here rides in the system prompt of every later turn.
+    const quiz = quizSchema.safeParse(shownInput);
+    const answers = r.answers;
+    if (!quiz.success || !Array.isArray(answers)) return summary;
+
+    const misses = quiz.data.questions
+      .map((question, i) => ({ question, chosen: answers[i], index: i }))
+      .filter(
+        ({ question, chosen }) =>
+          typeof chosen === "number" && chosen !== question.correct_index,
+      )
+      .map(({ question, chosen, index }) => {
+        const picked = question.options[chosen as number];
+        const right = question.options[question.correct_index];
+        return `Q${index + 1} "${clip(question.question)}" (they chose "${clip(picked)}", correct was "${clip(right)}")`;
+      });
+
+    return misses.length === 0
+      ? summary
+      : `${summary}; missed ${misses.join("; ")}`;
   },
   labelForModel(shownInput) {
     const title = (shownInput as { quiz_title?: unknown } | null)?.quiz_title;

--- a/apps/web/src/server/study/model-note.ts
+++ b/apps/web/src/server/study/model-note.ts
@@ -49,10 +49,18 @@ export function buildStudyResultsNote(
         const shown = responses.slice(-MAX_ATTEMPTS_PER_TOOL);
         const offset = responses.length - shown.length;
         const attempts = shown
-          .map(
-            (r, i) =>
-              `attempt ${offset + i + 1} ${handler.summarizeResponseForModel(r.response)}`,
-          )
+          .map((r, i) => {
+            // Spell out what was missed for the latest attempt only: that's the
+            // one a student asks about, and detailing every attempt would grow
+            // the system prompt on each retake.
+            const isLatest = i === shown.length - 1;
+            const summary = handler.summarizeResponseForModel(
+              r.response,
+              input,
+              isLatest,
+            );
+            return `attempt ${offset + i + 1} ${summary}`;
+          })
           .join("; ");
         const omitted =
           offset > 0 ? ` (${offset} earlier attempts omitted)` : "";


### PR DESCRIPTION
Diagnosed by replaying Prof Joubin's exact chatbot configuration against the live model, and by reading production data. Both root causes are measured, not inferred.

## 1. Why "Couldn't build the quiz" keeps happening

Not the token limit. Her max tokens is 3000, nowhere near truncation.

**GPT-OSS 120B never emits `correct_index`.** Six runs of her Shakespeare prompt:

| Run | What it sent instead | Result |
|---|---|---|
| 1, 4, 6 | `"answer": "B"` | invalid |
| 2 | `"correct_option": "<full option text>"` | invalid |
| 3 | `"correct_option_index": 1` | invalid |
| 5 | no tool call at all | empty, prose fallback |

**0/6 delivered a quiz.** Every other field (`quiz_title`, `questions`, `options`, `explanation`) was correct, so the quiz itself was fine and only the answer key was named wrong.

This is model-specific. All five other registry models emit `correct_index` correctly:

```
openai/gpt-oss-120b                schemaOk=false questionKeys=question,options,answer,explanation
qwen/qwen3-235b-a22b-2507          schemaOk=true  questionKeys=question,options,correct_index,explanation
meta-llama/llama-3.3-70b-instruct  schemaOk=true  ...
meta-llama/llama-4-maverick        schemaOk=true  ...
deepseek/deepseek-v3.2             schemaOk=true  ...
mistralai/mistral-large-2512       schemaOk=true  ...
```

Her Shakespeare bot is on GPT-OSS, hence a ~100% failure rate there.

### The fix

`coerceCorrectIndex` fills in `correct_index` from whichever field the model used. **Only unambiguous readings are accepted**, because a wrong answer key is worse than a missing quiz:

- a number, 0-based as the schema asked, except when it equals the option count (only coherent as 1-based)
- a string matching an option exactly
- a bare letter label (`B`, `B)`, `(B)`, `b.`)

Anything vaguer ("the second one") leaves the question untouched, so validation drops it rather than guessing.

Wired via `experimental_repairToolCall`, which fixes the call **before** the SDK rejects it. Repairing in the stream would be too late twice over: the student sees the error notice, and the model is handed a tool error, so it retries and renders a *second* quiz. That double-quiz turn is real, not theoretical: a production conversation has parts `tool-showQuiz(output-error), tool-showQuiz(output-available)`, which is exactly the "it said that and then also showed the quiz" report.

**Live result on her configuration: 0/6 before, 8/10 after.** The remaining two returned no tool call and no text at all; the existing empty-response fallback already covers those with a prose answer.

## 2. Why it "denies" what the student answered

The plumbing was fine. Verified against production: 67 recorded attempts, and the note built for a real conversation read `- "Hamlet Film Adaptations…" quiz: attempt 1 scored 2/5.`

The note only carried the **score**. So the model answered "how did I do?" correctly and, when asked what was actually chosen, truthfully said it had no record. The stored row has `answers: [0,1,2,1,1]` and the quiz has the correct indexes, so the information existed but was never passed along.

`summarizeResponseForModel` now also names the misses (question, what they chose, what was correct), for the **latest attempt only**, since every attempt rides in the system prompt of every later turn. Text is collapsed and clipped, same bounding as the existing quiz-title handling.

Confirmed live against the same note both models now answer correctly:

> "you chose 'Kenneth Branagh 1996', but the correct answer was 'Marlon Riggs 1996'"

## Judgment call worth a look

For a **bare numeric** alias I assume 0-based (what the schema told the model), with the equals-option-count guard for 1-based. If a model ever emits 1-based with a value inside the range, that grades a question wrong rather than showing an error. Letter and exact-text readings have no such ambiguity. Say the word and I'll drop numeric aliases entirely; it cost 1 of 6 observed runs.

## Tests

18 new (alias matrix incl. the verbatim production payload, detailed-summary content and bounding, latest-attempt-only detail). Full suite 739 passing, types and lint clean.