### PR TITLE
fix(quiz): fill the silence while a leaked quiz is buffering

### DIFF
--- a/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
+++ b/apps/web/src/__tests__/server/chat/recover-quiz.test.ts
@@ -403,3 +403,144 @@ describe("a leak that needs repairing", () => {
     expect(textOf(out)).toBe("");
   });
 });
+
+/**
+ * The gap the reporting professor actually hit: the whole leaked quiz is
+ * buffered, so between the model's preamble and the finished widget nothing
+ * reaches the screen. On Llama 4 Maverick that averaged 59s and peaked at 172s,
+ * so the quiz read as a dead stream and she gave up before it landed.
+ */
+describe("placeholder while a leaked quiz is buffering", () => {
+  /** A quiz-shaped pseudo-call long enough to clear the placeholder threshold. */
+  const bigLeak = (questionCount: number, correctIndex = 0) => {
+    const questions = Array.from({ length: questionCount }, (_, i) =>
+      JSON.stringify({
+        question: `Question number ${i + 1} about gender theory and the film Barbie?`,
+        options: [
+          "First option",
+          "Second option",
+          "Third option",
+          "Fourth option",
+        ],
+        correct_index: correctIndex,
+        explanation:
+          "A deliberately wordy explanation so the serialized payload comfortably exceeds the placeholder threshold.",
+      }),
+    ).join(", ");
+    return `showQuiz(quiz_title="Gender Theory and Barbie", questions=[${questions}])`;
+  };
+
+  const PREAMBLE =
+    "Here are 5 multiple-choice questions to assess your understanding:\n";
+
+  it("shows the quiz skeleton before the quiz is finished", async () => {
+    const leak = bigLeak(5);
+    expect(leak.length).toBeGreaterThan(600);
+
+    // Split mid-leak so the placeholder has to appear on an intermediate delta,
+    // not just at text-end.
+    const out = await pump(
+      textBlock("t1", [PREAMBLE, leak.slice(0, 700), leak.slice(700)]),
+    );
+
+    const types = out.map((c) => c.type);
+    expect(types).toContain("tool-input-start");
+    // Ordering is the whole point: preamble, then the skeleton, then the quiz.
+    expect(types.indexOf("text-delta")).toBeLessThan(
+      types.indexOf("tool-input-start"),
+    );
+    expect(types.indexOf("tool-input-start")).toBeLessThan(
+      types.indexOf("tool-input-available"),
+    );
+  });
+
+  it("upgrades the skeleton in place instead of adding a second widget", async () => {
+    const leak = bigLeak(5);
+    const out = await pump(
+      textBlock("t1", [PREAMBLE, leak.slice(0, 700), leak.slice(700)]),
+    );
+
+    const start = out.find((c) => c.type === "tool-input-start");
+    const available = out.find((c) => c.type === "tool-input-available");
+    expect(start?.toolCallId).toBeDefined();
+    expect(available?.toolCallId).toBe(start?.toolCallId);
+    expect(out.filter((c) => c.type === "tool-input-start")).toHaveLength(1);
+    expect(out.filter((c) => c.type === "tool-input-available")).toHaveLength(
+      1,
+    );
+  });
+
+  it("keeps the preamble as text and closes it exactly once", async () => {
+    const leak = bigLeak(5);
+    const out = await pump(
+      textBlock("t1", [PREAMBLE, leak.slice(0, 700), leak.slice(700)]),
+    );
+
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.delta as string)
+      .join("");
+    expect(text).toContain("Here are 5 multiple-choice questions");
+    // No part of the leak may reach the screen as prose.
+    expect(text).not.toContain("showQuiz");
+    expect(text).not.toContain("correct_index");
+    expect(out.filter((c) => c.type === "text-end")).toHaveLength(1);
+  });
+
+  it("does not show a skeleton for a short non-quiz JSON block", async () => {
+    const out = await pump(
+      textBlock("t1", ['```json\n{"model": "llama", "temperature": 0.7}\n```']),
+    );
+    expect(out.map((c) => c.type)).not.toContain("tool-input-start");
+  });
+
+  it("does not show a skeleton for ordinary prose that mentions the tool", async () => {
+    const out = await pump(
+      textBlock("t1", [
+        "When you ask to be quizzed I call showQuiz(quiz_title=..., questions=[...]) internally. ".repeat(
+          9,
+        ),
+      ]),
+    );
+    expect(out.map((c) => c.type)).not.toContain("tool-input-start");
+  });
+
+  it("turns the skeleton into an error rather than printing the answer key", async () => {
+    // Every question is unrenderable (correct_index past the options), so the
+    // payload is quiz-shaped, long, and unsalvageable. Committing to the
+    // skeleton means the raw call is dropped: showing the student the model's
+    // own answer key is the failure this transform exists to prevent.
+    const out = await pump(textBlock("t1", [PREAMBLE, bigLeak(5, 99)]));
+
+    const types = out.map((c) => c.type);
+    expect(types).toContain("tool-input-start");
+    expect(types).toContain("tool-output-error");
+    expect(types).not.toContain("tool-input-available");
+
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.delta as string)
+      .join("");
+    expect(text).toContain("Here are 5 multiple-choice questions");
+    expect(text).not.toContain("correct_index");
+    expect(text).not.toContain("showQuiz");
+  });
+
+  it("still recovers when the stream dies mid-quiz after the skeleton", async () => {
+    // Abort partway: the questions that finished are salvaged, and the skeleton
+    // resolves rather than spinning forever.
+    const leak = bigLeak(5);
+    const out = await pump([
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: PREAMBLE },
+      { type: "text-delta", id: "t1", delta: leak.slice(0, leak.length - 40) },
+    ]);
+
+    const types = out.map((c) => c.type);
+    expect(types).toContain("tool-input-start");
+    expect(types).toContain("tool-input-available");
+    const available = out.find((c) => c.type === "tool-input-available");
+    const input = available?.input as { questions: unknown[] };
+    expect(input.questions.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/server/chat/recover-quiz.ts
+++ b/apps/web/src/server/chat/recover-quiz.ts
@@ -34,6 +34,34 @@ const MAX_HELD_CHARS = 8_000;
  */
 const PSEUDO_ARG_WINDOW = 48;
 
+/**
+ * How much held text has to accumulate before the "Building your quiz..."
+ * placeholder is shown.
+ *
+ * The point of the threshold is to separate a real leak from a short non-quiz
+ * JSON blob. A five-question quiz with explanations serializes to 2KB or more,
+ * while the quiz-shaped false positives in `leak-false-positives.test.ts` are
+ * all under 200 characters, so nothing in that corpus can reach this.
+ */
+const QUIZ_PLACEHOLDER_MIN_CHARS = 600;
+
+/**
+ * Whether held text is a quiz being written, confidently enough to show the
+ * placeholder for it.
+ *
+ * Stricter than `stillPlausible`, which only asks "could this still be a quiz".
+ * Both keys are required: a blob carrying just one of them (a `questions` array
+ * with no title, a title with no questions) is a shape the parser rejects
+ * anyway.
+ */
+function isQuizInProgress(held: string): boolean {
+  return (
+    held.length >= QUIZ_PLACEHOLDER_MIN_CHARS &&
+    /quiz_title/.test(held) &&
+    /"question"\s*:/.test(held)
+  );
+}
+
 /** Index where the earliest leak marker starts in `text`, or -1. */
 function findMarker(text: string): number {
   let earliest = -1;
@@ -81,6 +109,15 @@ function stillPlausible(held: string): boolean {
  * Recover a quiz a model emitted as text instead of a native `showQuiz` tool
  * call.
  *
+ * Note the placeholder behaviour, which is what the reporting professor actually
+ * experienced: buffering the leak means nothing reaches the screen between the
+ * model's preamble ("Here are 5 multiple-choice questions:") and the finished
+ * widget. On Llama 4 Maverick that gap averaged 59s and peaked at 172s, so the
+ * quiz read as a dead stream and users gave up before it arrived. Once the held
+ * text is unmistakably a quiz being written, a `tool-input-start` is emitted so
+ * the existing `QuizSkeleton` ("Building your quiz...") fills the gap, exactly as
+ * it already does for a native streamed tool call.
+ *
  * Some otherwise tool-capable models (varies by model/provider) serialize the
  * tool call into the assistant *text* channel, so the AI SDK forms no
  * `tool-showQuiz` part and the raw call renders as prose. The leak can be the
@@ -115,6 +152,14 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
   let pendingText = "";
   /** Index in `pendingText` where a leak starts, or -1 while still watching. */
   let markerAt = -1;
+  /**
+   * Set once the placeholder has been emitted, which is also the point of no
+   * return: the held text has been declared a quiz, so it is never released as
+   * prose afterwards. That is deliberate. The alternative is printing the
+   * model's own answer key to the student, which is the failure this whole
+   * transform exists to prevent.
+   */
+  let placeholderCallId: string | null = null;
 
   const reset = () => {
     blockId = null;
@@ -123,6 +168,7 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
     pending = [];
     pendingText = "";
     markerAt = -1;
+    placeholderCallId = null;
   };
 
   const deltaOf = (chunk: Chunk): string =>
@@ -134,15 +180,71 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
     startEmitted = true;
   };
 
-  /** Emit every unemitted chunk of the block exactly as it arrived. */
+  /**
+   * Emit every unemitted chunk of the block exactly as it arrived.
+   *
+   * Once the placeholder is up the held text is NOT released: it was already
+   * declared a quiz, and the raw form is the model's answer key. The placeholder
+   * is turned into an error notice instead, so the student sees that the quiz
+   * failed rather than the answers to it.
+   */
   const flushPending = (
     controller: TransformStreamDefaultController<Chunk>,
   ) => {
+    if (placeholderCallId) {
+      controller.enqueue({
+        type: "tool-output-error",
+        toolCallId: placeholderCallId,
+        errorText: "The quiz could not be built. Please ask again.",
+      } as Chunk);
+      placeholderCallId = null;
+      pending = [];
+      pendingText = "";
+      markerAt = -1;
+      return;
+    }
     if (pending.length > 0 || !startEmitted) emitStart(controller);
     for (const chunk of pending) controller.enqueue(chunk);
     pending = [];
     pendingText = "";
     markerAt = -1;
+  };
+
+  /**
+   * Show "Building your quiz..." once the held text is unmistakably a quiz.
+   *
+   * The preamble is released first so the widget lands BELOW the model's
+   * sentence rather than above it, and it is dropped from the buffer at the same
+   * time so `closeBlock` cannot emit it twice.
+   */
+  const startPlaceholder = (
+    controller: TransformStreamDefaultController<Chunk>,
+    held: string,
+  ) => {
+    if (placeholderCallId || markerAt === -1 || !isQuizInProgress(held)) return;
+
+    const preamble = pendingText.slice(0, markerAt);
+    if (preamble.trim().length > 0) {
+      emitStart(controller);
+      controller.enqueue({
+        type: "text-delta",
+        id: blockId,
+        delta: preamble,
+      } as Chunk);
+      controller.enqueue({ type: "text-end", id: blockId } as Chunk);
+    }
+    // The preamble is out, and the rest is the leak. `pending` holds the raw
+    // chunks that would have been replayed as prose; they are no longer needed.
+    pendingText = pendingText.slice(markerAt);
+    markerAt = 0;
+    pending = [];
+
+    placeholderCallId = nanoid();
+    controller.enqueue({
+      type: "tool-input-start",
+      toolCallId: placeholderCallId,
+      toolName: "showQuiz",
+    } as Chunk);
   };
 
   /**
@@ -166,8 +268,10 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
     // Drop the leaked call. Keep any preamble before it as text -- it is a
     // real part of the answer -- and close the block only if text was
     // emitted, so a leak-only block leaves no empty bubble behind.
+    // Already released when the placeholder went up, in which case markerAt was
+    // reset to 0 and this is empty.
     const preamble = pendingText.slice(0, markerAt);
-    if (startEmitted || preamble.trim().length > 0) {
+    if (!placeholderCallId && (startEmitted || preamble.trim().length > 0)) {
       emitStart(controller);
       if (preamble.length > 0) {
         controller.enqueue({
@@ -180,12 +284,15 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
         endChunk ?? ({ type: "text-end", id: blockId } as Chunk),
       );
     }
+    // Reuse the placeholder's id so the skeleton becomes the finished quiz
+    // instead of a second widget appearing beneath it.
     controller.enqueue({
       type: "tool-input-available",
-      toolCallId: nanoid(),
+      toolCallId: placeholderCallId ?? nanoid(),
       toolName: "showQuiz",
       input: quiz,
     } as Chunk);
+    placeholderCallId = null;
     return true;
   };
 
@@ -197,8 +304,12 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
    */
   const endBlock = (controller: TransformStreamDefaultController<Chunk>) => {
     const id = blockId;
+    // Read before flushing: a committed placeholder means the text part was
+    // already closed when the preamble was released, so closing it again would
+    // emit a stray `text-end`.
+    const textPartOpen = placeholderCallId === null;
     flushPending(controller);
-    if (id !== null) {
+    if (id !== null && textPartOpen) {
       controller.enqueue({ type: "text-end", id } as Chunk);
     }
   };
@@ -244,7 +355,9 @@ export function recoverLeakedQuiz(): TransformStream<Chunk, Chunk> {
         const held = pendingText.slice(markerAt);
         if (held.length > MAX_HELD_CHARS || !stillPlausible(held)) {
           flushPending(controller);
+          return;
         }
+        startPlaceholder(controller, held);
         return;
       }
 


### PR DESCRIPTION
Closes the one symptom from Prof. Joubin's report that #448 did **not** fix.

> "My Critical Theory bot (using Llama 4 Maverick) fails to make the quiz. It
> says here are 5 questions. It just stops there. However, maybe it is just very
> slow?"

Her last sentence was the diagnosis.

## The quiz was never broken

Pulled the actual conversation. One user message produced a valid
`tool-showQuiz` part, `output-available`, titled **"Gender Theory and Barbie"**,
5 questions, correctly scoped to the chapter she asked about. It arrived
**2m21s** after her question, with nothing on screen in between.

`recoverLeakedQuiz` has to buffer a leaked quiz while deciding whether the text
is a quiz at all, so between the model's preamble and the finished widget there
is no output at all. A native streamed tool call has no such gap: the AI SDK
emits input deltas and the existing `QuizSkeleton` renders "Building your
quiz…". Leaked quizzes got nothing.

Quiz-turn latency measured across production:

| Model | Quiz turns | Avg | Max |
|---|---|---|---|
| `llama-4-maverick` | 8 | **59.2s** | **172.0s** |
| `llama-4-maverick` (other bot) | 4 | 62.9s | 68.6s |
| `mistral-large-2512` | 10 | 45.6s | 85.2s |
| `llama-3.3-70b` | 31 | 23.4s | 73.0s |
| `llama-3.3-70b` (other bot) | 18 | 19.1s | 53.4s |

Maverick is the model that leaks into the text channel, so it is simultaneously
the slowest **and** the only one with no feedback during the wait. Worst
combination possible.

## The change

Emit `tool-input-start` once the held text is unmistakably a quiz being written,
and reuse that call id for the final `tool-input-available` so the skeleton
*becomes* the finished quiz rather than a second widget appearing beneath it. The
preamble is released first, so the widget lands under the sentence introducing
it.

**The gate is deliberately stricter than `stillPlausible`**, which only asks
"could this still be a quiz". Here both `quiz_title` and a `"question"` key must
be present *and* 600+ characters held. A five-question quiz with explanations
serializes to 2KB or more, while every quiz-shaped false positive in
`leak-false-positives.test.ts` is under 200 characters — so nothing in that
corpus can reach the placeholder. That suite passes unchanged.

**Committing to the skeleton is a point of no return, by design.** Once held text
is declared a quiz it is never released as prose. If it turns out unsalvageable
the placeholder becomes an error notice instead. Printing the raw call would mean
showing the student the model's own answer key — the exact failure this transform
exists to prevent, and the one she reported separately as "it answered everything
itself".

## Tests

Seven new cases: the skeleton appears mid-stream before the quiz completes;
ordering is preamble → skeleton → quiz; the call id is reused so only one widget
is ever created; the text part closes exactly once; no part of the leak reaches
the screen as prose; a short non-quiz JSON block and prose mentioning
`showQuiz()` never trigger it; an unsalvageable quiz-shaped payload becomes an
error rather than an answer key; and a stream that dies mid-quiz after the
skeleton still salvages the finished questions.

834 web + 70 ai + 14 db green, lint and check-types clean.

## Worth doing regardless of this PR

Her Critical Theory bot is on `llama-4-maverick`. `llama-3.3-70b` is ~3x faster
on quiz turns and does not leak into the text channel at all, so it never enters
the buffered path. Switching that bot is a config change with no code behind it
and would help her more immediately than this fix does.
