### PR TITLE
fix(quiz): close the loophole that let a model deliver a quiz as a table

### DIFF
--- a/apps/web/src/__tests__/server/chat/study-tools.test.ts
+++ b/apps/web/src/__tests__/server/chat/study-tools.test.ts
@@ -165,10 +165,13 @@ describe("buildStudyToolsAddendum", () => {
     expect(buildStudyToolsAddendum(150, true)).toContain("at most 1 question,");
   });
 
-  it("still tells the model to call the tool rather than write prose", () => {
+  it("still tells the model to call the tool rather than write the quiz out", () => {
+    // Was pinned to the literal "do not write the quiz out as prose". That
+    // wording is gone on purpose: a markdown table is not prose, and a model
+    // delivered one. See the delivery-instruction suite at the end of this file.
     expect(buildStudyToolsAddendum(2000, true)).toContain("showQuiz");
     expect(buildStudyToolsAddendum(2000, true)).toContain(
-      "do not write the quiz out as prose",
+      "Never write the questions into your reply",
     );
   });
 
@@ -195,5 +198,43 @@ describe("buildStudyToolsAddendum", () => {
     expect(buildStudyToolsAddendum(2000, false)).toContain(
       "Scope the quiz to exactly what the student",
     );
+  });
+});
+
+/**
+ * These are string assertions, which is all a prompt can be pinned with. They
+ * exist because the previous wording had a loophole that a real model walked
+ * through: it said "do not write the quiz out as prose", and Mistral Large
+ * answered a quiz request with a markdown table of questions, options and a
+ * "Correct Answer" column. A table is not prose, so the instruction was obeyed
+ * and the feature still failed.
+ */
+describe("buildStudyToolsAddendum quiz-delivery instruction", () => {
+  const addendum = buildStudyToolsAddendum(2000, true);
+
+  it("names the tool as the only acceptable delivery", () => {
+    expect(addendum).toContain("ONLY acceptable way");
+    expect(addendum).toContain("showQuiz");
+  });
+
+  it("forbids each format a model has actually used instead", () => {
+    // Naming the formats is the point; "not as prose" alone was not enough.
+    expect(addendum).toContain("not as prose");
+    expect(addendum).toContain("not as a numbered list");
+    expect(addendum).toContain("not as a table");
+  });
+
+  it("says why writing it out is a failure, not just that it is disallowed", () => {
+    // A reason survives paraphrasing better than a bare prohibition.
+    expect(addendum).toMatch(/hands the student every answer|cannot be scored/);
+  });
+
+  it("covers the phrasings a request actually arrives in", () => {
+    expect(addendum).toContain("give me a quiz");
+    expect(addendum).toContain("test me");
+  });
+
+  it("still tells the model to answer normally when no quiz was asked for", () => {
+    expect(addendum).toContain("without calling a tool");
   });
 });

