### PR TITLE
fix: Bug Fixes in file uploads and quiz

### DIFF
--- a/apps/web/src/__tests__/lib/crawled-page-files.test.ts
+++ b/apps/web/src/__tests__/lib/crawled-page-files.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "@jest/globals";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  excludeCrawledPages,
+  isCrawledPagePath,
+} from "@/lib/crawled-page-files";
+
+/**
+ * `userFiles` mixes uploads and crawled pages, and `storagePath` is the only
+ * thing telling them apart. Both forms of the check are pinned here because
+ * they guard different layers -- the SQL one keeps crawled pages out of the
+ * Files tab and out of `sweepStaleFiles`, the predicate one keeps the guarantee
+ * if a future caller hands a row straight to `isStaleFile`.
+ */
+describe("isCrawledPagePath", () => {
+  it("recognizes a crawled page by its URL storagePath", () => {
+    expect(isCrawledPagePath("https://example.edu/syllabus")).toBe(true);
+    expect(isCrawledPagePath("http://example.edu/syllabus")).toBe(true);
+  });
+
+  it("treats an uploaded object key as an upload", () => {
+    expect(isCrawledPagePath("abc123/9f1c-4e2b.pdf")).toBe(false);
+    // Uploaded paths are `{userId}/{fileId}`, so the letters can appear without
+    // the path being a URL.
+    expect(isCrawledPagePath("abc123/http-notes.pdf")).toBe(false);
+  });
+
+  it("does not throw on a missing path", () => {
+    expect(isCrawledPagePath(null)).toBe(false);
+    expect(isCrawledPagePath(undefined)).toBe(false);
+  });
+});
+
+describe("excludeCrawledPages", () => {
+  it("renders as a negated prefix match on storage_path", () => {
+    const { sql, params } = new PgDialect().sqlToQuery(excludeCrawledPages);
+    expect(sql.replace(/\s+/g, " ")).toContain("storage_path");
+    expect(sql.toLowerCase()).toContain("not");
+    expect(sql.toLowerCase()).toContain("like");
+    // Case-sensitive LIKE, not ILIKE: upload paths are always lowercase, and
+    // LIKE can use the index.
+    expect(sql.toLowerCase()).not.toContain("ilike");
+    expect(params).toEqual(["http%"]);
+  });
+});

--- a/apps/web/src/__tests__/lib/file-stale.test.ts
+++ b/apps/web/src/__tests__/lib/file-stale.test.ts
@@ -109,13 +109,34 @@ describe("isStaleFile", () => {
     ).toBe(false);
   });
 
