### PR TITLE
fix(ai): stop retrying an exhausted API quota, and say so when the provider is the problem

### DIFF
--- a/apps/web/src/__tests__/lib/processing-errors.test.ts
+++ b/apps/web/src/__tests__/lib/processing-errors.test.ts
@@ -134,3 +134,50 @@ describe("sanitizeProcessingError", () => {
     expect(out).not.toContain("ENOENT");
   });
 });
+
+/**
+ * The failure mode that hits every file at once, and the one the generic
+ * catch-all served worst.
+ */
+describe("sanitizeProcessingError on provider failures", () => {
+  it("names an exhausted API balance as a platform problem", () => {
+    // Verified live against the real API while the balance was empty.
+    const out = sanitizeProcessingError(
+      new Error(
+        "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
+      ),
+    );
+    expect(out).toContain("out of quota");
+    expect(out).toContain("not a problem with your file");
+    expect(out).not.toBe("File processing failed due to an internal error");
+  });
+
+  it("names a rejected key without leaking it", () => {
+    // Verified live: OpenAI masks the key itself, but the prefix still appears.
+    const out = sanitizeProcessingError(
+      new Error(
+        "Incorrect API key provided: sk-proj-****************************0000. You can find your API key at https://platform.openai.com/account/api-keys.",
+      ),
+    );
+    expect(out).toContain("key was rejected");
+    expect(out).not.toContain("sk-proj");
+  });
+
+  it("tells the owner to wait when the provider was merely busy", () => {
+    const out = sanitizeProcessingError(
+      new Error("API error: 503 Service Unavailable"),
+    );
+    expect(out).toContain("Try again in a few minutes");
+  });
+
+  it("still classifies a parser error that happens to contain a status number", () => {
+    // Provider checks run last for exactly this reason: pdf.js messages carry
+    // object numbers, and an early status match would relabel a corrupt file as
+    // an outage.
+    const out = sanitizeProcessingError(
+      new Error("Failed to extract PDF content: bad object 500 in XRef"),
+    );
+    expect(out).toContain("could not be read");
+    expect(out).not.toContain("AI service");
+  });
+});

--- a/apps/web/src/__tests__/server/transient-error.test.ts
+++ b/apps/web/src/__tests__/server/transient-error.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "@jest/globals";
-import { isTransientError } from "@teachanything/ai/error-utils";
+import {
+  isTransientError,
+  isPermanentProviderError,
+} from "@teachanything/ai/error-utils";
 
 /**
  * RAG resilience tests.
@@ -51,5 +54,77 @@ describe("isTransientError", () => {
   it("does NOT match generic errors", () => {
     expect(isTransientError("Network error")).toBe(false);
     expect(isTransientError("Invalid API key")).toBe(false);
+  });
+});
+
+/**
+ * The case that motivated splitting these apart: OpenAI returns an exhausted
+ * prepaid balance as a 429, so the bare status test treated a permanent billing
+ * condition as backpressure and retried it with backoff on every embedding call.
+ *
+ * The two VERIFIED strings below are what the AI SDK actually puts in
+ * `error.message` (it copies OpenAI's `error.message` verbatim; the `type` and
+ * `code` stay in `responseBody`, which this function never sees). Captured live
+ * against the real API, not paraphrased. Do not "tidy" them.
+ */
+describe("isPermanentProviderError", () => {
+  // Verified live, 429, while the account balance was empty.
+  const QUOTA_EXHAUSTED =
+    "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.";
+  // Verified live, 401, with a deliberately bad key.
+  const BAD_KEY =
+    "Incorrect API key provided: sk-proj-****************************0000. You can find your API key at https://platform.openai.com/account/api-keys.";
+
+  it.each([
+    ["verified quota-exhausted message", QUOTA_EXHAUSTED],
+    ["verified bad-key message", BAD_KEY],
+    [
+      "OpenAI's older quota wording",
+      "You exceeded your current quota, please check your plan and billing details",
+    ],
+    [
+      "a full response body rather than just the message",
+      '{"type":"insufficient_quota","code":"credit_balance_exhausted"}',
+    ],
+  ])("is permanent: %s", (_label, msg) => {
+    expect(isPermanentProviderError(msg)).toBe(true);
+    expect(isTransientError(msg)).toBe(false);
+  });
+
+  it("does not rely on codes that never reach error.message", () => {
+    // Guards the reasoning in error-utils: these are `type`/`code` values living
+    // in responseBody. If someone ever removes the prose patterns and keeps only
+    // the codes, the real messages above stop matching and this suite catches it.
+    expect(isPermanentProviderError(QUOTA_EXHAUSTED)).toBe(true);
+    expect(QUOTA_EXHAUSTED).not.toContain("insufficient_quota");
+    expect(QUOTA_EXHAUSTED).not.toContain("credit_balance_exhausted");
+    expect(BAD_KEY).not.toContain("invalid_api_key");
+  });
+
+  it("leaves a genuine rate limit retryable", () => {
+    // A real 429 with no quota wording still means "slow down and try again".
+    expect(isPermanentProviderError("429 Rate limit exceeded")).toBe(false);
+    expect(isTransientError("429 Rate limit exceeded")).toBe(true);
+  });
+
+  it("leaves server errors retryable", () => {
+    for (const msg of [
+      "API error: 500",
+      "Service Unavailable",
+      "Bad Gateway",
+    ]) {
+      expect(isPermanentProviderError(msg)).toBe(false);
+      expect(isTransientError(msg)).toBe(true);
+    }
+  });
+
+  it("does not claim ordinary failures as provider problems", () => {
+    for (const msg of [
+      "Network error",
+      "PDF contains no readable text content",
+      "Failed to extract PDF content: bad object 500 in XRef",
+    ]) {
+      expect(isPermanentProviderError(msg)).toBe(false);
+    }
   });
 });