--- a/apps/web/src/server/chat/study-tools.ts
+++ b/apps/web/src/server/chat/study-tools.ts
@@ -53,6 +53,15 @@ export function maxQuestionsForBudget(maxOutputTokens: number): number {
  * system prompt, and it pointed the model at whatever the initial RAG query
  * happened to retrieve -- so a student who asked to be quizzed on one named
  * chapter got questions drawn from across the whole corpus instead.
+ *
+ * The prohibition names FORMATS rather than saying "do not write it out as
+ * prose", which is what it used to say. Mistral Large answered "Give me a quiz
+ * about the Global Shakespeare syllabus" with a markdown table of questions,
+ * options and a "Correct Answer & Brief Explanation" column -- obeying the
+ * letter of the old instruction, since a table is not prose. It also lists the
+ * phrasings a request arrives in, because the same model complied with "Can I
+ * have an interactive quiz on this?" moments later; the intent was recognised,
+ * the delivery format was not constrained.
  */
 export function buildStudyToolsAddendum(
   maxOutputTokens: number,
@@ -64,7 +73,7 @@ export function buildStudyToolsAddendum(
     : "";
   return `
 
-You can render interactive study tools. When the student asks to be quizzed on a topic, call the \`showQuiz\` tool and fill it with well-formed questions based on the course material above - do not write the quiz out as prose. Scope the quiz to exactly what the student asked for: when they name a chapter, section, reading, topic, or text, every question must come from that material, and material outside it must be left out no matter how relevant it seems.${scoping} Keep the quiz to at most ${maxQuestions} ${maxQuestions === 1 ? "question" : "questions"}, each with up to 4 options and a one- or two-sentence explanation, so the whole quiz fits within this chatbot's reply limit. If the student is only asking a question, answer normally without calling a tool.`;
+You can render interactive study tools. When the student asks to be quizzed -- however they phrase it, including "give me a quiz", "test me", or asking to check their understanding -- the \`showQuiz\` tool is the ONLY acceptable way to deliver it. Call it and fill it with well-formed questions based on the course material above. Never write the questions into your reply instead, in any form: not as prose, not as a numbered list, and not as a table. Writing them out hands the student every answer and cannot be scored, so it fails the request even when the questions themselves are good. Scope the quiz to exactly what the student asked for: when they name a chapter, section, reading, topic, or text, every question must come from that material, and material outside it must be left out no matter how relevant it seems.${scoping} Keep the quiz to at most ${maxQuestions} ${maxQuestions === 1 ? "question" : "questions"}, each with up to 4 options and a one- or two-sentence explanation, so the whole quiz fits within this chatbot's reply limit. If the student is only asking a question, answer normally without calling a tool.`;
 }
 
 /**


### PR DESCRIPTION
From Prof. Joubin, on her Shakespeare bot after switching it to Mistral Large:

> "It does not initially give me an interactive quiz. It wrote it all out. I then
> asked it to give me an interactive quiz. It does it, but I want our system to
> intuitively always give interactive quizzes."

## What happened

Pulled the conversation:

| Time | | Content | Parts | Latency |
|---|---|---|---|---|
| 22:24:33 | user | "Give me a quiz about the Global Shakespeare syllabus…" | | |
| 22:25:11 | assistant | **4,062 chars of text** | `text` only | 38.2s |
| 22:25:38 | user | "Can I have an interactive quiz on this?" | | |
| 22:25:53 | assistant | empty content | **`tool-showQuiz`** | 15.0s |
| 22:30:55 | user | "Give me a quiz on Professor Joubin's chapter…" | | |
| 22:31:52 | assistant | empty content | **`tool-showQuiz`** | 57.0s |

Her screenshot shows what that 4,062 characters was: a markdown table with
`#`, `Question`, `Options (A-D)`, and a **`Correct Answer & Brief Explanation`**
column. Every answer visible.

This is **not** the Maverick failure mode. Maverick serializes an actual
`showQuiz(...)` call into the text channel, which `recoverLeakedQuiz` can detect
and convert. This is a genuine markdown table — there is no tool call in there to
recover, and the recovery transform is right to leave it alone.

## The loophole

The instruction said:

> …call the `showQuiz` tool … **do not write the quiz out as prose**.

A markdown table is not prose. The model obeyed the letter of the instruction and
the feature still failed.

And intent recognition was never the problem: the *same model* called the tool
correctly 27 seconds later for "Can I have an interactive quiz on this?", and
again for a later "Give me a quiz on…". It understood both asks. Only the second
one made the required output format unambiguous.

## The change

Names the formats instead of gesturing at one, declares the tool the only
acceptable delivery, and says *why* writing it out fails — a reason survives
paraphrasing better than a bare prohibition:

> …the `showQuiz` tool is the ONLY acceptable way to deliver it. … Never write the
> questions into your reply instead, in any form: not as prose, not as a numbered
> list, and not as a table. Writing them out hands the student every answer and
> cannot be scored, so it fails the request even when the questions themselves are
> good.

Also lists the phrasings a request arrives in ("give me a quiz", "test me",
asking to check their understanding).

## How common is this, actually

Measured on production, **explicit** quiz requests since the first quiz fixes
shipped on Aug 17:

| Model | Requests | Used the tool |
|---|---|---|
| `llama-3.3-70b` | 8 | 8 (100%) |
| `qwen3-235b-2507` | 1 | 1 (100%) |
| `mistral-large-2512` | 5 | 4 (80%) |

**These samples are too small to rank models** and I am not presenting them as
such. What they do establish is that the reported case is an outlier rather than a
systematic failure, which is why this PR is a prompt change and not machinery.

A first, looser cut of the same query suggested compliance rates of 0-39% across
models, which was wrong: it matched any message containing "quiz" (including
"I got the quiz wrong", which correctly produces no new quiz) and spanned months
predating the fixes. Recording that here because the misleading version is the
one that looks alarming.

## If it recurs

The next step is a deterministic backstop, not more prompt wording — detect a
turn that answered a quiz request with no `showQuiz` part and repair it with a
single conversion call. That costs a model call and latency on a path already
taking 38-57s, so it is not worth paying until the prompt fix is shown to be
insufficient.

## Tests

String assertions, which is all a prompt can be pinned with: the tool named as
sole delivery, each forbidden format, the stated reason, and the request
phrasings. The pre-existing assertion on the literal `"do not write the quiz out
as prose"` is **updated rather than deleted**, with a comment explaining that the
phrase was removed on purpose, so the loophole stays documented where someone
would otherwise reintroduce it.

839 web + 70 ai + 14 db green, lint and check-types clean.
