### PR TITLE
fix(db): disable prepared statements on the transaction-mode pooler

### DIFF
--- a/apps/web/src/__tests__/lib/logger-cause.test.ts
+++ b/apps/web/src/__tests__/lib/logger-cause.test.ts
@@ -1,0 +1,102 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+process.env.ENABLE_LOGGING = "true";
+
+const { logError } = await import("@teachanything/logger");
+
+/**
+ * The failure that motivated this: a retry died on
+ * `Failed query: delete from "file_chunks" where ...` and the log carried only
+ * that line. drizzle keeps the Postgres error -- the part naming what actually
+ * went wrong -- in `cause`, and `logError` was dropping it, so the logs said a
+ * statement failed without ever saying why.
+ */
+type LoggedCause = {
+  message: string;
+  name?: string;
+  code?: string;
+  severity?: string;
+  routine?: string;
+};
+type LoggedPayload = {
+  error: { message: string; name?: string; causes?: LoggedCause[] };
+};
+
+describe("logError cause unwrapping", () => {
+  let spy: ReturnType<typeof jest.spyOn>;
+  const logged = () => spy.mock.calls[0]?.[1] as unknown as LoggedPayload;
+
+  beforeEach(() => {
+    spy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => spy.mockRestore());
+
+  it("surfaces the postgres error a drizzle wrapper hides", () => {
+    const pgError = Object.assign(new Error('relation "x" does not exist'), {
+      code: "42P01",
+      severity: "ERROR",
+      routine: "parserOpenTable",
+    });
+    const wrapped = new Error('Failed query: delete from "file_chunks" ...', {
+      cause: pgError,
+    });
+
+    logError(wrapped, "File retry failed", { fileId: "abc" });
+
+    const { error } = logged();
+    expect(error.message).toContain("Failed query");
+    expect(error.causes).toHaveLength(1);
+    expect(error.causes?.[0]).toMatchObject({
+      message: 'relation "x" does not exist',
+      code: "42P01",
+      severity: "ERROR",
+      routine: "parserOpenTable",
+    });
+  });
+
+  it("walks a nested chain", () => {
+    const root = Object.assign(new Error("connection terminated"), {
+      code: "08006",
+    });
+    const mid = new Error("driver failed", { cause: root });
+    logError(new Error("query failed", { cause: mid }), "boom");
+
+    expect(logged().error.causes?.map((c) => c.message)).toEqual([
+      "driver failed",
+      "connection terminated",
+    ]);
+  });
+
+  it("omits the field entirely when there is no cause", () => {
+    logError(new Error("plain"), "boom");
+    expect(logged().error).not.toHaveProperty("causes");
+  });
+
+  it("does not hang on a self-referential chain", () => {
+    const a: Error & { cause?: unknown } = new Error("a");
+    const b: Error & { cause?: unknown } = new Error("b");
+    a.cause = b;
+    b.cause = a;
+
+    expect(() => logError(a, "boom")).not.toThrow();
+    expect(logged().error.causes?.length ?? 0).toBeLessThanOrEqual(5);
+  });
+
+  it("still unwraps when the thrown value is a plain object", () => {
+    logError(
+      { message: "wrapped", cause: { message: "inner", code: "22P02" } },
+      "boom",
+    );
+    expect(logged().error.causes?.[0]).toMatchObject({
+      message: "inner",
+      code: "22P02",
+    });
+  });
+});

--- a/packages/db/src/__tests__/db-client.test.ts
+++ b/packages/db/src/__tests__/db-client.test.ts
@@ -1,0 +1,56 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+/**
+ * Pins the connection options, because getting these wrong fails ONLY in
+ * production.
+ *
+ * Production connects through Supabase's transaction-mode pooler on port 6543,
+ * where a connection moves between backends across statements. Local
+ * development uses port 5432 (session mode), where prepared statements behave
+ * normally. So `prepare: true` passes every local run and every test, then
+ * throws `Failed query: ...` on ordinary statements once deployed. A silent
+ * regression here is invisible until users cannot retry or delete a file.
+ */
+process.env.DATABASE_URL = "postgresql://u:p@localhost:5432/test";
+
+// Captured in a plain array, not a jest.fn: `db.ts` calls postgres() at module
+// scope during import, and jest's mock-reset between tests would wipe a spy's
+// recorded call before any assertion could read it.
+const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+
+jest.unstable_mockModule("postgres", () => ({
+  __esModule: true,
+  default: (url: string, opts?: Record<string, unknown>) => {
+    calls.push([url, opts]);
+    return {} as never;
+  },
+}));
+jest.unstable_mockModule("drizzle-orm/postgres-js", () => ({
+  drizzle: jest.fn(() => ({}) as never),
+}));
+
+await import("../db");
+
+describe("database client options", () => {
+  const options = () => calls[0]?.[1] ?? {};
+
+  it("is constructed with an options object at all", () => {
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toBeDefined();
+  });
+
+  it("disables prepared statements for the transaction-mode pooler", () => {
+    expect(options().prepare).toBe(false);
+  });
+
+  it("caps the per-instance pool below the postgres.js default of 10", () => {
+    const max = options().max as number;
+    expect(typeof max).toBe("number");
+    expect(max).toBeGreaterThan(0);
+    expect(max).toBeLessThan(10);
+  });
+
+  it("sets an idle timeout so serverless instances release connections", () => {
+    expect(options().idle_timeout).toBeGreaterThan(0);
+  });
+});

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -13,5 +13,32 @@ if (!process.env.DATABASE_URL && !skipValidation) {
 const databaseUrl =
   process.env.DATABASE_URL || "postgresql://ci:ci@localhost:5432/ci";
 
-const client = postgres(databaseUrl);
+/**
+ * `prepare: false` is required, not a tuning knob.
+ *
+ * Production connects through Supabase's pooler on port 6543, which is
+ * TRANSACTION mode: a connection is handed to a different backend between
+ * statements, so a prepared statement created on one is not there for the next.
+ * postgres.js prepares any query it can infer is static, which is every
+ * parameterized drizzle query, so this surfaces as intermittent
+ * `Failed query: ...` on ordinary statements -- a chunk delete, a status update
+ * -- depending on which backend the connection landed on.
+ *
+ * It does not reproduce locally: local development points at port 5432, which is
+ * SESSION mode, where one backend serves a connection for its whole life and
+ * prepared statements behave normally. Same code, same driver, different pooler.
+ *
+ * The `?pgbouncer=true` in the production URL does not help; that is a Prisma
+ * parameter and postgres.js ignores it.
+ *
+ * `max` caps connections PER SERVERLESS INSTANCE. The default of 10 is a
+ * per-instance figure that multiplies by every concurrent function, so it is
+ * lowered here while leaving enough room that concurrent requests in one
+ * instance are not serialized behind a single connection.
+ */
+const client = postgres(databaseUrl, {
+  prepare: false,
+  max: 5,
+  idle_timeout: 20,
+});
 export const db = drizzle(client, { schema });

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -59,6 +59,56 @@ export async function withTiming<T>(
 }
 
 /**
+ * Fields a driver or client attaches to an error alongside `message`.
+ *
+ * Postgres (via postgres.js) is the one that matters here: `code`, `detail`,
+ * `constraint` and friends carry the actual reason a statement failed, and none
+ * of it is in `message`.
+ */
+const CAUSE_FIELDS = [
+  "code",
+  "detail",
+  "hint",
+  "constraint",
+  "table",
+  "column",
+  "routine",
+  "severity",
+] as const;
+
+type CauseInfo = {
+  message: string;
+  name?: string;
+} & Partial<Record<(typeof CAUSE_FIELDS)[number], string>>;
+
+/**
+ * Unwrap an error's `cause` chain into something loggable.
+ *
+ * Wrapper libraries put the real failure here and keep only a summary in
+ * `message`. drizzle is the case that bit us: a failing statement arrives as
+ * `Failed query: delete from "file_chunks" where ...` with the Postgres error
+ * -- the part naming what actually went wrong -- reachable only through
+ * `cause`. Logging just `message` turned a one-look diagnosis into a hunt.
+ *
+ * Depth-capped because a cause chain can be self-referential.
+ */
+function unwrapCause(error: unknown, depth = 0): CauseInfo[] {
+  if (depth > 4 || !error || typeof error !== "object") return [];
+  const cause = (error as { cause?: unknown }).cause;
+  if (!cause || typeof cause !== "object") return [];
+
+  const c = cause as Record<string, unknown>;
+  const info: CauseInfo = {
+    message: c.message?.toString() ?? String(cause),
+    name: c.name?.toString(),
+  };
+  for (const field of CAUSE_FIELDS) {
+    if (c[field] !== undefined) info[field] = String(c[field]);
+  }
+  return [info, ...unwrapCause(cause, depth + 1)];
+}
+
+/**
  * Log error with stack trace
  */
 export function logError(
@@ -72,6 +122,7 @@ export function logError(
     stack?: string;
     name?: string;
     details?: unknown;
+    causes?: CauseInfo[];
   };
 
   if (error instanceof Error) {
@@ -96,6 +147,9 @@ export function logError(
       name: "Error",
     };
   }
+
+  const causes = unwrapCause(error);
+  if (causes.length > 0) errorInfo.causes = causes;
 
   console.error(`[ERROR] ${message}`, {
     ...context,


### PR DESCRIPTION
> **Amended after merge (2026-08-21).** The original description named this as
> the fix for a specific production `files.retry` failure. That attribution was
> wrong, and the correction is recorded below under
> "Correction: what actually caused the reported failure". The code change is
> still correct and worth keeping — it is **preventative**, not corrective.

## What this changes

`packages/db/src/db.ts` built the client as `postgres(databaseUrl)` with no
options, so postgres.js used its default of `prepare: true`.

Production connects through Supabase's pooler on **port 6543**, which is
**transaction mode**: a connection is handed to a different backend between
statements, so a prepared statement created on one isn't there for the next.
Supabase's own documentation is explicit:

> Transaction mode does not support prepared statements. To avoid errors, turn
> off prepared statements for your connection library.

Port 5432 (session mode) supports them; port 6543 does not. Local development
points at 5432, which is why nothing here reproduces on a dev machine.

The `?pgbouncer=true` already in the production URL does not help: that's a
Prisma parameter, and postgres.js ignores it.

**Changes:**

- **`prepare: false`** — required by the pooler mode, per the docs above.
- **`max: 5`** (down from the postgres.js default of 10). That default is *per
  serverless instance* and multiplies by every concurrent function. Left high
  enough that concurrent requests in one instance aren't serialized behind a
  single connection.
- **`idle_timeout: 20`** so instances release connections instead of holding them.
- **`logError` now unwraps the `cause` chain.** It serialized only `message`,
  `stack` and `name`, and drizzle keeps the Postgres error in `cause` — so a
  failing statement reached the logs named but unexplained. Also carries the
  fields a driver attaches alongside `message` (`code`, `detail`, `hint`,
  `constraint`, …), depth-capped since a chain can be self-referential.

## Correction: what actually caused the reported failure

The failure that prompted this PR was:

```
[ERROR] File retry failed {
  error: { message: 'Failed query: delete from "file_chunks" where "file_chunks"."file_id" = $1' }
```

I attributed it to prepared statements. **It was almost certainly not that.**

The real cause was leaked session state on the pooler. Ad-hoc diagnostic queries
had been run against production through the 6543 pooler with
`SET default_transaction_read_only = on` prefixed to each one as a safety
measure. In transaction mode Supavisor returns a server backend to the pool
**without resetting session state**, so that `SET` persisted on shared backends
and other clients inherited it. A `DELETE` arriving on a poisoned backend fails,
and drizzle surfaces it as exactly the `Failed query: …` line above.

That also explains the two symptoms I read as pointing elsewhere: file
*deletion* failed too (not retry-specific), and it worked locally (a local
database was never poisoned).

Confirmed afterwards by comparing the two ports:

| | `setting` | `reset_val` | `source` |
|---|---|---|---|
| 6543 pooler | `on` | `off` | session |
| 5432 direct | `off` | `off` | default |

`source=session` with `reset_val=off`, on a connection nobody configured, is
leaked state — not a server default. It was cleared by repeatedly issuing
`SET default_transaction_read_only = off` until fresh connections read clean.
The same leak separately broke a release deploy with
`25006 / PreventCommandIfReadOnly` on `CREATE EXTENSION`.

### The gap in my original reasoning

The elimination table below was real work, but it had a hole: I never checked
`transaction_read_only`. Ruling out timeouts, locks, indexes and connection
limits made prepared statements look like the only candidate left, when the
actual cause was a category I hadn't tested for.

| Hypothesis | Finding |
|---|---|
| Slow delete / statement timeout | `EXPLAIN` shows an index scan, cost 35. `statement_timeout` is 2min. |
| The file has many chunks | It has **zero**. The delete matches nothing. |
| Missing index on `file_chunks.file_id` | Present. |
| Lock contention | No non-idle queries, no waits. |
| Connection exhaustion | 9 of 60 in use. |
| Read-only transaction state | **Not checked. This was the actual cause.** |

## Why it still belongs on main

`prepare: true` against a transaction-mode pooler is a genuine latent bug that
the vendor documents against. It fails probabilistically — postgres.js prepares
lazily per connection, so a collision needs the client's statement cache to
disagree with whichever backend it lands on — which is consistent with the app
having run 9+ months without an attributable incident. Landing the fix removes a
real failure mode; it just wasn't the one in the log above.

The `cause` logging is the durable win here. Diagnosing this took hours of
probing that a single log line should have answered, and the next occurrence will
print the Postgres `code` instead of leaving it to inference.

## Tests

`packages/db/src/__tests__/db-client.test.ts` pins the connection options —
worth having because **every wrong value here passes locally and fails only once
deployed**. The mock captures into a plain array rather than a `jest.fn`, since
`db.ts` calls `postgres()` at module scope during import and this package's jest
config resets mocks before assertions run.

`apps/web/src/__tests__/lib/logger-cause.test.ts` covers the wrapped-Postgres-error
case verbatim, nested chains, absent causes, self-referential chains, and a thrown
plain object.