--- a/apps/web/src/lib/processing-error.ts
+++ b/apps/web/src/lib/processing-error.ts
@@ -1,3 +1,8 @@
+import {
+  isPermanentProviderError,
+  isTransientError,
+} from "@teachanything/ai/error-utils";
+
 /**
  * Owner-facing messages for a failed file-processing run.
  *
@@ -60,6 +65,21 @@ export function sanitizeProcessingError(error: unknown): string {
   }
   if (msg.includes("Failed to extract content")) {
     return "This file could not be read. Try re-saving it in its native application and uploading again.";
+  }
+  // Provider failures are classified LAST, after every extraction-specific
+  // branch above. The patterns include bare status numbers, and a parser message
+  // can legitimately contain one ("bad object 500"), so letting these run first
+  // would relabel a corrupt PDF as an outage.
+  //
+  // Both branches exist because the generic catch-all below is actively harmful
+  // here: an exhausted API balance takes out EVERY file at once, and reporting
+  // that as "an internal error" is what made a billing problem look like a
+  // platform bug. It cost hours of diagnosis twice.
+  if (isPermanentProviderError(msg)) {
+    return "The AI service is out of quota or its key was rejected, so this file could not be indexed. This is a platform issue, not a problem with your file.";
+  }
+  if (isTransientError(msg)) {
+    return "The AI service was busy or unavailable and did not recover after retrying. Try again in a few minutes.";
   }
   return "File processing failed due to an internal error";
 }

--- a/packages/ai/src/error-utils.ts
+++ b/packages/ai/src/error-utils.ts
@@ -1,8 +1,56 @@
 /**
+ * Failures that arrive wearing a retryable-looking status but can never succeed
+ * on a retry.
+ *
+ * Why this matters: OpenAI reports an exhausted prepaid balance as HTTP **429**,
+ * so the bare `429` test in `isTransientError` read a permanent billing
+ * condition as backpressure and retried it three times with 1s/2s/4s backoff,
+ * per embedding call. At ~40 chunks per file in micro-batches of 10 that is
+ * roughly 28 seconds spent waiting out something only a human with a credit card
+ * can clear, and a large enough file can spend the process-file route's whole
+ * 300s `maxDuration` doing it, get killed mid-run, and leave the row claimed in
+ * `processing` for the stale sweep to reap.
+ *
+ * The patterns are prose, not codes, because of what the caller actually
+ * receives. `generateEmbedding` passes `lastError.message`, and the AI SDK sets
+ * `AI_APICallError.message` to OpenAI's `error.message` verbatim -- the machine
+ * readable `type` and `code` stay behind in `responseBody`/`data`. Verified
+ * against a live 401:
+ *
+ *   message:  "Incorrect API key provided: sk-proj-****0000. You can find your
+ *              API key at https://platform.openai.com/account/api-keys."
+ *   data:     { error: { type: "invalid_request_error", code: "invalid_api_key" } }
+ *
+ * and against a live 429 captured while the balance was empty:
+ *
+ *   message:  "You have no credits remaining. Add credits to continue using the
+ *              API at https://platform.openai.com/settings/organization/billing/."
+ *   type/code: insufficient_quota / credit_balance_exhausted
+ *
+ * So `no credits remaining` and `incorrect api key` are the patterns that do the
+ * work here. `exceeded your current quota` covers OpenAI's other, older wording
+ * for the same condition. The bare `insufficient_quota` / `credit_balance_exhausted`
+ * / `invalid_api_key` codes are kept for a caller that hands over a full
+ * response body rather than just the message; they will not match `.message`.
+ *
+ * Auth failures belong here for the same reason as quota: a revoked or wrong key
+ * is not going to become valid four seconds later.
+ */
+export function isPermanentProviderError(errorMessage: string): boolean {
+  return /insufficient_quota|credit_balance_exhausted|billing_hard_limit_reached|no credits remaining|exceeded your current quota|invalid_api_key|incorrect api key/i.test(
+    errorMessage,
+  );
+}
+
+/**
  * Check if an error message indicates a transient/retryable error
  * (rate limits or server errors that may resolve on retry).
  */
 export function isTransientError(errorMessage: string): boolean {
+  // Checked first, because a quota-exhausted response IS a 429 and would
+  // otherwise match the status test below.
+  if (isPermanentProviderError(errorMessage)) return false;
+
   return (
     /\b429\b/.test(errorMessage) ||
     /\b500\b/.test(errorMessage) ||


### PR DESCRIPTION
Follow-up to #450. Two bugs found while diagnosing today's upload failures,
where an exhausted OpenAI balance took out every upload and reported itself as
"File processing failed due to an internal error".

## 1. An exhausted quota was retried as if it were rate limiting

`isTransientError` matched a bare `/\b429\b/`. OpenAI returns an exhausted
prepaid balance as HTTP **429**, so `generateEmbedding` read a permanent billing
condition as backpressure and retried it three times with 1s/2s/4s backoff —
**per embedding call**.

At ~40 chunks per file (94,307 chunks / 2,335 files in production) in
micro-batches of 10, that is roughly **28 seconds per file** spent waiting out
something only a human with a credit card can clear. A large enough file can
spend the process-file route's whole 300s `maxDuration` doing it, get killed
mid-run, and leave the row claimed in `processing` for the stale sweep to reap 15
minutes later. A billing problem manufacturing a stuck-file problem.

`isPermanentProviderError` now runs first. A genuine 429 with no quota wording
still retries.

### The patterns are verified, not guessed

This is the part worth reviewing. `generateEmbedding` passes `lastError.message`,
and I checked what actually lands there by calling the real API through the same
code path:

| | verified value |
|---|---|
| **401, bad key** | `message`: `"Incorrect API key provided: sk-proj-****0000. You can find your API key at ..."` <br> `data.error.code`: `invalid_api_key` |
| **429, empty balance** | `message`: `"You have no credits remaining. Add credits to continue using the API at ..."` <br> `type`/`code`: `insufficient_quota` / `credit_balance_exhausted` |

The AI SDK copies OpenAI's `error.message` verbatim into
`AI_APICallError.message`; the machine-readable `type` and `code` stay behind in
`responseBody`, which this function never sees. **So matching on the codes alone
would never have fired.** The prose patterns do the work.

The tests pin those exact strings and additionally assert the codes are *absent*
from them, so a future "cleanup" to code-only matching fails loudly instead of
silently reverting the fix.

## 2. The owner was told nothing useful

`sanitizeProcessingError` had no branch for provider failures, so quota and auth
errors fell to the generic catch-all. That message cost hours of diagnosis twice
in one day: a professor cannot distinguish a billing problem from a corrupt PDF,
and neither could we — it took a hand-rolled `curl` against the embeddings
endpoint to find it.

Two branches now, sharing the classifier from `@teachanything/ai/error-utils` so
the patterns live in one place:

- permanent (quota exhausted, key rejected) → *"The AI service is out of quota or
  its key was rejected … This is a platform issue, not a problem with your file."*
- transient that outlived its retries → *"… busy or unavailable and did not
  recover after retrying. Try again in a few minutes."*

**Ordering matters and is deliberate.** These run *last*, after every
extraction-specific branch. The patterns include bare status numbers and a parser
message can legitimately contain one (`"Failed to extract PDF content: bad object
500 in XRef"`), so running them earlier would relabel a corrupt PDF as an outage.
There is a test for precisely that case.

## Note on the original trigger

The OpenAI balance has since been topped up and embeddings now succeed, so
uploads should process again. That makes this PR preventative rather than
urgent — but the retry-storm and the useless message are both still live bugs,
and the next time the balance runs out they will behave exactly the same way.

## Tests

830 → verified green across all three packages, plus lint and check-types.
New coverage: the two verified provider messages, OpenAI's older quota wording, a
full-response-body input, the codes-not-in-message guard, a genuine rate limit
staying retryable, server errors staying retryable, and the parser-message-with-a-
status-number case.