-  it("ignores progress metadata for a pending file", () => {
-    // Left over from an earlier attempt; the file is queued, not running.
+  it("spares a re-queued file whose upload is old but whose retry is fresh", () => {
+    // `files.retry` flips an existing file back to `pending` and stamps the
+    // queue time; `createdAt` still points at the original upload. Dating this
+    // from `createdAt` swept every retried file straight back to `failed` --
+    // and the retry mutation refetches `files.list`, which runs the sweep, so
+    // the failure landed before the job could even start.
     expect(
       check({
         status: "pending",
-        metadata: { processingProgress: { lastUpdatedAt: iso(0) } },
-        createdAt: ago(STALE_PENDING_MS + 1),
+        metadata: {
+          processingProgress: { startedAt: iso(0), lastUpdatedAt: iso(0) },
+        },
+        createdAt: ago(7 * 24 * 60 * 60_000),
+      }),
+    ).toBe(false);
+  });
+
+  it("still times out a re-queued file whose job never ran", () => {
+    expect(
+      check({
+        status: "pending",
+        metadata: {
+          processingProgress: {
+            startedAt: iso(STALE_PENDING_MS + 1),
+            lastUpdatedAt: iso(STALE_PENDING_MS + 1),
+          },
+        },
+        createdAt: ago(7 * 24 * 60 * 60_000),
       }),
     ).toBe(true);
   });

--- a/apps/web/src/__tests__/lib/file-stale.test.ts
+++ b/apps/web/src/__tests__/lib/file-stale.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  isStaleFile,
+  lastFileActivityAt,
+  staleFileError,
+  STALE_PENDING_ERROR,
+  STALE_PENDING_MS,
+  STALE_PROCESSING_ERROR,
+  STALE_PROCESSING_MS,
+} from "@/lib/file-stale";
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+const iso = (ms: number) => ago(ms).toISOString();
+
+describe("lastFileActivityAt", () => {
+  it("prefers lastUpdatedAt, the stamp every progress write refreshes", () => {
+    expect(
+      lastFileActivityAt({
+        metadata: {
+          processingProgress: {
+            startedAt: iso(60 * 60_000),
+            lastUpdatedAt: iso(60_000),
+          },
+        },
+        createdAt: ago(2 * 60 * 60_000),
+      }),
+    ).toEqual(ago(60_000));
+  });
+
+  it("falls back to startedAt, then to createdAt", () => {
+    expect(
+      lastFileActivityAt({
+        metadata: { processingProgress: { startedAt: iso(60_000) } },
+        createdAt: ago(60 * 60_000),
+      }),
+    ).toEqual(ago(60_000));
+
+    expect(
+      lastFileActivityAt({ metadata: {}, createdAt: ago(60_000) }),
+    ).toEqual(ago(60_000));
+    expect(
+      lastFileActivityAt({ metadata: null, createdAt: ago(60_000) }),
+    ).toEqual(ago(60_000));
+  });
+
+  it("ignores an unparseable stamp rather than throwing", () => {
+    expect(
+      lastFileActivityAt({
+        metadata: { processingProgress: { lastUpdatedAt: "not a date" } },
+        createdAt: ago(60_000),
+      }),
+    ).toEqual(ago(60_000));
+  });
+});
+
+describe("isStaleFile", () => {
+  const check = (over: Partial<Parameters<typeof isStaleFile>[0]>) =>
+    isStaleFile({
+      status: "processing",
+      metadata: {},
+      createdAt: ago(60_000),
+      now: NOW,
+      ...over,
+    });
+
+  it("leaves settled files alone", () => {
+    for (const status of ["completed", "failed"]) {
+      expect(check({ status, createdAt: ago(24 * 60 * 60_000) })).toBe(false);
+    }
+  });
+
+  it("keeps a file that is still reporting progress", () => {
+    // The shape the bug produced: minutes into a big embed, but still alive.
+    expect(
+      check({
+        metadata: {
+          processingProgress: {
+            startedAt: iso(STALE_PROCESSING_MS * 3),
+            lastUpdatedAt: iso(30_000),
+          },
+        },
+        createdAt: ago(STALE_PROCESSING_MS * 3),
+      }),
+    ).toBe(false);
+  });
+
+  it("times out a processing file whose worker went silent", () => {
+    expect(
+      check({
+        metadata: {
+          processingProgress: { lastUpdatedAt: iso(STALE_PROCESSING_MS + 1) },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("judges a processing file with no progress write by createdAt", () => {
+    expect(check({ createdAt: ago(STALE_PROCESSING_MS + 1) })).toBe(true);
+    expect(check({ createdAt: ago(STALE_PROCESSING_MS - 1) })).toBe(false);
+  });
+
+  it("times out a pending file whose job never arrived", () => {
+    expect(
+      check({ status: "pending", createdAt: ago(STALE_PENDING_MS + 1) }),
+    ).toBe(true);
+    expect(
+      check({ status: "pending", createdAt: ago(STALE_PENDING_MS - 1) }),
+    ).toBe(false);
+  });
+
+  it("ignores progress metadata for a pending file", () => {
+    // Left over from an earlier attempt; the file is queued, not running.
+    expect(
+      check({
+        status: "pending",
+        metadata: { processingProgress: { lastUpdatedAt: iso(0) } },
+        createdAt: ago(STALE_PENDING_MS + 1),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("staleFileError", () => {
+  it("explains which stage was abandoned and points at Retry", () => {
+    expect(staleFileError("pending")).toBe(STALE_PENDING_ERROR);
+    expect(staleFileError("processing")).toBe(STALE_PROCESSING_ERROR);
+    expect(staleFileError("pending")).toContain("Retry");
+    expect(staleFileError("processing")).toContain("Retry");
+  });
+});

--- a/apps/web/src/__tests__/lib/file-stale.test.ts
+++ b/apps/web/src/__tests__/lib/file-stale.test.ts
@@ -3,6 +3,8 @@ import {
   isStaleFile,
   lastFileActivityAt,
   staleFileError,
+  sweepStaleFiles,
+  MAX_THROTTLE_ENTRIES,
   STALE_PENDING_ERROR,
   STALE_PENDING_MS,
   STALE_PROCESSING_ERROR,
@@ -180,5 +182,237 @@ describe("staleFileError", () => {
     expect(staleFileError("processing")).toBe(STALE_PROCESSING_ERROR);
     expect(staleFileError("pending")).toContain("Retry");
     expect(staleFileError("processing")).toContain("Retry");
+  });
+});
+
+/**
+ * Minimal chainable stand-in for the drizzle query builder, mirroring the one in
+ * `crawl-stale.test.ts`. Each `select()` resolves to the next scripted response;
+ * each `update()` records the payload it was handed.
+ */
+function fakeDb(responses: unknown[][]) {
+  const updates: Array<Record<string, unknown>> = [];
+  let queryIndex = 0;
+
+  const makeSelect = () => {
+    const index = queryIndex++;
+    const query: Record<string, unknown> = {};
+    const self = () => query;
+    query.from = self;
+    query.where = self;
+    query.orderBy = self;
+    query.limit = self;
+    query.then = (onOk: (v: unknown) => unknown, onErr?: () => unknown) =>
+      Promise.resolve(responses[index] ?? []).then(onOk, onErr);
+    return query;
+  };
+
+  const makeUpdate = () => {
+    const query: Record<string, unknown> = {};
+    query.set = (values: Record<string, unknown>) => {
+      updates.push(values);
+      return query;
+    };
+    query.where = () => query;
+    query.then = (onOk: (v: unknown) => unknown, onErr?: () => unknown) =>
+      Promise.resolve([]).then(onOk, onErr);
+    return query;
+  };
+
+  return {
+    db: { select: makeSelect, update: makeUpdate } as unknown as Parameters<
+      typeof sweepStaleFiles
+    >[0]["db"],
+    updates,
+  };
+}
+
+let userSeq = 0;
+/**
+ * A fresh user id per test. `sweepStaleFiles` throttles per user in a
+ * module-level map, so reusing an id would make one test's sweep suppress the
+ * next one's.
+ */
+const freshUser = () => `user-${++userSeq}`;
+
+const upload = (over: Record<string, unknown> = {}) => ({
+  id: "f1",
+  processingStatus: "processing",
+  storagePath: "u/f1",
+  metadata: {},
+  createdAt: ago(STALE_PROCESSING_MS + 60_000),
+  ...over,
+});
+
+describe("sweepStaleFiles", () => {
+  it("swallows a database failure so the list read it fronts still succeeds", async () => {
+    const db = {
+      select: () => {
+        throw new Error("connection terminated");
+      },
+    } as unknown as Parameters<typeof sweepStaleFiles>[0]["db"];
+
+    await expect(
+      sweepStaleFiles({ db, userId: freshUser(), now: NOW }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does no writes when nothing is in progress", async () => {
+    const { db, updates } = fakeDb([[]]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("does no writes when the in-progress files are still alive", async () => {
+    const { db, updates } = fakeDb([
+      [upload({ createdAt: ago(60_000) })],
+      // A second response in case the implementation ever issues another read.
+      [],
+    ]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("fails a silent processing file with the processing message", async () => {
+    const { db, updates } = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toEqual([
+      {
+        processingStatus: "failed",
+        metadata: { error: STALE_PROCESSING_ERROR },
+      },
+    ]);
+  });
+
+  it("fails a stuck pending file with the pending message", async () => {
+    const { db, updates } = fakeDb([
+      [
+        upload({
+          processingStatus: "pending",
+          createdAt: ago(STALE_PENDING_MS + 60_000),
+        }),
+      ],
+    ]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toEqual([
+      { processingStatus: "failed", metadata: { error: STALE_PENDING_ERROR } },
+    ]);
+  });
+
+  it("writes one update per status, not one per file", async () => {
+    const { db, updates } = fakeDb([
+      [
+        upload({ id: "a" }),
+        upload({ id: "b" }),
+        upload({
+          id: "c",
+          processingStatus: "pending",
+          createdAt: ago(STALE_PENDING_MS + 60_000),
+        }),
+      ],
+    ]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toHaveLength(2);
+    expect(updates.map((u) => u.metadata)).toEqual([
+      { error: STALE_PENDING_ERROR },
+      { error: STALE_PROCESSING_ERROR },
+    ]);
+  });
+
+  it("leaves a crawled page alone even when its row is ancient", async () => {
+    // The SQL predicate already excludes these; this covers the belt in
+    // `isStaleFile` for a caller that hands the row over anyway.
+    const { db, updates } = fakeDb([
+      [
+        upload({
+          storagePath: "https://example.edu/syllabus",
+          createdAt: ago(30 * 24 * 60 * 60_000),
+        }),
+      ],
+    ]);
+    await sweepStaleFiles({ db, userId: freshUser(), now: NOW });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("skips a repeat sweep inside the throttle window", async () => {
+    const userId = freshUser();
+    const first = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: first.db, userId, now: NOW });
+    expect(first.updates).toHaveLength(1);
+
+    // The Files tab polls while a file processes; the second read must not
+    // re-run the query.
+    const second = fakeDb([[upload()]]);
+    await sweepStaleFiles({
+      db: second.db,
+      userId,
+      now: new Date(NOW.getTime() + 30_000),
+    });
+    expect(second.updates).toHaveLength(0);
+  });
+
+  it("sweeps again once the throttle window has passed", async () => {
+    const userId = freshUser();
+    const first = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: first.db, userId, now: NOW });
+
+    const later = fakeDb([[upload()]]);
+    await sweepStaleFiles({
+      db: later.db,
+      userId,
+      now: new Date(NOW.getTime() + 5 * 60_000),
+    });
+    expect(later.updates).toHaveLength(1);
+  });
+
+  it("does not throttle one user behind another", async () => {
+    const a = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: a.db, userId: freshUser(), now: NOW });
+    const b = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: b.db, userId: freshUser(), now: NOW });
+    expect(b.updates).toHaveLength(1);
+  });
+
+  it("drops the throttle wholesale rather than growing without bound", async () => {
+    // One entry per active user per instance, so this is not a shape production
+    // reaches -- but an unbounded module-level map on a long-lived instance is
+    // a leak, and clearing it only costs one extra sweep per active user.
+    const pinned = freshUser();
+    const first = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: first.db, userId: pinned, now: NOW });
+    expect(first.updates).toHaveLength(1);
+
+    const empty = fakeDb([[]]);
+    for (let i = 0; i < MAX_THROTTLE_ENTRIES; i++) {
+      await sweepStaleFiles({
+        db: empty.db,
+        userId: `filler-${i}`,
+        now: NOW,
+      });
+    }
+
+    // The pinned user's entry went with the clear, so it sweeps again even
+    // though it is still inside the interval.
+    const again = fakeDb([[upload()]]);
+    await sweepStaleFiles({ db: again.db, userId: pinned, now: NOW });
+    expect(again.updates).toHaveLength(1);
+  });
+
+  it("retries after a failure instead of waiting out the throttle", async () => {
+    const userId = freshUser();
+    const broken = {
+      select: () => {
+        throw new Error("connection terminated");
+      },
+    } as unknown as Parameters<typeof sweepStaleFiles>[0]["db"];
+    await sweepStaleFiles({ db: broken, userId, now: NOW });
+
+    const retry = fakeDb([[upload()]]);
+    await sweepStaleFiles({
+      db: retry.db,
+      userId,
+      now: new Date(NOW.getTime() + 1_000),
+    });
+    expect(retry.updates).toHaveLength(1);
   });
 });

--- a/apps/web/src/__tests__/lib/file-stale.test.ts
+++ b/apps/web/src/__tests__/lib/file-stale.test.ts
@@ -58,6 +58,7 @@ describe("isStaleFile", () => {
   const check = (over: Partial<Parameters<typeof isStaleFile>[0]>) =>
     isStaleFile({
       status: "processing",
+      storagePath: "user-1/file-1",
       metadata: {},
       createdAt: ago(60_000),
       now: NOW,
@@ -124,6 +125,37 @@ describe("isStaleFile", () => {
         createdAt: ago(7 * 24 * 60 * 60_000),
       }),
     ).toBe(false);
+  });
+
+  it("never touches a crawled page, however old its row is", () => {
+    // Crawled pages share `userFiles`, and `crawl-processor` flips one back to
+    // `processing` on a re-crawl WITHOUT writing a progress stamp -- so this
+    // predicate would date a live re-crawl from the day the page was first
+    // crawled and fail it mid-flight. Worse, the message it writes tells the
+    // owner to hit Retry, which queues a process-file job against a URL.
+    for (const status of ["pending", "processing"]) {
+      expect(
+        check({
+          status,
+          storagePath: "https://example.edu/syllabus",
+          createdAt: ago(30 * 24 * 60 * 60_000),
+        }),
+      ).toBe(false);
+    }
+    // http, not just https.
+    expect(
+      check({
+        storagePath: "http://example.edu/syllabus",
+        createdAt: ago(30 * 24 * 60 * 60_000),
+      }),
+    ).toBe(false);
+    // An upload whose name merely starts with those letters is still swept.
+    expect(
+      check({
+        storagePath: "user-1/https-notes.pdf",
+        createdAt: ago(STALE_PROCESSING_MS + 1),
+      }),
+    ).toBe(true);
   });
 
   it("still times out a re-queued file whose job never ran", () => {

--- a/apps/web/src/__tests__/lib/pdf-parse-import.test.ts
+++ b/apps/web/src/__tests__/lib/pdf-parse-import.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "@jest/globals";
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { promisify } from "node:util";
+import { resolve } from "node:path";
+
+const run = promisify(execFile);
+// Jest runs with cwd at the package root (apps/web), per the repo's test setup.
+const REPO_ROOT = resolve(process.cwd(), "../..");
+const RAG_SERVICE = resolve(REPO_ROOT, "packages/ai/src/rag-service.ts");
+
+/**
+ * `extractPDF` must not import the `pdf-parse` package ROOT.
+ *
+ * pdf-parse@1.1.1's index.js decides it is in debug mode when `module.parent`
+ * is falsy -- which is always, under ESM -- and then synchronously reads
+ * `./test/data/05-versions-space.pdf` relative to the process CWD. That fixture
+ * only exists inside the package, so unless the server happens to be running
+ * from node_modules/pdf-parse the read misses and the import throws ENOENT
+ * before any upload is touched -- every pdf failing to process. Verified
+ * against a real `output: "standalone"` build run from its own directory.
+ *
+ * Jest cannot see this directly: its CJS interop gives `module.parent` a value,
+ * so the debug block stays off and a root import looks fine here while failing
+ * in production. So the check runs in a real Node ESM process instead, and the
+ * specifier is read out of the source rather than hardcoded -- reverting
+ * `extractPDF` to the package root fails this test.
+ */
+describe("pdf-parse import", () => {
+  const source = readFileSync(RAG_SERVICE, "utf8");
+  const specifier = source.match(
+    /const pdfParse = \(await import\("([^"]+)"\)\)\.default;/,
+  )?.[1];
+
+  it("imports a specifier that is not the crash-prone package root", () => {
+    expect(specifier).toBeDefined();
+    expect(specifier).not.toBe("pdf-parse");
+  });
+
+  it("loads in a bare Node ESM process, the way the server loads it", async () => {
+    const probe = `
+      const mod = await import(${JSON.stringify(specifier)});
+      const fn = mod.default ?? mod;
+      if (typeof fn !== "function") throw new Error("not callable: " + typeof fn);
+      console.log("LOADED");
+    `;
+    // cwd is the repo root, as on the server -- and NOT the pdf-parse package
+    // directory, which is what makes the debug-mode read fail.
+    const { stdout } = await run("node", ["--input-type=module", "-e", probe], {
+      cwd: REPO_ROOT,
+    });
+    expect(stdout).toContain("LOADED");
+  }, 60000);
+});

--- a/apps/web/src/__tests__/lib/processing-errors.test.ts
+++ b/apps/web/src/__tests__/lib/processing-errors.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "@jest/globals";
+import { sanitizeProcessingError } from "@/lib/processing-error";
+
+/**
+ * Every message a file owner can be shown when processing fails.
+ *
+ * The generic fallback is the reason the pdf-parse outage went undiagnosed:
+ * "failed due to an internal error" is indistinguishable from a scanned PDF, a
+ * corrupt upload, or a platform outage, so nothing actionable ever got reported.
+ * Each case below is a failure observed running a real corpus through
+ * `processFile`.
+ */
+describe("sanitizeProcessingError", () => {
+  const cases: Array<[string, string, string]> = [
+    [
+      "scanned / image-only PDF",
+      "PDF contains no readable text content",
+      "OCR",
+    ],
+    [
+      "empty upload",
+      "Empty buffer: cannot extract PDF from empty buffer",
+      "not a readable PDF",
+    ],
+    [
+      "non-PDF renamed .pdf",
+      'Invalid PDF format: expected PDF header, got "This"',
+      "not a readable PDF",
+    ],
+    [
+      "truncated PDF",
+      'Invalid PDF format: expected PDF header, got "\\u0000"',
+      "not a readable PDF",
+    ],
+    // pdf.js vocabulary varies by version; the wrapper text does not.
+    [
+      "structurally damaged PDF",
+      "Failed to extract PDF content: invalid top-level pages dictionary",
+      "could not be read",
+    ],
+    [
+      "bad xref PDF",
+      "Failed to extract PDF content: bad XRef entry",
+      "could not be read",
+    ],
+    [
+      "legacy .doc",
+      "Failed to extract Word document content: Could not find file",
+      ".docx",
+    ],
+    [
+      "corrupt .docx",
+      "Failed to extract Word document content: end of central directory",
+      ".docx",
+    ],
+    [
+      "word with no text",
+      "Word document contains no readable text content",
+      "OCR",
+    ],
+    [
+      "password protected",
+      "The file is encrypted and needs a password",
+      "password-protected",
+    ],
+    [
+      "unknown office file",
+      "Failed to extract content: something went wrong",
+      "could not be read",
+    ],
+    ["timeout", "File extraction timed out after 60s", "timed out"],
+  ];
+
+  it.each(cases)("%s explains what to do", (_label, raw, expected) => {
+    const out = sanitizeProcessingError(new Error(raw));
+    expect(out).toContain(expected);
+    expect(out).not.toBe("File processing failed due to an internal error");
+  });
+
+  it("keeps the unsupported-type message the extractor already wrote", () => {
+    const raw = "Unsupported file type: application/zip";
+    expect(sanitizeProcessingError(new Error(raw))).toBe(raw);
+  });
+
+  it("still has a generic fallback for genuinely unknown failures", () => {
+    expect(sanitizeProcessingError(new Error("ECONNRESET"))).toBe(
+      "File processing failed due to an internal error",
+    );
+  });
+
+  it("never leaks a stack trace or internal path to the user", () => {
+    const raw =
+      "Failed to extract PDF content: ENOENT: no such file or directory, open '/var/task/.next/server/chunks/x.js'";
+    const out = sanitizeProcessingError(new Error(raw));
+    expect(out).not.toContain("/var/task");
+    expect(out).not.toContain("ENOENT");
+  });
+});

--- a/apps/web/src/__tests__/lib/processing-errors.test.ts
+++ b/apps/web/src/__tests__/lib/processing-errors.test.ts
@@ -89,6 +89,24 @@ describe("sanitizeProcessingError", () => {
     expect(out).not.toBe("File processing failed due to an internal error");
   });
 
+  it("names an embedding dimension mismatch", () => {
+    expect(
+      sanitizeProcessingError(
+        new Error("embedding returned dimension 3072, expected 1536"),
+      ),
+    ).toBe("Embedding dimension mismatch");
+  });
+
+  it("handles a thrown non-Error without losing the message", () => {
+    // Anything can be thrown; the classifier reads whatever String() gives it.
+    expect(sanitizeProcessingError("File extraction timed out")).toBe(
+      "File processing timed out",
+    );
+    expect(sanitizeProcessingError({ code: 500 })).toBe(
+      "File processing failed due to an internal error",
+    );
+  });
+
   it("keeps the unsupported-type message the extractor already wrote", () => {
     const raw = "Unsupported file type: application/zip";
     expect(sanitizeProcessingError(new Error(raw))).toBe(raw);

--- a/apps/web/src/__tests__/lib/processing-errors.test.ts
+++ b/apps/web/src/__tests__/lib/processing-errors.test.ts
@@ -63,6 +63,18 @@ describe("sanitizeProcessingError", () => {
       "The file is encrypted and needs a password",
       "password-protected",
     ],
+    // pdf.js's PasswordException wording, wrapped by RAGService.extractPDF.
+    // "Incorrect Password" is capitalized, which a substring match missed.
+    [
+      "encrypted PDF, no password supplied",
+      "Failed to extract PDF content: No password given",
+      "password-protected",
+    ],
+    [
+      "encrypted PDF, wrong password",
+      "Failed to extract PDF content: Incorrect Password",
+      "password-protected",
+    ],
     [
       "unknown office file",
       "Failed to extract content: something went wrong",
@@ -86,6 +98,14 @@ describe("sanitizeProcessingError", () => {
     expect(sanitizeProcessingError(new Error("ECONNRESET"))).toBe(
       "File processing failed due to an internal error",
     );
+  });
+
+  it("does not read a password hint out of an unrelated word", () => {
+    // The match is word-bounded, so a message that merely contains the letters
+    // is not turned into "remove the protection and upload it again".
+    expect(
+      sanitizeProcessingError(new Error("upstream returned passwordless=true")),
+    ).toBe("File processing failed due to an internal error");
   });
 
   it("never leaks a stack trace or internal path to the user", () => {

--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -516,4 +516,95 @@ describe("parseQuizFromText", () => {
       ).toBeNull();
     });
   });
+
+  /**
+   * A leak must recover exactly when the same quiz would have recovered had the
+   * model used the tool channel -- the native path runs `repairQuiz` twice
+   * (`experimental_repairToolCall`, `repairQuizToolParts`) while this path used
+   * to demand a schema-perfect quiz. Every case below was previously discarded
+   * whole, which flushed the raw call -- answer keys and explanations included --
+   * to the student as text.
+   */
+  describe("repairs a leak the way a tool call is repaired", () => {
+    const question = (i: number) => ({
+      question: `Q${i}: what does Barbie stage about gender?`,
+      options: ["A", "B", "C", "D"],
+      correct_index: 2,
+      explanation: `Because ${i}.`,
+    });
+
+    it("trims a leak that runs past the question ceiling", () => {
+      const quiz = {
+        quiz_title: "Gender Theory and Barbie",
+        questions: [1, 2, 3, 4, 5, 6].map(question),
+      };
+      const recovered = parseQuizFromText(JSON.stringify(quiz));
+      expect(recovered?.questions).toHaveLength(5);
+      expect(recovered?.quiz_title).toBe("Gender Theory and Barbie");
+    });
+
+    it("coerces an aliased answer key in a leaked quiz", () => {
+      const leaked = {
+        quiz_title: "Gender Theory",
+        questions: [
+          {
+            question: "Who wrote Gender Trouble?",
+            options: ["Butler", "Foucault", "Sedgwick", "Ahmed"],
+            answer: "A",
+            explanation: "Judith Butler, 1990.",
+          },
+        ],
+      };
+      expect(parseQuizFromText(JSON.stringify(leaked))?.questions[0]).toEqual(
+        expect.objectContaining({ correct_index: 0 }),
+      );
+    });
+
+    it("drops one botched question and keeps the rest", () => {
+      const leaked = {
+        quiz_title: "Gender Theory",
+        questions: [
+          question(1),
+          { question: "Too many options?", options: ["A", "B", "C", "D", "E"] },
+          question(2),
+        ],
+      };
+      const recovered = parseQuizFromText(JSON.stringify(leaked));
+      expect(recovered?.questions).toHaveLength(2);
+      expect(recovered?.questions.map((q) => q.question)).toEqual([
+        "Q1: what does Barbie stage about gender?",
+        "Q2: what does Barbie stage about gender?",
+      ]);
+    });
+
+    it("salvages a JSON leak the token limit cut off mid-question", () => {
+      const full = JSON.stringify({
+        quiz_title: "Gender Theory",
+        questions: [question(1), question(2), question(3)],
+      });
+      const cutOff = full.slice(0, full.indexOf("Q3:") + 2);
+      const recovered = parseQuizFromText(cutOff);
+      expect(recovered?.questions).toHaveLength(2);
+    });
+
+    it("salvages a pseudo-call whose questions array never closes", () => {
+      // How Llama-family models leak, cut off by `maxTokens` mid-write.
+      const full = `[showQuiz(quiz_title="Gender Theory", questions=${JSON.stringify(
+        [question(1), question(2), question(3)],
+      )})]`;
+      const cutOff = full.slice(0, full.indexOf("Q3:") + 2);
+      const recovered = parseQuizFromText(cutOff);
+      expect(recovered?.quiz_title).toBe("Gender Theory");
+      expect(recovered?.questions).toHaveLength(2);
+    });
+
+    it("still returns null when a truncated leak has no complete question", () => {
+      expect(
+        parseQuizFromText('{"quiz_title":"Gender Theory","questions":[{"que'),
+      ).toBeNull();
+      expect(
+        parseQuizFromText('[showQuiz(quiz_title="Gender Theory", questions=[{'),
+      ).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/__tests__/lib/quiz.test.ts
+++ b/apps/web/src/__tests__/lib/quiz.test.ts
@@ -608,3 +608,35 @@ describe("parseQuizFromText", () => {
     });
   });
 });
+
+describe("parseQuizFromText salvage edges", () => {
+  const question =
+    '{"question":"Q1?","options":["a","b"],"correct_index":0,"explanation":"e"}';
+
+  it("stops at the first question that is not valid JSON", () => {
+    // `extractBalanced` finds a closed `{...}`, but it is not JSON (unquoted
+    // key), so the salvage keeps what it already has and stops there rather
+    // than throwing or discarding the whole quiz.
+    const leak = `showQuiz(quiz_title="Photosynthesis", questions=[${question}, {question: "Q2?"}`;
+    const quiz = parseQuizFromText(leak);
+    expect(quiz?.questions).toHaveLength(1);
+    expect(quiz?.quiz_title).toBe("Photosynthesis");
+  });
+
+  it("rejects a pseudo-call whose title is not valid JSON", () => {
+    // A bad escape makes JSON.parse of the captured title throw. Better to drop
+    // the candidate than to render a quiz with a mangled title.
+    const leak = `showQuiz(quiz_title="Bad \\q escape", questions=[${question}])`;
+    expect(parseQuizFromText(leak)).toBeNull();
+  });
+
+  it("rejects a truncated JSON leak whose title is not valid JSON", () => {
+    const leak = `{"quiz_title": "Bad \\q escape", "questions": [${question},`;
+    expect(parseQuizFromText(leak)).toBeNull();
+  });
+
+  it("rejects a pseudo-call whose questions array is closed but not JSON", () => {
+    const leak = 'showQuiz(quiz_title="T", questions=[{question: "Q?"}])';
+    expect(parseQuizFromText(leak)).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/server/chat/leak-false-positives.test.ts
+++ b/apps/web/src/__tests__/server/chat/leak-false-positives.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "@jest/globals";
+import { parseQuizFromText } from "@/lib/quiz";
+import { recoverLeakedQuiz } from "@/server/chat/recover-quiz";
+
+type Chunk = Record<string, unknown>;
+
+async function pump(chunks: Chunk[]): Promise<Chunk[]> {
+  const stream = recoverLeakedQuiz();
+  const writer = stream.writable.getWriter();
+  const out: Chunk[] = [];
+  const drained = (async () => {
+    const reader = stream.readable.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out.push(value as Chunk);
+    }
+  })();
+  for (const chunk of chunks) await writer.write(chunk as never);
+  await writer.close();
+  await drained;
+  return out;
+}
+
+const textOf = (chunks: Chunk[]) =>
+  chunks
+    .filter((c) => c.type === "text-delta")
+    .map((c) => c.delta)
+    .join("");
+
+/**
+ * `parseQuizFromText` was loosened to repair leaks the way the native tool-call
+ * path does. That runs against EVERY tool-capable assistant turn, so the cost of
+ * a false positive is high: prose would be swallowed and replaced by a bogus
+ * quiz widget.
+ *
+ * These are answers a critical-theory or CS bot plausibly gives -- each contains
+ * a brace, a fence, or the word showQuiz -- and every one must survive as text,
+ * byte for byte, through the real stream transform.
+ */
+const NON_QUIZ_ANSWERS: Array<[string, string]> = [
+  ["plain prose", "Butler argues that gender precedes sex assignment."],
+  ["set notation", "Consider the set {a, b, c} and its powerset."],
+  ["LaTeX fraction", "The ratio is \\frac{1}{2} of the total."],
+  ["empty object in prose", "An empty config looks like {} in practice."],
+  ["json config block", '```json\n{"model": "llama", "temperature": 0.7}\n```'],
+  [
+    "js code fence",
+    '```js\nconst quiz = { title: "x" };\nexport default quiz;\n```',
+  ],
+  [
+    "python fence",
+    '```python\ndef grade(answers):\n    return {"score": 1}\n```',
+  ],
+  ["bare fence", "```\nplain preformatted text\n```"],
+  [
+    "mentions the tool by name",
+    "I could call showQuiz() here, but you have not uploaded any readings yet.",
+  ],
+  [
+    "explains the tool",
+    "When you ask to be quizzed I call showQuiz(quiz_title=..., questions=[...]) internally.",
+  ],
+  [
+    "quiz-shaped but missing a title",
+    '{"questions": [{"question": "Q?", "options": ["a","b"], "correct_index": 0, "explanation": "e"}]}',
+  ],
+  [
+    "quiz-shaped but no renderable question",
+    '{"quiz_title": "T", "questions": [{"question": "Q?", "options": ["a","b"], "correct_index": 9, "explanation": "e"}]}',
+  ],
+  ["empty questions array", '{"quiz_title": "T", "questions": []}'],
+  ["title only, no questions key", '{"quiz_title": "Gender Theory"}'],
+  [
+    "prose about a syllabus with braces",
+    "The syllabus template uses {course_name} and {semester} as placeholders.",
+  ],
+  [
+    "markdown table",
+    "| Term | Meaning |\n|---|---|\n| performativity | gender as repeated acts |",
+  ],
+];
+
+describe("leaked-quiz recovery does not eat ordinary answers", () => {
+  it.each(NON_QUIZ_ANSWERS)("parseQuizFromText returns null: %s", (_, text) => {
+    expect(parseQuizFromText(text)).toBeNull();
+  });
+
+  it.each(NON_QUIZ_ANSWERS)(
+    "streams through byte-for-byte: %s",
+    async (_, text) => {
+      const out = await pump([
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: text },
+        { type: "text-end", id: "t1" },
+      ]);
+      expect(textOf(out)).toBe(text);
+      expect(out.some((c) => c.type === "tool-input-available")).toBe(false);
+    },
+  );
+
+  it.each(NON_QUIZ_ANSWERS)(
+    "survives delta-by-delta fragmentation: %s",
+    async (_, text) => {
+      // Split into 3-char deltas, the worst case for marker detection.
+      const deltas: Chunk[] = [];
+      for (let i = 0; i < text.length; i += 3) {
+        deltas.push({
+          type: "text-delta",
+          id: "t1",
+          delta: text.slice(i, i + 3),
+        });
+      }
+      const out = await pump([
+        { type: "text-start", id: "t1" },
+        ...deltas,
+        { type: "text-end", id: "t1" },
+      ]);
+      expect(textOf(out)).toBe(text);
+      expect(out.some((c) => c.type === "tool-input-available")).toBe(false);
+    },
+  );
+});

--- a/apps/web/src/__tests__/server/chat/multi-step-text.test.ts
+++ b/apps/web/src/__tests__/server/chat/multi-step-text.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "@jest/globals";
+import { streamText, stepCountIs, tool } from "ai";
+import { MockLanguageModelV3, convertArrayToReadableStream } from "ai/test";
+import { z } from "zod";
+
+/**
+ * Pins the AI SDK semantics that `streamChat`'s empty-response fallback depends
+ * on: `result.text` is the LAST step's text, not the turn's.
+ *
+ * `streamChat` runs a multi-step turn (`stopWhen: [stepCountIs(5),
+ * hasToolCall("done")]`), so a model that answers in an earlier step and then
+ * calls a retrieval tool ends on an empty step. Reading `result.text` there
+ * reports no visible answer, which fired the fallback and appended a second,
+ * independently generated answer to a turn the student had already seen
+ * answered -- the "history shows a different reply than the live one" bug.
+ *
+ * If a future SDK release makes `result.text` span the whole turn, this test
+ * fails and the `stepsText` accumulation in stream-chat.ts can be simplified.
+ */
+describe("multi-step turn text", () => {
+  const twoStepModel = () => {
+    let call = 0;
+    return new MockLanguageModelV3({
+      doStream: async () => {
+        call++;
+        return call === 1
+          ? {
+              stream: convertArrayToReadableStream([
+                { type: "stream-start", warnings: [] },
+                { type: "text-start", id: "t1" },
+                {
+                  type: "text-delta",
+                  id: "t1",
+                  delta: "Butler argues gender precedes sex assignment.",
+                },
+                { type: "text-end", id: "t1" },
+                {
+                  type: "tool-call",
+                  toolCallId: "c1",
+                  toolName: "search_documents",
+                  input: "{}",
+                },
+                {
+                  type: "finish",
+                  finishReason: "tool-calls",
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                },
+              ] as never),
+            }
+          : {
+              stream: convertArrayToReadableStream([
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "finish",
+                  finishReason: "stop",
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                },
+              ] as never),
+            };
+      },
+    });
+  };
+
+  const runTurn = async () => {
+    const result = streamText({
+      model: twoStepModel(),
+      tools: {
+        search_documents: tool({
+          description: "search",
+          inputSchema: z.object({}),
+          execute: async () => "a passage",
+        }),
+      },
+      stopWhen: [stepCountIs(5)],
+      prompt: "quiz me on the gender theory chapter",
+    });
+    for await (const chunk of result.textStream) void chunk;
+    const [text, steps] = await Promise.all([result.text, result.steps]);
+    return { text, steps };
+  };
+
+  it("reports no text from the final step even though the turn answered", async () => {
+    const { text, steps } = await runTurn();
+    expect(steps).toHaveLength(2);
+    expect(text).toBe("");
+  });
+
+  it("finds the answer when text is accumulated across every step", async () => {
+    const { text, steps } = await runTurn();
+    // How stream-chat.ts derives `turnText`.
+    const stepsText = steps.map((step) => step.text ?? "").join("");
+    const turnText = stepsText.trim() ? stepsText : text;
+
+    expect(turnText).toContain("Butler argues gender precedes sex assignment.");
+    // The gate that decides whether the fallback turn runs.
+    expect(Boolean(turnText.trim())).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -252,3 +252,106 @@ describe("recoverLeakedQuiz", () => {
     });
   });
 });
+
+/**
+ * The Critical Theory bot (Llama 4 Maverick) reported 2026-08-19: the leaked
+ * call was well-formed enough to render, but `parseQuizFromText` demanded a
+ * schema-perfect quiz, so the whole leak was flushed as text -- handing the
+ * student a quiz with every answer and explanation already filled in.
+ *
+ * A leak must now recover on exactly the terms a native tool call does.
+ */
+describe("a leak that needs repairing", () => {
+  const textOf = (chunks: Chunk[]) =>
+    chunks
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.delta)
+      .join("");
+
+  const question = (i: number) => ({
+    question: `Q${i}: how does Barbie stage gender as performance?`,
+    options: ["A", "B", "C", "D"],
+    correct_index: 1,
+    explanation: `Because ${i}.`,
+  });
+
+  const pseudoCall = (questions: unknown) =>
+    `[showQuiz(quiz_title="Gender Theory and Barbie", questions=${JSON.stringify(
+      questions,
+    )})]`;
+
+  /** Split the way a leak really streams: many small deltas. */
+  const deltasOf = (text: string, size = 17) => {
+    const deltas: string[] = [];
+    for (let i = 0; i < text.length; i += size)
+      deltas.push(text.slice(i, i + size));
+    return deltas;
+  };
+
+  const quizPartOf = (out: Chunk[]) =>
+    out.find((c) => c.type === "tool-input-available") as
+      | {
+          toolName: string;
+          input: { quiz_title: string; questions: unknown[] };
+        }
+      | undefined;
+
+  it("recovers a six-question leak by trimming to the ceiling", async () => {
+    const leak = pseudoCall([1, 2, 3, 4, 5, 6].map(question));
+    const out = await pump(textBlock("t1", deltasOf(leak)));
+
+    const part = quizPartOf(out);
+    expect(part?.toolName).toBe("showQuiz");
+    expect(part?.input.questions).toHaveLength(5);
+    // The answer key must never reach the student as text.
+    expect(textOf(out)).toBe("");
+    expect(textOf(out)).not.toContain("correct_index");
+  });
+
+  it("recovers a leak whose answer key uses an alias", async () => {
+    const leak = pseudoCall([
+      {
+        question: "Who wrote Gender Trouble?",
+        options: ["Butler", "Foucault", "Sedgwick", "Ahmed"],
+        answer: "A",
+        explanation: "Judith Butler, 1990.",
+      },
+    ]);
+    const out = await pump(textBlock("t1", deltasOf(leak)));
+
+    expect(quizPartOf(out)?.input.questions[0]).toEqual(
+      expect.objectContaining({ correct_index: 0 }),
+    );
+    expect(textOf(out)).toBe("");
+  });
+
+  it("keeps the preamble and recovers a leak cut off by the token limit", async () => {
+    const full = `Here are 5 questions on the gender theory chapter.\n\n${pseudoCall(
+      [1, 2, 3, 4, 5].map(question),
+    )}`;
+    const cutOff = full.slice(0, full.indexOf("Q3:") + 2);
+    const out = await pump(textBlock("t1", deltasOf(cutOff)));
+
+    expect(quizPartOf(out)?.input.questions).toHaveLength(2);
+    expect(textOf(out)).toBe(
+      "Here are 5 questions on the gender theory chapter.\n\n",
+    );
+    expect(textOf(out)).not.toContain("showQuiz(");
+  });
+
+  it("recovers a leak when the stream ends without text-end", async () => {
+    // An aborted turn: `flush` used to dump the held leak as raw text.
+    const leak = pseudoCall([1, 2].map(question));
+    const out = await pump([
+      { type: "text-start", id: "t1" },
+      ...deltasOf(leak).map((delta) => ({
+        type: "text-delta",
+        id: "t1",
+        delta,
+      })),
+    ]);
+
+    expect(quizPartOf(out)?.input.questions).toHaveLength(2);
+    expect(textOf(out)).toBe("");
+  });
+});

--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -115,13 +115,61 @@ describe("recoverLeakedQuiz", () => {
   });
 
   it("flushes a held quiz-candidate block if the stream ends before text-end", async () => {
-    // Stream cut off mid-JSON (no text-end): the partial text must not be lost.
+    // Stream cut off mid-JSON (no text-end): the partial text must not be lost,
+    // and the block must still be closed -- an unterminated text part stays in
+    // `streaming` state on the client, so the text renders as a message that
+    // never finished arriving.
     const partial = '{"quiz_title":"Photo';
     const input: Chunk[] = [
       { type: "text-start", id: "t1" },
       { type: "text-delta", id: "t1", delta: partial },
     ];
-    expect(await pump(input)).toEqual(input);
+    expect(await pump(input)).toEqual([
+      ...input,
+      { type: "text-end", id: "t1" },
+    ]);
+  });
+
+  it("closes an open block when a non-text chunk interrupts it", async () => {
+    // Ordering is preserved by flushing the block first; closing it is what
+    // stops the flushed text from rendering as still-streaming behind the tool
+    // part that follows.
+    const input: Chunk[] = [
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "Working on it." },
+      {
+        type: "tool-input-available",
+        toolCallId: "c1",
+        toolName: "search_documents",
+        input: { query: "x" },
+      } as unknown as Chunk,
+    ];
+    const out = await pump(input);
+    expect(out.map((c) => c.type)).toEqual([
+      "text-start",
+      "text-delta",
+      "text-end",
+      "tool-input-available",
+    ]);
+  });
+
+  it("closes an open block when the stream opens another without ending it", async () => {
+    const input: Chunk[] = [
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "First." },
+      { type: "text-start", id: "t2" },
+      { type: "text-delta", id: "t2", delta: "Second." },
+      { type: "text-end", id: "t2" },
+    ];
+    const out = await pump(input);
+    expect(out.map((c) => `${c.type}:${(c as { id?: string }).id}`)).toEqual([
+      "text-start:t1",
+      "text-delta:t1",
+      "text-end:t1",
+      "text-start:t2",
+      "text-delta:t2",
+      "text-end:t2",
+    ]);
   });
 
   it("streams prose that has leading whitespace", async () => {

--- a/apps/web/src/__tests__/server/chat/stream-chat-turn.test.ts
+++ b/apps/web/src/__tests__/server/chat/stream-chat-turn.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  streamText,
+  stepCountIs,
+  hasToolCall,
+  tool,
+  createUIMessageStream,
+  type InferUIMessageChunk,
+} from "ai";
+import { MockLanguageModelV3, convertArrayToReadableStream } from "ai/test";
+import { z } from "zod";
+import { studyTools, type StudyUIMessage } from "@/server/chat/study-tools";
+import { stripRetrievalOutputs } from "@/server/chat/stream-filter";
+import { repairQuizToolParts } from "@/server/chat/repair-quiz-parts";
+import { recoverLeakedQuiz } from "@/server/chat/recover-quiz";
+import { assistantMessageForDb } from "@/server/chat/ui-messages";
+import { isRetrievalToolPart } from "@/lib/retrieval-tool-names";
+
+type Chunk = InferUIMessageChunk<StudyUIMessage>;
+type Step = {
+  text?: string;
+  call?: { name: string; args: unknown };
+  finish: string;
+};
+
+/**
+ * Replica of the decision logic in `streamChat`'s `execute` + `onFinish`, run
+ * over the real AI SDK with a scripted multi-step model.
+ *
+ * The two gates it exercises look interchangeable and are not:
+ *
+ * - the `done`-answer gate must read the LAST step's text. `done` is a
+ *   retrieval tool, so its part is stripped from the stream and from
+ *   persistence; a model that narrates in step 1 and answers via `done` in
+ *   step 2 loses its answer entirely if this gate spans the whole turn.
+ * - `hasVisibleAnswer` must span EVERY step, or a turn that answered early and
+ *   ended on a tool call looks empty and the fallback appends a second,
+ *   independently generated answer.
+ *
+ * Getting either backwards produced a shipped bug, so both are pinned here.
+ */
+async function runTurn(script: Step[]) {
+  let call = 0;
+  let fallbackRan = false;
+
+  const model = () =>
+    new MockLanguageModelV3({
+      doStream: async () => {
+        const step = script[call] ?? { finish: "stop" };
+        call++;
+        const parts: unknown[] = [{ type: "stream-start", warnings: [] }];
+        if (step.text) {
+          parts.push({ type: "text-start", id: `t${call}` });
+          parts.push({ type: "text-delta", id: `t${call}`, delta: step.text });
+          parts.push({ type: "text-end", id: `t${call}` });
+        }
+        if (step.call) {
+          parts.push({
+            type: "tool-call",
+            toolCallId: `c${call}`,
+            toolName: step.call.name,
+            input: JSON.stringify(step.call.args),
+          });
+        }
+        parts.push({
+          type: "finish",
+          finishReason: step.finish,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        });
+        return { stream: convertArrayToReadableStream(parts as never) };
+      },
+    });
+
+  const tools = {
+    ...studyTools,
+    search_documents: tool({
+      description: "search",
+      inputSchema: z.object({ query: z.string() }),
+      execute: async () => "a passage about gender performativity",
+    }),
+    done: tool({
+      description: "final answer",
+      inputSchema: z.object({ answer: z.string() }),
+    }),
+  };
+
+  const stream = createUIMessageStream<StudyUIMessage>({
+    onError: (e) => String(e),
+    execute: async ({ writer }) => {
+      const primary = streamText({
+        model: model(),
+        prompt: "quiz me on the gender theory chapter",
+        tools,
+        stopWhen: [stepCountIs(5), hasToolCall("done")],
+      });
+
+      const source = primary
+        .toUIMessageStream<StudyUIMessage>({
+          sendReasoning: false,
+          sendFinish: false,
+        })
+        .pipeThrough(stripRetrievalOutputs())
+        .pipeThrough(repairQuizToolParts())
+        .pipeThrough(recoverLeakedQuiz());
+      const reader = source.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        writer.write(value);
+      }
+
+      const [primaryText, steps] = await Promise.all([
+        primary.text,
+        primary.steps,
+      ]);
+      const stepsText = steps.map((s) => s.text ?? "").join("");
+      const turnText = stepsText.trim() ? stepsText : primaryText;
+
+      const calls = steps.flatMap((s) => s.toolCalls ?? []);
+      const doneInput = calls.find((c) => c.toolName === "done")?.input as
+        | { answer?: unknown }
+        | undefined;
+      const doneAnswer =
+        typeof doneInput?.answer === "string" ? doneInput.answer : undefined;
+      const producedQuiz = calls.some((c) => c.toolName === "showQuiz");
+
+      // Gate 1: last-step text.
+      if (doneAnswer && doneAnswer.trim() && !primaryText.trim()) {
+        writer.write({ type: "text-start", id: "done" } as Chunk);
+        writer.write({
+          type: "text-delta",
+          id: "done",
+          delta: doneAnswer,
+        } as Chunk);
+        writer.write({ type: "text-end", id: "done" } as Chunk);
+      }
+
+      // Gate 2: whole-turn text.
+      const hasVisibleAnswer =
+        Boolean(turnText.trim()) || Boolean(doneAnswer?.trim()) || producedQuiz;
+      if (!hasVisibleAnswer) {
+        fallbackRan = true;
+        writer.write({ type: "text-start", id: "fb" } as Chunk);
+        writer.write({
+          type: "text-delta",
+          id: "fb",
+          delta: "What topic are you interested in?",
+        } as Chunk);
+        writer.write({ type: "text-end", id: "fb" } as Chunk);
+      }
+    },
+    onFinish: ({ responseMessage }) => {
+      const kept = responseMessage.parts.filter(
+        (p) => !isRetrievalToolPart(p.type),
+      );
+      persisted = assistantMessageForDb({ ...responseMessage, parts: kept });
+    },
+  });
+
+  let persisted: { content: string; parts: StudyUIMessage["parts"] } = {
+    content: "",
+    parts: [],
+  };
+  const reader = stream.getReader();
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+  return { ...persisted, fallbackRan, modelCalls: call };
+}
+
+describe("streamChat turn semantics", () => {
+  it("surfaces a done answer that follows an earlier narration step", async () => {
+    const r = await runTurn([
+      {
+        text: "Let me check the readings.",
+        call: { name: "search_documents", args: { query: "gender" } },
+        finish: "tool-calls",
+      },
+      {
+        call: {
+          name: "done",
+          args: { answer: "Butler argues gender precedes sex assignment." },
+        },
+        finish: "tool-calls",
+      },
+    ]);
+    expect(r.content).toContain(
+      "Butler argues gender precedes sex assignment.",
+    );
+    expect(r.fallbackRan).toBe(false);
+  });
+
+  it("does not append a fallback answer when an earlier step already answered", async () => {
+    const r = await runTurn([
+      {
+        text: "Gender is performative, per Butler.",
+        call: { name: "search_documents", args: { query: "gender" } },
+        finish: "tool-calls",
+      },
+      { finish: "stop" },
+    ]);
+    expect(r.content).toContain("Gender is performative, per Butler.");
+    expect(r.content).not.toContain("What topic are you interested in?");
+    expect(r.fallbackRan).toBe(false);
+  });
+
+  it("still runs the fallback for a genuinely empty turn", async () => {
+    const r = await runTurn([{ finish: "stop" }]);
+    expect(r.fallbackRan).toBe(true);
+  });
+
+  it("renders a leaked quiz as a tool part and never as an answer key", async () => {
+    const leak = `Here are 5 questions on the gender theory chapter.\n\n[showQuiz(quiz_title="Gender Theory and Barbie", questions=${JSON.stringify(
+      [1, 2, 3, 4, 5, 6].map((i) => ({
+        question: `Q${i}: what does Barbie stage about gender?`,
+        options: ["A", "B", "C", "D"],
+        answer: "B",
+        explanation: `Because ${i}.`,
+      })),
+    )})]`;
+    const r = await runTurn([{ text: leak, finish: "stop" }]);
+
+    const quiz = r.parts.find((p) => p.type === "tool-showQuiz") as
+      | { input: { questions: unknown[] } }
+      | undefined;
+    expect(quiz).toBeDefined();
+    expect(quiz!.input.questions).toHaveLength(5); // trimmed to the ceiling
+    expect(r.content).toContain("Here are 5 questions");
+    expect(r.content).not.toContain("showQuiz(");
+    expect(r.content).not.toContain("explanation");
+    expect(r.fallbackRan).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/server/chat/study-tools.test.ts
+++ b/apps/web/src/__tests__/server/chat/study-tools.test.ts
@@ -155,18 +155,45 @@ describe("maxQuestionsForBudget", () => {
 
 describe("buildStudyToolsAddendum", () => {
   it("tells the model the question budget", () => {
-    expect(buildStudyToolsAddendum(500)).toContain("at most 2 questions");
-    expect(buildStudyToolsAddendum(2000)).toContain("at most 5 questions");
+    expect(buildStudyToolsAddendum(500, true)).toContain("at most 2 questions");
+    expect(buildStudyToolsAddendum(2000, true)).toContain(
+      "at most 5 questions",
+    );
   });
 
   it("uses the singular for a one-question budget", () => {
-    expect(buildStudyToolsAddendum(150)).toContain("at most 1 question,");
+    expect(buildStudyToolsAddendum(150, true)).toContain("at most 1 question,");
   });
 
   it("still tells the model to call the tool rather than write prose", () => {
-    expect(buildStudyToolsAddendum(2000)).toContain("showQuiz");
-    expect(buildStudyToolsAddendum(2000)).toContain(
+    expect(buildStudyToolsAddendum(2000, true)).toContain("showQuiz");
+    expect(buildStudyToolsAddendum(2000, true)).toContain(
       "do not write the quiz out as prose",
+    );
+  });
+
+  // The addendum is the LAST thing in the system prompt, so "based on the
+  // course material above" was the model's most recent instruction and it
+  // quizzed on whatever the initial RAG query retrieved -- ignoring a student
+  // who named one chapter.
+  it("tells the model to scope the quiz to what the student named", () => {
+    const addendum = buildStudyToolsAddendum(2000, true);
+    expect(addendum).toContain("Scope the quiz to exactly what the student");
+    expect(addendum).toContain("chapter");
+  });
+
+  it("offers a targeted search only when retrieval tools exist", () => {
+    expect(buildStudyToolsAddendum(2000, true)).toContain(
+      "search the documents for it before writing any questions",
+    );
+    // No files (or a degraded RAG pipeline): `search_documents` is not in the
+    // toolset, so promising a search would send the model after a tool it
+    // cannot call.
+    expect(buildStudyToolsAddendum(2000, false)).not.toContain(
+      "search the documents",
+    );
+    expect(buildStudyToolsAddendum(2000, false)).toContain(
+      "Scope the quiz to exactly what the student",
     );
   });
 });

--- a/apps/web/src/__tests__/server/chat/ui-messages.test.ts
+++ b/apps/web/src/__tests__/server/chat/ui-messages.test.ts
@@ -274,3 +274,77 @@ describe("stripToolPartsForTextModel", () => {
     expect(msg.parts).toEqual(parts);
   });
 });
+
+/**
+ * A turn that ended mid-quiz -- a Stop, a disconnect, or the token limit --
+ * leaves the part in `input-streaming`. Stored as-is that is the "Building your
+ * quiz..." skeleton, which `hasPersistableStudyPart` treats as unrenderable, so
+ * the turn either spins forever in history or is dropped from it entirely.
+ */
+describe("assistantMessageForDb: an unfinished quiz part", () => {
+  const partialInput = {
+    quiz_title: "Gender Theory and Barbie",
+    questions: [
+      {
+        question: "What does Butler argue about sex assignment?",
+        options: ["Gender precedes it", "It precedes gender"],
+        correct_index: 0,
+        explanation: "Gender is the scheme within which sex is assigned.",
+      },
+      // Cut off mid-write: no options, no answer key.
+      { question: "What does Barbie stage" },
+    ],
+  };
+
+  const messageWith = (part: unknown) =>
+    ({ id: "m20", role: "assistant", parts: [part] }) as never;
+
+  it("repairs a repairable input-streaming quiz into a persistable part", () => {
+    const { parts } = assistantMessageForDb(
+      messageWith({
+        type: "tool-showQuiz",
+        toolCallId: "c1",
+        state: "input-streaming",
+        input: partialInput,
+      }),
+    );
+    const part = parts[0] as unknown as {
+      state: string;
+      output: string;
+      input: { questions: unknown[] };
+    };
+    expect(part.state).toBe("output-available");
+    expect(part.output).toBe("rendered");
+    // The question that finished survives; the truncated one is dropped.
+    expect(part.input.questions).toHaveLength(1);
+    expect(hasPersistableStudyPart(parts)).toBe(true);
+  });
+
+  it("leaves an unsalvageable input-streaming quiz non-persistable", () => {
+    const { parts } = assistantMessageForDb(
+      messageWith({
+        type: "tool-showQuiz",
+        toolCallId: "c2",
+        state: "input-streaming",
+        input: { quiz_title: "Gender Theory" },
+      }),
+    );
+    expect((parts[0] as unknown as { state: string }).state).toBe(
+      "input-streaming",
+    );
+    expect(hasPersistableStudyPart(parts)).toBe(false);
+  });
+
+  it("leaves an output-error part alone so history matches what was shown", () => {
+    const part = {
+      type: "tool-showQuiz",
+      toolCallId: "c3",
+      state: "output-error",
+      errorText: "Couldn't build the quiz",
+      input: partialInput,
+    };
+    const { parts } = assistantMessageForDb(messageWith(part));
+    expect(parts[0]).toEqual(part);
+    expect(hasPersistableStudyPart(parts)).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/server/process-file-route.test.ts
+++ b/apps/web/src/__tests__/server/process-file-route.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ *
+ * The file-processing job's runtime ceiling.
+ *
+ * Embedding is the slowest stage of the pipeline, and this route ran on the
+ * platform default until it was set here -- so any file needing more than a
+ * couple of embedding batches was killed mid-run and showed the owner a file
+ * stuck at 40% before failing. The value is asserted rather than assumed
+ * because nothing else in the build catches its absence: a missing export is a
+ * silent revert to the default.
+ */
+import { jest, describe, it, expect } from "@jest/globals";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+
+// Every boundary the module pulls in at import time. Nothing here is exercised;
+// the point is to be able to import the route at all.
+jest.unstable_mockModule("@/lib/qstash", () => ({
+  qstashReceiver: null,
+  verifyQStashSignature: jest.fn(),
+}));
+jest.unstable_mockModule("@/lib/logger", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+}));
+jest.unstable_mockModule("@/lib/file-processor", () => ({
+  processFile: jest.fn(),
+}));
+
+const route = await import("@/app/api/jobs/process-file/route");
+
+describe("POST /api/jobs/process-file", () => {
+  it("declares the same 5-minute ceiling as the crawl jobs", () => {
+    expect(route.maxDuration).toBe(300);
+  });
+
+  it("still exports a POST handler", () => {
+    expect(typeof route.POST).toBe("function");
+  });
+});

--- a/apps/web/src/app/api/jobs/process-file/route.ts
+++ b/apps/web/src/app/api/jobs/process-file/route.ts
@@ -3,6 +3,16 @@ import { qstashReceiver, verifyQStashSignature } from "@/lib/qstash";
 import { logError } from "@/lib/logger";
 import { processFile } from "@/lib/file-processor";
 
+/**
+ * Embedding a document is the slowest stage of the pipeline and the one that
+ * dominates wall-clock time, so this job needs the same ceiling the crawl jobs
+ * already declare. Without it the route ran on the platform default -- an order
+ * of magnitude shorter -- and any file big enough to need more than a couple of
+ * embedding batches was killed mid-run, which the student sees as a file that
+ * sticks at 40% and then fails.
+ */
+export const maxDuration = 300;
+
 export async function POST(req: NextRequest) {
   try {
     // When QStash is not configured, signature verification is impossible

--- a/apps/web/src/lib/crawled-page-files.ts
+++ b/apps/web/src/lib/crawled-page-files.ts
@@ -1,0 +1,41 @@
+import { userFiles } from "@teachanything/db/schema";
+import { like, not } from "drizzle-orm";
+
+/**
+ * `userFiles` holds two different kinds of row and `storagePath` is the only
+ * thing separating them:
+ *
+ * - an uploaded file stores a Supabase Storage object key, always the lowercase
+ *   `{userId}/{fileId}`
+ * - a crawled page stores the page URL (see `crawl-processor.ts`)
+ *
+ * Every query over `userFiles` therefore has to decide, explicitly, whether
+ * crawled pages belong in it. They usually do not: the Files tab renders them
+ * as grouped "Web Sources" rows from `crawler.getCrawlSources`, they are
+ * recovered by `sweepStaleCrawls` rather than by the upload pipeline, and
+ * `files.retry` would try to download their URL out of object storage.
+ *
+ * Shared from one module so the SQL predicate and the in-process check can't
+ * drift apart, and so a new `userFiles` query has an obvious thing to reach for.
+ */
+
+/**
+ * True for a `userFiles` row that came from the crawler.
+ *
+ * Case-sensitive on purpose, matching `excludeCrawledPages`: upload paths are
+ * always lowercase `{userId}/{fileId}` and crawl URLs are normalized to a
+ * lowercase scheme, so there is no casing to be tolerant of.
+ */
+export function isCrawledPagePath(
+  storagePath: string | null | undefined,
+): boolean {
+  return typeof storagePath === "string" && storagePath.startsWith("http");
+}
+
+/**
+ * The SQL form of `isCrawledPagePath`, negated for use in a `where`.
+ *
+ * A case-sensitive `LIKE` is both sufficient (see above) and index-friendlier
+ * than `ILIKE`.
+ */
+export const excludeCrawledPages = not(like(userFiles.storagePath, "http%"));

--- a/apps/web/src/lib/file-processor.ts
+++ b/apps/web/src/lib/file-processor.ts
@@ -7,6 +7,10 @@ import { createOpenRouterClient, createRAGService } from "@teachanything/ai";
 import { EMBEDDING_MODEL } from "@teachanything/ai/models";
 import { env } from "./env";
 import { logInfo, logError } from "./logger";
+import {
+  sanitizeProcessingError,
+  STORAGE_MISSING_ERROR,
+} from "./processing-error";
 
 const EXTRACTION_TIMEOUT_MS = 60_000;
 
@@ -21,15 +25,29 @@ export const CURRENT_PROCESSING_VERSION = 2;
  * Sanitize error messages before storing in metadata visible to users.
  * Prevents internal details (hostnames, connection strings, API keys) from leaking.
  */
-function sanitizeProcessingError(error: unknown): string {
-  const msg = error instanceof Error ? error.message : String(error);
-  if (msg.includes("timed out")) return "File processing timed out";
-  if (msg.includes("Unsupported file type")) return msg;
-  if (msg.includes("no readable text")) return msg;
-  if (msg.includes("Invalid PDF")) return "Invalid PDF format";
-  if (msg.includes("embedding") && msg.includes("dimension"))
-    return "Embedding dimension mismatch";
-  return "File processing failed due to an internal error";
+/**
+ * Mark a file failed and stop. Used by the paths that bail out mid-run without
+ * throwing: the atomic guard has already flipped the row to `processing`, so
+ * returning without a terminal status leaves it claimed forever -- a spinner the
+ * owner cannot clear and that every QStash retry bounces off. The stale sweep
+ * would eventually catch it, but only after 15 minutes and with a misleading
+ * "stopped responding" message, so settle it here with the real reason.
+ */
+async function abandonProcessing(
+  fileId: string,
+  reason: string,
+): Promise<{ success: false; chunkCount: 0 }> {
+  try {
+    await db
+      .update(userFiles)
+      .set({ processingStatus: "failed", metadata: { error: reason } })
+      .where(eq(userFiles.id, fileId));
+  } catch (statusError) {
+    logError(statusError, "Failed to mark abandoned file as failed", {
+      fileId,
+    });
+  }
+  return { success: false, chunkCount: 0 };
 }
 
 function withTimeout<T>(
@@ -178,7 +196,7 @@ export async function processFile(params: {
             "File not found in local storage (likely deleted), skipping processing",
             { fileId, storagePath: file.storagePath },
           );
-          return { success: false, chunkCount: 0 };
+          return abandonProcessing(fileId, STORAGE_MISSING_ERROR);
         }
         throw err;
       }
@@ -197,7 +215,7 @@ export async function processFile(params: {
             "File storage not found (likely deleted), skipping processing",
             { fileId, storagePath: file.storagePath },
           );
-          return { success: false, chunkCount: 0 };
+          return abandonProcessing(fileId, STORAGE_MISSING_ERROR);
         }
         throw new Error(`Failed to download file: ${error?.message}`);
       }

--- a/apps/web/src/lib/file-stale.ts
+++ b/apps/web/src/lib/file-stale.ts
@@ -29,6 +29,45 @@ const IN_PROGRESS_STATUSES = ["pending", "processing"] as const;
 /** Bounds one sweep so a pathological account can't stall the list read. */
 const MAX_SWEPT_FILES = 200;
 
+/**
+ * How long one sweep covers a user for.
+ *
+ * The sweep fronts two list procedures, and the Files tab polls them while an
+ * upload processes -- so without this every poll paid for an extra query to
+ * re-derive an answer that cannot have changed. Nothing here is time-critical:
+ * the thresholds are 15 minutes, so re-checking more often than once a minute
+ * buys nothing.
+ */
+const SWEEP_INTERVAL_MS = 60_000;
+
+/**
+ * Last successful sweep per user, for `SWEEP_INTERVAL_MS`.
+ *
+ * Per-instance and best-effort on purpose. A cold instance just sweeps once
+ * more than it strictly had to, which is the cheap direction to be wrong in --
+ * the alternative (a shared lock) would cost more than the query it saves.
+ */
+const lastSweptAt = new Map<string, number>();
+
+/** Keeps the throttle map from growing without bound on a long-lived instance. */
+export const MAX_THROTTLE_ENTRIES = 10_000;
+
+function shouldSweep(userId: string, now: Date): boolean {
+  const previous = lastSweptAt.get(userId);
+  return (
+    previous === undefined || now.getTime() - previous >= SWEEP_INTERVAL_MS
+  );
+}
+
+function recordSweep(userId: string, now: Date): void {
+  // Bounded by clearing rather than by evicting: an entry is worth exactly one
+  // skipped query, so dropping all of them costs at most one extra sweep per
+  // active user. Not expected to fire -- one entry per active user per instance
+  // -- but it keeps a long-lived instance from growing without bound.
+  if (lastSweptAt.size >= MAX_THROTTLE_ENTRIES) lastSweptAt.clear();
+  lastSweptAt.set(userId, now.getTime());
+}
+
 export const STALE_PENDING_ERROR =
   "Processing never started. It may have been interrupted -- use Retry to try again.";
 
@@ -113,7 +152,10 @@ export function staleFileError(status: string): string {
  * owned by `sweepStaleCrawls`, which judges them by crawl-page activity rather
  * than by this table's progress stamps -- see `excludeCrawledPages`.
  *
- * Never throws; a failed sweep must not break the read that triggered it.
+ * Throttled per user (see `SWEEP_INTERVAL_MS`), so a polling list read does not
+ * re-run it on every request. Never throws; a failed sweep must not break the
+ * read that triggered it, and a failure is not recorded, so the next read
+ * retries instead of waiting out the interval.
  */
 export async function sweepStaleFiles(params: {
   db: typeof database;
@@ -122,6 +164,8 @@ export async function sweepStaleFiles(params: {
 }): Promise<void> {
   const { db, userId } = params;
   const now = params.now ?? new Date();
+
+  if (!shouldSweep(userId, now)) return;
 
   try {
     const candidates = await db
@@ -156,7 +200,10 @@ export async function sweepStaleFiles(params: {
         now,
       }),
     );
-    if (stale.length === 0) return;
+    if (stale.length === 0) {
+      recordSweep(userId, now);
+      return;
+    }
 
     // Grouped by the message each status earns, and re-checked against the
     // status in the WHERE clause so a file that started making progress between
@@ -182,6 +229,7 @@ export async function sweepStaleFiles(params: {
         );
     }
 
+    recordSweep(userId, now);
     logInfo("Timed out stale file processing", {
       userId,
       count: stale.length,

--- a/apps/web/src/lib/file-stale.ts
+++ b/apps/web/src/lib/file-stale.ts
@@ -1,0 +1,169 @@
+import type { db as database } from "@teachanything/db";
+import { userFiles } from "@teachanything/db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { logInfo, logError } from "./logger";
+
+/**
+ * A file sitting in `pending` this long never had its job picked up -- the
+ * QStash publish failed silently, or every delivery attempt was rejected.
+ */
+export const STALE_PENDING_MS = 15 * 60 * 1000;
+
+/**
+ * A file in `processing` is judged by progress activity, not by when it
+ * started: a large document legitimately takes minutes. `maxDuration` on
+ * /api/jobs/process-file caps one attempt at 5 minutes, and each embedding
+ * batch writes `lastUpdatedAt`, so 15 minutes of total silence means every
+ * attempt (including QStash retries) is gone.
+ */
+export const STALE_PROCESSING_MS = 15 * 60 * 1000;
+
+/** Statuses that show the user a spinner and can therefore hang forever. */
+const IN_PROGRESS_STATUSES = ["pending", "processing"] as const;
+
+/** Bounds one sweep so a pathological account can't stall the list read. */
+const MAX_SWEPT_FILES = 200;
+
+export const STALE_PENDING_ERROR =
+  "Processing never started. It may have been interrupted -- use Retry to try again.";
+
+export const STALE_PROCESSING_ERROR =
+  "Processing stopped responding and was timed out. Use Retry to try again; if it keeps failing, the file may be too large or contain no readable text.";
+
+type StaleFileMetadata = {
+  processingProgress?: { startedAt?: string; lastUpdatedAt?: string };
+} | null;
+
+/**
+ * The most recent sign of life for a file, as a timestamp.
+ *
+ * `lastUpdatedAt` is rewritten at every pipeline stage and after every
+ * embedding batch, so it is the real activity signal. It is absent until the
+ * first progress write lands, hence the fallbacks. An unparseable value is
+ * treated as no signal at all rather than throwing.
+ */
+export function lastFileActivityAt(params: {
+  metadata: StaleFileMetadata;
+  createdAt: Date;
+}): Date {
+  const progress = params.metadata?.processingProgress;
+  for (const stamp of [progress?.lastUpdatedAt, progress?.startedAt]) {
+    if (!stamp) continue;
+    const parsed = new Date(stamp);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return params.createdAt;
+}
+
+/**
+ * True when an in-progress file has gone quiet long enough that its worker is
+ * presumed dead.
+ *
+ * This is the only way out of a wedged file. `processFile` claims the file with
+ * an atomic `status -> processing` guard and refuses to re-enter a file already
+ * in `processing`, so a worker that dies without reaching its `catch` -- killed
+ * at the duration limit, an OOM, a deploy mid-run -- leaves the row claimed
+ * forever. Every QStash retry then bails at the guard, and nothing else ever
+ * revisits it.
+ */
+export function isStaleFile(params: {
+  status: string;
+  metadata: StaleFileMetadata;
+  createdAt: Date;
+  now: Date;
+}): boolean {
+  const { status, now } = params;
+  if (status !== "pending" && status !== "processing") return false;
+  const limit = status === "pending" ? STALE_PENDING_MS : STALE_PROCESSING_MS;
+  const lastActivity =
+    status === "pending"
+      ? params.createdAt
+      : lastFileActivityAt({
+          metadata: params.metadata,
+          createdAt: params.createdAt,
+        });
+  return now.getTime() - lastActivity.getTime() > limit;
+}
+
+/** The message shown for a swept file, by the status it was swept from. */
+export function staleFileError(status: string): string {
+  return status === "pending" ? STALE_PENDING_ERROR : STALE_PROCESSING_ERROR;
+}
+
+/**
+ * Mark abandoned file-processing runs as failed so they stop spinning forever
+ * and the owner can retry or delete them.
+ *
+ * Modelled on `sweepStaleCrawls`: recovery has to be driven from stored state,
+ * because the worker that should have written a terminal status is exactly the
+ * thing that died. Runs opportunistically on the file list reads, so it
+ * self-heals the moment the owner next opens the page.
+ *
+ * Never throws; a failed sweep must not break the read that triggered it.
+ */
+export async function sweepStaleFiles(params: {
+  db: typeof database;
+  userId: string;
+  now?: Date;
+}): Promise<void> {
+  const { db, userId } = params;
+  const now = params.now ?? new Date();
+
+  try {
+    const candidates = await db
+      .select({
+        id: userFiles.id,
+        processingStatus: userFiles.processingStatus,
+        metadata: userFiles.metadata,
+        createdAt: userFiles.createdAt,
+      })
+      .from(userFiles)
+      .where(
+        and(
+          eq(userFiles.userId, userId),
+          inArray(userFiles.processingStatus, [...IN_PROGRESS_STATUSES]),
+        ),
+      )
+      .limit(MAX_SWEPT_FILES);
+
+    const stale = candidates.filter((file) =>
+      isStaleFile({
+        status: file.processingStatus,
+        metadata: file.metadata,
+        createdAt: file.createdAt,
+        now,
+      }),
+    );
+    if (stale.length === 0) return;
+
+    // Grouped by the message each status earns, and re-checked against the
+    // status in the WHERE clause so a file that started making progress between
+    // the read and the write is left alone.
+    for (const status of IN_PROGRESS_STATUSES) {
+      const ids = stale
+        .filter((file) => file.processingStatus === status)
+        .map((file) => file.id);
+      if (ids.length === 0) continue;
+
+      await db
+        .update(userFiles)
+        .set({
+          processingStatus: "failed",
+          metadata: { error: staleFileError(status) },
+        })
+        .where(
+          and(
+            inArray(userFiles.id, ids),
+            eq(userFiles.processingStatus, status),
+          ),
+        );
+    }
+
+    logInfo("Timed out stale file processing", {
+      userId,
+      count: stale.length,
+    });
+  } catch (error) {
+    logError(error, "Failed to sweep stale files", { userId });
+  }
+}

--- a/apps/web/src/lib/file-stale.ts
+++ b/apps/web/src/lib/file-stale.ts
@@ -6,6 +6,10 @@ import { logInfo, logError } from "./logger";
 /**
  * A file sitting in `pending` this long never had its job picked up -- the
  * QStash publish failed silently, or every delivery attempt was rejected.
+ *
+ * Measured from the last recorded activity, not from `createdAt`: `files.retry`
+ * re-queues an existing file by setting it back to `pending`, and an upload
+ * from last week is not stale just because it is being retried today.
  */
 export const STALE_PENDING_MS = 15 * 60 * 1000;
 
@@ -75,13 +79,10 @@ export function isStaleFile(params: {
   const { status, now } = params;
   if (status !== "pending" && status !== "processing") return false;
   const limit = status === "pending" ? STALE_PENDING_MS : STALE_PROCESSING_MS;
-  const lastActivity =
-    status === "pending"
-      ? params.createdAt
-      : lastFileActivityAt({
-          metadata: params.metadata,
-          createdAt: params.createdAt,
-        });
+  const lastActivity = lastFileActivityAt({
+    metadata: params.metadata,
+    createdAt: params.createdAt,
+  });
   return now.getTime() - lastActivity.getTime() > limit;
 }
 

--- a/apps/web/src/lib/file-stale.ts
+++ b/apps/web/src/lib/file-stale.ts
@@ -1,6 +1,7 @@
 import type { db as database } from "@teachanything/db";
 import { userFiles } from "@teachanything/db/schema";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { excludeCrawledPages, isCrawledPagePath } from "./crawled-page-files";
 import { logInfo, logError } from "./logger";
 
 /**
@@ -72,12 +73,20 @@ export function lastFileActivityAt(params: {
  */
 export function isStaleFile(params: {
   status: string;
+  storagePath: string | null;
   metadata: StaleFileMetadata;
   createdAt: Date;
   now: Date;
 }): boolean {
   const { status, now } = params;
   if (status !== "pending" && status !== "processing") return false;
+  // Crawled pages share this table and are recovered by `sweepStaleCrawls`, not
+  // here. They also never carry a `processingProgress` stamp -- a re-crawl sets
+  // `processing` without touching metadata -- so dating one from `createdAt`
+  // condemns a live re-crawl of a page first crawled weeks ago. The candidate
+  // query already filters them out; this keeps the guarantee in the predicate
+  // so a future caller can't lose it.
+  if (isCrawledPagePath(params.storagePath)) return false;
   const limit = status === "pending" ? STALE_PENDING_MS : STALE_PROCESSING_MS;
   const lastActivity = lastFileActivityAt({
     metadata: params.metadata,
@@ -100,6 +109,10 @@ export function staleFileError(status: string): string {
  * thing that died. Runs opportunistically on the file list reads, so it
  * self-heals the moment the owner next opens the page.
  *
+ * Covers uploaded files only. Crawled pages live in `userFiles` too but are
+ * owned by `sweepStaleCrawls`, which judges them by crawl-page activity rather
+ * than by this table's progress stamps -- see `excludeCrawledPages`.
+ *
  * Never throws; a failed sweep must not break the read that triggered it.
  */
 export async function sweepStaleFiles(params: {
@@ -115,6 +128,7 @@ export async function sweepStaleFiles(params: {
       .select({
         id: userFiles.id,
         processingStatus: userFiles.processingStatus,
+        storagePath: userFiles.storagePath,
         metadata: userFiles.metadata,
         createdAt: userFiles.createdAt,
       })
@@ -123,13 +137,20 @@ export async function sweepStaleFiles(params: {
         and(
           eq(userFiles.userId, userId),
           inArray(userFiles.processingStatus, [...IN_PROGRESS_STATUSES]),
+          excludeCrawledPages,
         ),
       )
+      // Oldest first, so the `MAX_SWEPT_FILES` cap takes the rows most likely
+      // to be stale instead of an arbitrary slice. Without an order, an account
+      // over the cap can hand back the same page of rows forever and never
+      // reach the rest.
+      .orderBy(asc(userFiles.createdAt))
       .limit(MAX_SWEPT_FILES);
 
     const stale = candidates.filter((file) =>
       isStaleFile({
         status: file.processingStatus,
+        storagePath: file.storagePath,
         metadata: file.metadata,
         createdAt: file.createdAt,
         now,
@@ -156,6 +177,7 @@ export async function sweepStaleFiles(params: {
           and(
             inArray(userFiles.id, ids),
             eq(userFiles.processingStatus, status),
+            excludeCrawledPages,
           ),
         );
     }

--- a/apps/web/src/lib/processing-error.ts
+++ b/apps/web/src/lib/processing-error.ts
@@ -1,0 +1,60 @@
+/**
+ * Owner-facing messages for a failed file-processing run.
+ *
+ * Split out from `file-processor.ts` so it can be tested without pulling in
+ * the database, storage, and env singletons that module needs at import time.
+ */
+
+/** Shown when the upload is gone from storage but the row still exists. */
+export const STORAGE_MISSING_ERROR =
+  "The uploaded file could not be found in storage. Upload it again.";
+
+/**
+ * Turn an internal error into something the file owner can act on.
+ *
+ * The catch-all matters more than it looks: a professor who sees only "failed
+ * due to an internal error" cannot tell a scanned PDF from a corrupt one from
+ * an outage, so every failure looks like a platform bug and none of them get
+ * reported usefully. Each branch below names a real, observed failure and says
+ * what to do about it.
+ */
+export function sanitizeProcessingError(error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (msg.includes("timed out")) return "File processing timed out";
+  if (msg.includes("Unsupported file type")) return msg;
+  if (msg.includes("no readable text")) {
+    // Overwhelmingly a scan or an image-only export: there is no text layer to
+    // extract, and no amount of retrying will create one.
+    return (
+      "No readable text found. If this is a scanned document, it needs to be " +
+      "run through OCR (or re-exported as a text PDF) before it can be used."
+    );
+  }
+  if (msg.includes("Invalid PDF") || msg.includes("Empty buffer")) {
+    return "This file is not a readable PDF -- it may be truncated or corrupt. Try re-exporting or re-downloading it.";
+  }
+  if (msg.includes("password") || msg.includes("encrypted")) {
+    return "This file is password-protected. Remove the protection and upload it again.";
+  }
+  if (msg.includes("embedding") && msg.includes("dimension"))
+    return "Embedding dimension mismatch";
+  // Catch-alls keyed on OUR OWN wrapper text rather than on the parser's
+  // internals. pdf.js reports structural damage a dozen different ways ("bad
+  // XRef entry", "invalid top-level pages dictionary", ...) and that vocabulary
+  // shifts between versions, but the wrapper messages thrown by
+  // `RAGService.extract*` do not. Anything that failed inside extraction is,
+  // from the file owner's point of view, a file that could not be read.
+  if (msg.includes("Failed to extract PDF content")) {
+    return "This PDF could not be read -- it may be damaged, truncated, or protected. Try re-saving or re-downloading it from the original source.";
+  }
+  if (
+    msg.includes("Word document") ||
+    msg.includes("Failed to extract Word document content")
+  ) {
+    return "This Word document could not be read. If it is an older .doc file, save it as .docx and upload again.";
+  }
+  if (msg.includes("Failed to extract content")) {
+    return "This file could not be read. Try re-saving it in its native application and uploading again.";
+  }
+  return "File processing failed due to an internal error";
+}

--- a/apps/web/src/lib/processing-error.ts
+++ b/apps/web/src/lib/processing-error.ts
@@ -33,7 +33,12 @@ export function sanitizeProcessingError(error: unknown): string {
   if (msg.includes("Invalid PDF") || msg.includes("Empty buffer")) {
     return "This file is not a readable PDF -- it may be truncated or corrupt. Try re-exporting or re-downloading it.";
   }
-  if (msg.includes("password") || msg.includes("encrypted")) {
+  // Word-bounded and case-insensitive: the signal here comes from pdf.js's
+  // `PasswordException`, wrapped by `RAGService.extractPDF`, and its wording
+  // varies by cause and by version ("No password given", "Incorrect Password").
+  // A bare `includes("password")` missed the capitalized one outright, and
+  // matched unrelated messages that merely contained the letters.
+  if (/\bpasswords?\b|\bencrypted\b/i.test(msg)) {
     return "This file is password-protected. Remove the protection and upload it again.";
   }
   if (msg.includes("embedding") && msg.includes("dimension"))

--- a/apps/web/src/lib/quiz.ts
+++ b/apps/web/src/lib/quiz.ts
@@ -87,6 +87,33 @@ function extractBalanced(text: string, start: number): string | null {
 }
 
 /**
+ * Every complete `{...}` object inside the array that opens at `arrayStart`,
+ * stopping at the first one that was cut off mid-write.
+ *
+ * Shared by both truncation salvages: a quiz the token limit interrupted arrives
+ * either as JSON (`salvageTruncatedQuiz`) or as an unclosed pseudo-call
+ * (`extractPseudoCall`), and in both shapes the questions that finished writing
+ * are perfectly good.
+ */
+function collectClosedObjects(text: string, arrayStart: number): unknown[] {
+  const objects: unknown[] = [];
+  let cursor = arrayStart + 1;
+  for (;;) {
+    const objectStart = text.indexOf("{", cursor);
+    if (objectStart === -1) break;
+    const object = extractBalanced(text, objectStart);
+    if (!object) break; // the question that was cut off mid-write
+    try {
+      objects.push(JSON.parse(object));
+    } catch {
+      break;
+    }
+    cursor = objectStart + object.length;
+  }
+  return objects;
+}
+
+/**
  * Extract the first balanced top-level `{...}` object from free text, unwrapping
  * a leading ```json fence if present. Returns the JSON substring or null.
  */
@@ -110,7 +137,12 @@ function extractJsonObject(raw: string): string | null {
  * read, in either order; the `questions` payload must be valid JSON (it is, in
  * practice -- these models serialize the array itself as JSON). Anything looser
  * is rejected rather than repaired, so ordinary prose can't be misread as a
- * quiz. Returns a candidate object for schema validation, or null.
+ * quiz. Returns a candidate object for validation/repair, or null.
+ *
+ * A call the token limit cut off mid-write never closes its `questions` array.
+ * Rather than discard a quiz that is almost entirely usable, keep the question
+ * objects that finished -- the same salvage `salvageTruncatedQuiz` performs for
+ * a truncated JSON leak.
  */
 function extractPseudoCall(raw: string): unknown | null {
   const call = raw.match(/showQuiz\s*\(/);
@@ -122,14 +154,23 @@ function extractPseudoCall(raw: string): unknown | null {
   if (!title?.[1] || questionsKey?.index === undefined) return null;
 
   const arrayStart = questionsKey.index + questionsKey[0].length - 1;
-  const questions = extractBalanced(body, arrayStart);
-  if (!questions) return null;
+  const array = extractBalanced(body, arrayStart);
+
+  let questions: unknown;
+  if (array) {
+    try {
+      questions = JSON.parse(array) as unknown;
+    } catch {
+      return null;
+    }
+  } else {
+    const salvaged = collectClosedObjects(body, arrayStart);
+    if (salvaged.length === 0) return null;
+    questions = salvaged;
+  }
 
   try {
-    return {
-      quiz_title: JSON.parse(title[1]) as string,
-      questions: JSON.parse(questions) as unknown,
-    };
+    return { quiz_title: JSON.parse(title[1]) as string, questions };
   } catch {
     return null;
   }
@@ -142,15 +183,33 @@ function extractPseudoCall(raw: string): unknown | null {
  * `tool-showQuiz` part and the raw call renders as prose. Two shapes are
  * recovered: a JSON object (optionally in a ```json fence) and a pseudo-call
  * (`showQuiz(quiz_title=..., questions=[...])`). The JSON shape is tried first
- * -- it's the cheaper parse and the more common leak. Returns null for anything
- * that isn't a structurally valid, renderable quiz, so ordinary prose (or a
- * non-quiz JSON code block) is left untouched.
+ * -- it's the cheaper parse and the more common leak -- then the pseudo-call,
+ * then a JSON leak the token limit truncated.
+ *
+ * Each candidate goes through `repairQuiz`, the same coercion the native
+ * tool-call path applies (`experimental_repairToolCall` and
+ * `repairQuizToolParts`). Without it this path was strictly stricter than the
+ * tool-call path: a leak with a sixth question, a five-option question, one
+ * botched question, or an aliased answer key (`answer: "B"`) was discarded
+ * whole and the raw call -- answer keys, explanations and all -- was flushed to
+ * the student as text. A leaked quiz now renders exactly when the same quiz
+ * would have rendered had the model used the tool channel.
+ *
+ * Still returns null for anything that can't yield a renderable quiz, so
+ * ordinary prose (or a non-quiz JSON code block) is left untouched: `repairQuiz`
+ * requires a non-empty string `quiz_title` plus an array of questions, and
+ * drops every question that won't render.
  */
 export function parseQuizFromText(text: string): Quiz | null {
-  for (const candidate of [jsonCandidate(text), extractPseudoCall(text)]) {
+  const candidates = [
+    jsonCandidate(text),
+    extractPseudoCall(text),
+    salvageTruncatedQuiz(text),
+  ];
+  for (const candidate of candidates) {
     if (candidate === null) continue;
-    const result = quizSchema.safeParse(candidate);
-    if (result.success && isRenderableQuiz(result.data)) return result.data;
+    const quiz = repairQuiz(candidate);
+    if (quiz) return quiz;
   }
   return null;
 }
@@ -171,20 +230,7 @@ function salvageTruncatedQuiz(text: string): unknown | null {
   const questionsKey = text.search(/"questions"\s*:\s*\[/);
   if (!title?.[1] || questionsKey === -1) return null;
 
-  const questions: unknown[] = [];
-  let cursor = text.indexOf("[", questionsKey) + 1;
-  for (;;) {
-    const objectStart = text.indexOf("{", cursor);
-    if (objectStart === -1) break;
-    const object = extractBalanced(text, objectStart);
-    if (!object) break; // the question that was cut off mid-write
-    try {
-      questions.push(JSON.parse(object));
-    } catch {
-      break;
-    }
-    cursor = objectStart + object.length;
-  }
+  const questions = collectClosedObjects(text, text.indexOf("[", questionsKey));
   if (questions.length === 0) return null;
 
   try {

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -145,6 +145,45 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
     markerAt = -1;
   };
 
+  /**
+   * Try to end the held block as a recovered quiz. Returns false when the held
+   * text isn't one, leaving the caller to emit the block unchanged.
+   *
+   * `endChunk` is the block's `text-end` when the stream produced one; a stream
+   * that dies first (abort, or an upstream that closes without it) passes
+   * undefined, and the text parts are simply closed by the stream ending.
+   */
+  const closeBlock = (
+    controller: TransformStreamDefaultController<Chunk>,
+    endChunk?: Chunk,
+  ): boolean => {
+    const quiz =
+      markerAt === -1 ? null : parseQuizFromText(pendingText.slice(markerAt));
+    if (!quiz) return false;
+    // Drop the leaked call. Keep any preamble before it as text -- it is a
+    // real part of the answer -- and close the block only if text was
+    // emitted, so a leak-only block leaves no empty bubble behind.
+    const preamble = pendingText.slice(0, markerAt);
+    if (startEmitted || preamble.trim().length > 0) {
+      emitStart(controller);
+      if (preamble.length > 0) {
+        controller.enqueue({
+          type: "text-delta",
+          id: blockId,
+          delta: preamble,
+        } as Chunk);
+      }
+      if (endChunk) controller.enqueue(endChunk);
+    }
+    controller.enqueue({
+      type: "tool-input-available",
+      toolCallId: nanoid(),
+      toolName: "showQuiz",
+      input: quiz,
+    } as Chunk);
+    return true;
+  };
+
   return new TransformStream<Chunk, Chunk>({
     transform(chunk, controller) {
       if (chunk.type === "text-start") {
@@ -195,37 +234,10 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
         chunk.type === "text-end" &&
         chunk.id === blockId
       ) {
-        const quiz =
-          markerAt === -1
-            ? null
-            : parseQuizFromText(pendingText.slice(markerAt));
-        if (!quiz) {
+        if (!closeBlock(controller, chunk)) {
           flushPending(controller);
           controller.enqueue(chunk);
-          reset();
-          return;
         }
-        // Drop the leaked call. Keep any preamble before it as text -- it is a
-        // real part of the answer -- and close the block only if text was
-        // emitted, so a leak-only block leaves no empty bubble behind.
-        const preamble = pendingText.slice(0, markerAt);
-        if (startEmitted || preamble.trim().length > 0) {
-          emitStart(controller);
-          if (preamble.length > 0) {
-            controller.enqueue({
-              type: "text-delta",
-              id: blockId,
-              delta: preamble,
-            } as Chunk);
-          }
-          controller.enqueue(chunk);
-        }
-        controller.enqueue({
-          type: "tool-input-available",
-          toolCallId: nanoid(),
-          toolName: "showQuiz",
-          input: quiz,
-        } as Chunk);
         reset();
         return;
       }
@@ -239,7 +251,11 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
       controller.enqueue(chunk);
     },
     flush(controller) {
-      if (blockId !== null) flushPending(controller);
+      // A stream that ends without the block's `text-end` -- an abort, or an
+      // upstream that just stops -- used to dump the held leak as raw text.
+      // Recover it here too, so the student gets the widget rather than the
+      // model's own answer key.
+      if (blockId !== null && !closeBlock(controller)) flushPending(controller);
       reset();
     },
   });

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -151,7 +151,10 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
    *
    * `endChunk` is the block's `text-end` when the stream produced one; a stream
    * that dies first (abort, or an upstream that closes without it) passes
-   * undefined, and the text parts are simply closed by the stream ending.
+   * undefined, in which case a `text-end` is synthesized. Every `text-start`
+   * this transform emits gets a matching `text-end`: an unterminated text part
+   * stays in `streaming` state on the client and in the persisted parts, which
+   * renders the preamble as a message that never finished arriving.
    */
   const closeBlock = (
     controller: TransformStreamDefaultController<Chunk>,
@@ -173,7 +176,9 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
           delta: preamble,
         } as Chunk);
       }
-      if (endChunk) controller.enqueue(endChunk);
+      controller.enqueue(
+        endChunk ?? ({ type: "text-end", id: blockId } as Chunk),
+      );
     }
     controller.enqueue({
       type: "tool-input-available",
@@ -184,11 +189,25 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
     return true;
   };
 
+  /**
+   * Flush a block that will never receive its own `text-end` -- the stream
+   * ended, or a non-text chunk arrived while the block was still open -- and
+   * close it. `flushPending` always emits the `text-start`, so there is always a
+   * part to close.
+   */
+  const endBlock = (controller: TransformStreamDefaultController<Chunk>) => {
+    const id = blockId;
+    flushPending(controller);
+    if (id !== null) {
+      controller.enqueue({ type: "text-end", id } as Chunk);
+    }
+  };
+
   return new TransformStream<Chunk, Chunk>({
     transform(chunk, controller) {
       if (chunk.type === "text-start") {
         // Defensive: a well-formed stream closes a block before opening another.
-        if (blockId !== null) flushPending(controller);
+        if (blockId !== null) endBlock(controller);
         reset();
         blockId = chunk.id;
         startChunk = chunk;
@@ -245,7 +264,7 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
       // Any other chunk (tool parts, a delta for a different id, etc.). Flush an
       // open block first to preserve ordering.
       if (blockId !== null) {
-        flushPending(controller);
+        endBlock(controller);
         reset();
       }
       controller.enqueue(chunk);
@@ -255,7 +274,7 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
       // upstream that just stops -- used to dump the held leak as raw text.
       // Recover it here too, so the student gets the widget rather than the
       // model's own answer key.
-      if (blockId !== null && !closeBlock(controller)) flushPending(controller);
+      if (blockId !== null && !closeBlock(controller)) endBlock(controller);
       reset();
     },
   });

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -55,7 +55,7 @@ import {
 } from "./repair-quiz-parts";
 import { ChatRequestError } from "./request";
 import { buildStudyResultsNote } from "@/server/study/model-note";
-import { repairQuiz } from "@/lib/quiz";
+import { parseQuizFromText, repairQuiz } from "@/lib/quiz";
 
 import { isRetrievalToolPart } from "@/lib/retrieval-tool-names";
 
@@ -333,7 +333,7 @@ export async function streamChat(params: {
   );
 
   const studyAddendum = modelCanUseTools
-    ? buildStudyToolsAddendum(maxOutputTokens)
+    ? buildStudyToolsAddendum(maxOutputTokens, useRetrievalTools)
     : "";
   const primarySystemPrompt =
     (useRetrievalTools
@@ -489,6 +489,17 @@ export async function streamChat(params: {
         executeErrored = true;
         return;
       }
+      // The turn's text, across every step. `primary.text` resolves to the LAST
+      // step's text only, and this turn is deliberately multi-step
+      // (`stopWhen` above), so a model that answers in an earlier step and ends
+      // on a retrieval call -- or on the step cap -- reads as having produced
+      // nothing. That false negative fired the empty-response fallback below,
+      // appending a second, independently generated answer to a turn the
+      // student had already seen answered. Fall back to `primaryText` so a
+      // provider that leaves `step.text` unset can't regress this.
+      const stepsText = primarySteps.map((step) => step.text ?? "").join("");
+      const turnText = stepsText.trim() ? stepsText : primaryText;
+
       const allToolCalls = primarySteps.flatMap((s) => s.toolCalls ?? []);
       const doneCall = allToolCalls.find((tc) => tc.toolName === "done");
       const doneInput = doneCall?.input as { answer?: unknown } | undefined;
@@ -520,7 +531,7 @@ export async function streamChat(params: {
 
       // If the model answered only through the `done` tool (no free text),
       // surface that answer as a text part so it renders and persists as text.
-      if (doneAnswer && doneAnswer.trim() && !primaryText.trim()) {
+      if (doneAnswer && doneAnswer.trim() && !turnText.trim()) {
         const id = nanoid();
         writer.write({ type: "text-start", id });
         writer.write({ type: "text-delta", id, delta: doneAnswer });
@@ -528,7 +539,7 @@ export async function streamChat(params: {
       }
 
       const hasVisibleAnswer =
-        Boolean(primaryText.trim()) ||
+        Boolean(turnText.trim()) ||
         Boolean(doneAnswer?.trim()) ||
         producedQuiz ||
         salvagedTruncatedQuiz;
@@ -537,12 +548,13 @@ export async function streamChat(params: {
 
       if (!hasVisibleAnswer && modelCanUseTools && !abortSignal.aborted) {
         // Empty-response safety net (#357): a tool-capable turn produced no
-        // user-visible content (searched then hit the step cap, `done` with an
-        // empty answer, an invalid-only quiz, or a study-only bot that emitted
-        // neither text nor a valid quiz). Gated on `modelCanUseTools` -- not
-        // `useRetrievalTools` -- so the study-only path (zero files, or RAG
-        // unhealthy) is covered too. Fall back to a static, no-tools turn so the
-        // user always gets an answer instead of a stuck, empty stream.
+        // user-visible content in ANY step (searched then hit the step cap,
+        // `done` with an empty answer, an invalid-only quiz, or a study-only
+        // bot that emitted neither text nor a valid quiz). Gated on
+        // `modelCanUseTools` -- not `useRetrievalTools` -- so the study-only
+        // path (zero files, or RAG unhealthy) is covered too. Fall back to a
+        // static, no-tools turn so the user always gets an answer instead of a
+        // stuck, empty stream.
         logWarn(
           "Agentic path produced no text response; falling back to static RAG",
           { chatbotId: chatbot.id, modelId },
@@ -617,15 +629,22 @@ export async function streamChat(params: {
         parts: persistedParts,
       });
       const hasStudyPart = hasPersistableStudyPart(parts);
+      // A quiz the model leaked into the text channel (see `recoverLeakedQuiz`)
+      // is quiz content too, even though it never became a tool part. Buffering
+      // that leak is exactly what makes the turn look stalled, so it is the turn
+      // a student is most likely to Stop -- and dropping it is what made a quiz
+      // turn vanish from the professor's transcript entirely.
+      const hasQuizContent =
+        hasStudyPart || parseQuizFromText(content) !== null;
 
       // On a client disconnect, don't persist a partial assistant turn (or its
-      // analytics) -- UNLESS it carries a completed study part. The rendered
-      // quiz stays interactive on screen after a Stop, and recording an attempt
-      // requires the persisted part to validate against; skipping the persist
-      // would make every submission for that quiz 404 forever. The user message
-      // was already saved up front either way.
+      // analytics) -- UNLESS it carries quiz content. The rendered quiz stays
+      // interactive on screen after a Stop, and recording an attempt requires
+      // the persisted part to validate against; skipping the persist would make
+      // every submission for that quiz 404 forever. The user message was
+      // already saved up front either way.
       const clientAborted = abortSignal.aborted && !timeoutSignal.aborted;
-      if (clientAborted && !hasStudyPart) return;
+      if (clientAborted && !hasQuizContent) return;
 
       const interrupted =
         timeoutSignal.aborted || executeErrored || clientAborted;

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -639,13 +639,6 @@ export async function streamChat(params: {
         parts: persistedParts,
       });
       const hasStudyPart = hasPersistableStudyPart(parts);
-      // A quiz the model leaked into the text channel (see `recoverLeakedQuiz`)
-      // is quiz content too, even though it never became a tool part. Buffering
-      // that leak is exactly what makes the turn look stalled, so it is the turn
-      // a student is most likely to Stop -- and dropping it is what made a quiz
-      // turn vanish from the professor's transcript entirely.
-      const hasQuizContent =
-        hasStudyPart || parseQuizFromText(content) !== null;
 
       // On a client disconnect, don't persist a partial assistant turn (or its
       // analytics) -- UNLESS it carries quiz content. The rendered quiz stays
@@ -653,8 +646,17 @@ export async function streamChat(params: {
       // the persisted part to validate against; skipping the persist would make
       // every submission for that quiz 404 forever. The user message was
       // already saved up front either way.
+      //
+      // A quiz the model leaked into the text channel (see `recoverLeakedQuiz`)
+      // counts as quiz content too, even though it never became a tool part.
+      // Buffering that leak is exactly what makes the turn look stalled, so it
+      // is the turn a student is most likely to Stop -- and dropping it is what
+      // made a quiz turn vanish from the professor's transcript entirely. Only
+      // parsed on the abort path: on every other turn the answer is unused, and
+      // this is a full scan plus a JSON parse of the whole message.
       const clientAborted = abortSignal.aborted && !timeoutSignal.aborted;
-      if (clientAborted && !hasQuizContent) return;
+      if (clientAborted && !hasStudyPart && parseQuizFromText(content) === null)
+        return;
 
       const interrupted =
         timeoutSignal.aborted || executeErrored || clientAborted;

--- a/apps/web/src/server/chat/stream-chat.ts
+++ b/apps/web/src/server/chat/stream-chat.ts
@@ -531,7 +531,17 @@ export async function streamChat(params: {
 
       // If the model answered only through the `done` tool (no free text),
       // surface that answer as a text part so it renders and persists as text.
-      if (doneAnswer && doneAnswer.trim() && !turnText.trim()) {
+      //
+      // This gate deliberately reads `primaryText` (the LAST step's text), not
+      // `turnText`. `done` is a retrieval tool: its part is stripped from the
+      // stream and from `persistedParts`, so an answer delivered through it is
+      // invisible unless written out here. A model that narrates in an earlier
+      // step ("Let me check the readings.") and then answers via `done` has a
+      // non-empty `turnText` but an empty final step -- gating on `turnText`
+      // there would swallow the answer entirely. `hasVisibleAnswer` below is
+      // the opposite question ("did the turn produce anything at all?") and
+      // correctly spans every step.
+      if (doneAnswer && doneAnswer.trim() && !primaryText.trim()) {
         const id = nanoid();
         writer.write({ type: "text-start", id });
         writer.write({ type: "text-delta", id, delta: doneAnswer });

--- a/apps/web/src/server/chat/study-tools.ts
+++ b/apps/web/src/server/chat/study-tools.ts
@@ -42,12 +42,29 @@ export function maxQuestionsForBudget(maxOutputTokens: number): number {
   return Math.min(MAX_QUIZ_QUESTIONS, Math.max(1, affordable));
 }
 
-/** Appended to the chatbot's system prompt so the model knows the tools exist. */
-export function buildStudyToolsAddendum(maxOutputTokens: number): string {
+/**
+ * Appended to the chatbot's system prompt so the model knows the tools exist.
+ *
+ * `canSearch` mirrors the retrieval-tool gate in `streamChat`: only promise the
+ * model a search when `search_documents` is actually in its toolset.
+ *
+ * The scoping sentence matters as much as the tool instruction. Without it this
+ * addendum's "based on the course material above" was the last thing in the
+ * system prompt, and it pointed the model at whatever the initial RAG query
+ * happened to retrieve -- so a student who asked to be quizzed on one named
+ * chapter got questions drawn from across the whole corpus instead.
+ */
+export function buildStudyToolsAddendum(
+  maxOutputTokens: number,
+  canSearch: boolean,
+): string {
   const maxQuestions = maxQuestionsForBudget(maxOutputTokens);
+  const scoping = canSearch
+    ? " If the passages above do not cover what they named, search the documents for it before writing any questions."
+    : "";
   return `
 
-You can render interactive study tools. When the student asks to be quizzed on a topic, call the \`showQuiz\` tool and fill it with well-formed questions based on the course material above - do not write the quiz out as prose. Keep the quiz to at most ${maxQuestions} ${maxQuestions === 1 ? "question" : "questions"}, each with up to 4 options and a one- or two-sentence explanation, so the whole quiz fits within this chatbot's reply limit. If the student is only asking a question, answer normally without calling a tool.`;
+You can render interactive study tools. When the student asks to be quizzed on a topic, call the \`showQuiz\` tool and fill it with well-formed questions based on the course material above - do not write the quiz out as prose. Scope the quiz to exactly what the student asked for: when they name a chapter, section, reading, topic, or text, every question must come from that material, and material outside it must be left out no matter how relevant it seems.${scoping} Keep the quiz to at most ${maxQuestions} ${maxQuestions === 1 ? "question" : "questions"}, each with up to 4 options and a one- or two-sentence explanation, so the whole quiz fits within this chatbot's reply limit. If the student is only asking a question, answer normally without calling a tool.`;
 }
 
 /**

--- a/apps/web/src/server/chat/ui-messages.ts
+++ b/apps/web/src/server/chat/ui-messages.ts
@@ -1,3 +1,4 @@
+import { repairQuiz } from "@/lib/quiz";
 import type { StudyUIMessage } from "./study-tools";
 
 type MessageRow = {
@@ -59,13 +60,41 @@ export function rowToUIMessage(row: MessageRow): StudyUIMessage {
   };
 }
 
+/**
+ * Finish a study-tool part for storage.
+ *
+ * A completed call (`input-available`) becomes `output-available`, which is what
+ * makes it render on reload.
+ *
+ * A part still in `input-streaming` is a quiz the turn ended in the middle of --
+ * a Stop, a disconnect, or the token limit -- and stored as-is it is the
+ * "Building your quiz..." skeleton, which spins forever in history (see
+ * `hasPersistableStudyPart`). Repair it into the questions that finished, the
+ * same salvage the live stream applies via `closeTruncatedQuizInputs`. When
+ * nothing is salvageable the part is left alone, so it stays non-persistable
+ * rather than becoming a ghost row.
+ *
+ * `output-error` parts are left untouched: the student saw the error notice and
+ * history should show what they saw.
+ */
 function completeStudyToolPart(
   part: StudyUIMessage["parts"][number],
 ): StudyUIMessage["parts"][number] {
-  if (part.type === "tool-showQuiz" && part.state === "input-available") {
+  if (part.type !== "tool-showQuiz") return part;
+  if (part.state === "input-available") {
     return {
       ...part,
       state: "output-available",
+      output: "rendered",
+    } as unknown as StudyUIMessage["parts"][number];
+  }
+  if (part.state === "input-streaming") {
+    const quiz = repairQuiz(part.input);
+    if (!quiz) return part;
+    return {
+      ...part,
+      state: "output-available",
+      input: quiz,
       output: "rendered",
     } as unknown as StudyUIMessage["parts"][number];
   }

--- a/apps/web/src/server/routers/files/procedures/list.ts
+++ b/apps/web/src/server/routers/files/procedures/list.ts
@@ -19,6 +19,7 @@ import {
   chatbotFileAssociations,
 } from "@teachanything/db/schema";
 import { escapeLikePattern } from "@/server/utils";
+import { sweepStaleFiles } from "@/lib/file-stale";
 
 // Crawler-sourced userFiles have storagePath set to the page URL.
 // Crawled pages are shown as grouped "Web Sources" rows in the Files tab
@@ -53,6 +54,10 @@ export const listProcedure = protectedProcedure
       .optional(),
   )
   .query(async ({ ctx, input }) => {
+    // Settle abandoned processing runs before reading so a dead worker can't
+    // leave a file spinning at 40% forever (see sweepStaleFiles).
+    await sweepStaleFiles({ db: ctx.db, userId: ctx.session.user.id });
+
     const limit = input?.limit ?? 10;
     const offset = input?.offset ?? 0;
     const currentChatbotId = input?.currentChatbotId;
@@ -193,6 +198,10 @@ export const listForChatbotProcedure = protectedProcedure
     }),
   )
   .query(async ({ ctx, input }) => {
+    // Settle abandoned processing runs before reading so a dead worker can't
+    // leave a file spinning at 40% forever (see sweepStaleFiles).
+    await sweepStaleFiles({ db: ctx.db, userId: ctx.session.user.id });
+
     // Verify chatbot ownership
     const [chatbot] = await ctx.db
       .select()

--- a/apps/web/src/server/routers/files/procedures/list.ts
+++ b/apps/web/src/server/routers/files/procedures/list.ts
@@ -1,17 +1,6 @@
 import { protectedProcedure } from "@/server/trpc";
 import { z } from "zod";
-import {
-  eq,
-  and,
-  sql,
-  desc,
-  asc,
-  ilike,
-  like,
-  or,
-  isNull,
-  not,
-} from "drizzle-orm";
+import { eq, and, sql, desc, asc, ilike, or, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import {
   chatbots,
@@ -20,14 +9,10 @@ import {
 } from "@teachanything/db/schema";
 import { escapeLikePattern } from "@/server/utils";
 import { sweepStaleFiles } from "@/lib/file-stale";
-
-// Crawler-sourced userFiles have storagePath set to the page URL.
 // Crawled pages are shown as grouped "Web Sources" rows in the Files tab
 // (rendered from crawler.getCrawlSources) rather than cluttering the
 // uploaded-file table as individual rows.
-// Uploaded files always use a lowercase `{userId}/{fileId}` path, so a
-// case-sensitive LIKE is sufficient (and index-friendlier than ILIKE).
-const excludeCrawledPages = not(like(userFiles.storagePath, "http%"));
+import { excludeCrawledPages } from "@/lib/crawled-page-files";
 
 /**
  * List all user files (centralized) with search and sort

--- a/apps/web/src/server/routers/files/procedures/retry.ts
+++ b/apps/web/src/server/routers/files/procedures/retry.ts
@@ -58,12 +58,27 @@ export const retryProcedure = protectedProcedure
         userId: ctx.session.user.id,
       });
 
-      // Reset file status to pending and clear error metadata
+      // Reset file status to pending and clear error metadata.
+      //
+      // The progress stamp matters: `userFiles` has no `updatedAt`, so the
+      // stale sweep dates a `pending` file from its last recorded activity,
+      // falling back to `createdAt`. Clearing metadata outright would leave a
+      // days-old upload looking like it had been queued days ago, and the
+      // `files.list` refetch this mutation triggers would sweep it straight
+      // back to `failed` before the job ever ran.
+      const queuedAt = new Date().toISOString();
       await ctx.db
         .update(userFiles)
         .set({
           processingStatus: "pending",
-          metadata: {},
+          metadata: {
+            processingProgress: {
+              stage: "downloading",
+              percentage: 0,
+              startedAt: queuedAt,
+              lastUpdatedAt: queuedAt,
+            },
+          },
         })
         .where(eq(userFiles.id, input.fileId));
 

--- a/apps/web/src/types/pdf-parse-lib.d.ts
+++ b/apps/web/src/types/pdf-parse-lib.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Types for the `pdf-parse/lib/pdf-parse.js` subpath.
+ *
+ * `@types/pdf-parse` declares only the package root, but the root is exactly
+ * what must not be imported: its `!module.parent` debug block crashes under ESM
+ * (see the note in `RAGService.extractPDF`). `lib/pdf-parse.js` is the parser
+ * the root re-exports, so it takes the same arguments and returns the same
+ * shape -- borrow the root's declaration rather than restating it.
+ */
+declare module "pdf-parse/lib/pdf-parse.js" {
+  import type PdfParse from "pdf-parse";
+
+  const pdfParse: typeof PdfParse;
+  export default pdfParse;
+}

--- a/packages/ai/src/__tests__/extract-pdf.test.ts
+++ b/packages/ai/src/__tests__/extract-pdf.test.ts
@@ -1,0 +1,95 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+/**
+ * Mock the IMPLEMENTATION subpath, not the package root.
+ *
+ * That is the whole point of the fix under test: pdf-parse@1.1.1's index.js
+ * runs `!module.parent` debug code at import time, which under ESM tries to
+ * read a fixture relative to the process CWD and throws ENOENT before touching
+ * the upload. `extractPDF` imports `pdf-parse/lib/pdf-parse.js` to skip it.
+ *
+ * Because this mock is keyed to that exact specifier, it only intercepts if the
+ * production code still uses it -- so a revert to `import("pdf-parse")` makes
+ * these tests load the real (crashing) module rather than passing quietly.
+ */
+const mockPdfParse = jest.fn<(buffer: Buffer) => Promise<{ text: string }>>();
+
+jest.unstable_mockModule("pdf-parse/lib/pdf-parse.js", () => ({
+  default: mockPdfParse,
+}));
+
+const { RAGService } = await import("../rag-service");
+
+const service = new RAGService({ openaiApiKey: "test-key" });
+const pdf = (body = "body") => Buffer.from(`%PDF-1.7\n${body}`);
+const extract = (buffer: Buffer) =>
+  service.extractContent(buffer, "application/pdf");
+
+describe("RAGService PDF extraction", () => {
+  beforeEach(() => {
+    mockPdfParse.mockReset();
+  });
+
+  it("parses through the implementation subpath", async () => {
+    mockPdfParse.mockResolvedValue({ text: "Photosynthesis converts light." });
+
+    await expect(extract(pdf())).resolves.toBe(
+      "Photosynthesis converts light.",
+    );
+    expect(mockPdfParse).toHaveBeenCalledTimes(1);
+    // The buffer is handed over untouched; pdf-parse accepts Buffers.
+    expect(Buffer.isBuffer(mockPdfParse.mock.calls[0]![0])).toBe(true);
+  });
+
+  it("keeps form feeds so page-aware chunking still sees page breaks", async () => {
+    mockPdfParse.mockResolvedValue({ text: "page one\fpage two" });
+
+    await expect(extract(pdf())).resolves.toBe("page one\fpage two");
+  });
+
+  it("rejects an empty upload before reaching the parser", async () => {
+    await expect(extract(Buffer.alloc(0))).rejects.toThrow("Empty buffer");
+    expect(mockPdfParse).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-PDF renamed .pdf before reaching the parser", async () => {
+    await expect(extract(Buffer.from("This is a text file"))).rejects.toThrow(
+      "Invalid PDF format",
+    );
+    expect(mockPdfParse).not.toHaveBeenCalled();
+  });
+
+  it("wraps a parser failure in the message the sanitizer keys on", async () => {
+    // `sanitizeProcessingError` matches this wrapper text rather than pdf.js's
+    // own vocabulary, which shifts between versions.
+    mockPdfParse.mockRejectedValue(new Error("bad XRef entry"));
+
+    await expect(extract(pdf())).rejects.toThrow(
+      "Failed to extract PDF content: bad XRef entry",
+    );
+  });
+
+  it("surfaces an encrypted PDF as a password failure", async () => {
+    mockPdfParse.mockRejectedValue(new Error("No password given"));
+
+    await expect(extract(pdf())).rejects.toThrow("No password given");
+  });
+
+  it("reports a scanned PDF as having no readable text", async () => {
+    // A text layer of nothing but whitespace is what an image-only export looks
+    // like once sanitized.
+    mockPdfParse.mockResolvedValue({ text: "  " });
+
+    await expect(extract(pdf())).rejects.toThrow(
+      "PDF contains no readable text content",
+    );
+  });
+
+  it("reports a parser that returns no text at all", async () => {
+    mockPdfParse.mockResolvedValue({ text: "" });
+
+    await expect(extract(pdf())).rejects.toThrow(
+      "Failed to extract PDF content",
+    );
+  });
+});

--- a/packages/ai/src/pdf-parse-lib.d.ts
+++ b/packages/ai/src/pdf-parse-lib.d.ts
@@ -7,10 +7,10 @@
  * the root re-exports, so it takes the same arguments and returns the same
  * shape -- borrow the root's declaration rather than restating it.
  *
- * Deliberately duplicated at `packages/ai/src/pdf-parse-lib.d.ts`. Both
- * projects type-check `rag-service.ts` (this app compiles that package's source
- * directly), and neither tsconfig includes the other's files, so an ambient
- * declaration in one is invisible to the other. Keep the two in sync.
+ * Deliberately duplicated at `apps/web/src/types/pdf-parse-lib.d.ts`. Both
+ * projects type-check `rag-service.ts` (the web app compiles this package's
+ * source directly), and neither tsconfig includes the other's files, so an
+ * ambient declaration in one is invisible to the other. Keep the two in sync.
  */
 declare module "pdf-parse/lib/pdf-parse.js" {
   import type PdfParse from "pdf-parse";

--- a/packages/ai/src/rag-service.ts
+++ b/packages/ai/src/rag-service.ts
@@ -137,8 +137,28 @@ export class RAGService {
         );
       }
 
-      // Dynamic import to avoid build-time execution
-      const pdfParse = (await import("pdf-parse")).default;
+      // Import the implementation module directly, NOT the package root.
+      //
+      // pdf-parse@1.1.1's index.js runs `let isDebugMode = !module.parent` at
+      // module scope. Under ESM (`"type": "module"` + dynamic import) there is
+      // no `module.parent`, so debug mode switches itself on and the file
+      // synchronously does:
+      //
+      //   Fs.readFileSync('./test/data/05-versions-space.pdf')
+      //
+      // That path is relative to the PROCESS CWD, but the fixture only ever
+      // exists inside the package (node_modules/pdf-parse/test/data/). The
+      // server's CWD is the app root -- `.next/standalone` in this app's
+      // `output: "standalone"` build -- so the read always misses and the
+      // import throws ENOENT before a single byte of the upload is touched.
+      // Every PDF then fails to process, whatever it contains. (pdf-parse is in
+      // `serverExternalPackages`, so it is loaded from node_modules by real
+      // Node at runtime rather than bundled, which is what exposes this.)
+      //
+      // `lib/pdf-parse.js` is the parser that index.js re-exports, so importing
+      // it skips the debug block entirely. Keep this subpath import; there is a
+      // regression test that loads this exact specifier in a bare Node process.
+      const pdfParse = (await import("pdf-parse/lib/pdf-parse.js")).default;
 
       // Pass the buffer directly - pdf-parse accepts Buffer instances
       const data = await pdfParse(buffer);


### PR DESCRIPTION
 - PDFs could not be uploaded at all:  the PDF library crashed before reading the file
- Uploads got stuck at 40% and then failed, and a killed job locked the file permanently
- The quiz bot wrote quizzes out in plain text (answers included), generated a second unrelated answer, and ignored the chapter a student named
- Failure messages were too broad to act on

# Changes
## 1) No one could upload PDFs

The library that reads PDFs has a bug: it contains leftover debugging code that tries to open a sample file the moment it loads. Where it's looking for the sample file doesn't exist, so the library crashes before it actually touches the file.

To fix this, we make it load that library through a side door, so it skips the broken debugging code.

## 2) Files uploading get stuck at 40%, then fail

The upload pipeline had no time limit set, so the uploads were getting cut off. To fix this, I made it have the same five-minute limit as all the other jobs.n addition to this, a job that got killed locked the file. When processing starts, the file gets marked as in progress, so two jobs can't grab it at once. But if one of the jobs dies, it doesn't get unmarked  so the file stays locked forever and every retry gives up on it. There is now a sweep that clears an abandoned lock so the file can be retried.

## 3) Quiz bugs

Llama 4 Maverick doesn't use the proper channel for building quizzes. This was already known, but the recovery step wasn't properly built  it gave up when the model used six questions instead of five, or a differently named answer field, and dumped the raw text on screen (which contains the answers). The system now uses the same repair path as the normal route: it trims extra questions and fixes renamed answer fields.

The history didn't match what the students saw, because the code basically checked "did the model say anything?" by looking at only the last step of its work. If the bot answered early and then did one more step, it looked like it had said nothing, so the app generated a second, different answer and stuck it on the end. That's where the "What topic are you interested in?" reply came from. Also, if a student hit Stop on a response that was still working, the whole reply was thrown away and never saved. To fix this, I made it check all the steps instead of just the last one.

The chapter instructions were also being ignored, because the instructions sent to the bot ended with "base questions on the course material above", pointing at whatever got pulled up automatically, with nothing telling it to respect the chapter the student named. I added that.

In addition to this, the failure messages were overly broad, so I made them less broad. A scanned PDF, a corrupt file and a real outage all reported the same generic "internal error", which is a large part of why this went undiagnosed for so long.

## Test Plan

- [x] Full pipeline run against a real Postgres + pgvector database with a 16-file corpus: real PDFs from five different producers, plus truncated, corrupt, empty, mislabelled, non-English, very long, and legacy-format files — all reach a proper end state with a sensible message
- [x] Verified the PDF fix by A/B: the same file fails to process before the change and completes after it
- [x] Edge cases: file deleted from storage mid-job, job killed mid-embedding, retrying a file uploaded weeks ago, student pressing Stop mid-quiz, quiz cut off by the token limit, model emitting six questions or a renamed answer field
- [x] Checked that ordinary answers containing JSON, code blocks, LaTeX or braces still stream through untouched and are not mistaken for a quiz
- [x] Manual check after deploy: upload a text PDF and a Word file, run a chapter-scoped quiz on the Critical Theory bot, and compare against the Shakespeare bot
- [x] Manual check after deploy: press Retry on a file that previously failed


