### PR TITLE
docs: label the tutorials for instructors and signpost them

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
         path: "/instructors",
         icon: "graduation-cap",
       },
-      { label: "Tutorials", path: "/tutorials", icon: "compass" },
+      { label: "Instructor Tutorials", path: "/tutorials", icon: "compass" },
       { label: "For Students", path: "/students", icon: "book-open" },
     ],
   },

--- a/apps/docs/docs/instructors/index.mdx
+++ b/apps/docs/docs/instructors/index.mdx
@@ -8,6 +8,10 @@ sidebar:
 
 This guide walks you through building an AI teaching assistant for your course, from your first login to sharing it with students. No technical background needed.
 
+:::tip[In a hurry?]
+Skip this guide and follow an [Instructor Tutorial](/tutorials) instead. Each one is a short walkthrough aimed at a single goal, and you finish with something working: a syllabus Q&A assistant in about five minutes, or a full course assistant in about fifteen.
+:::
+
 ## The big picture
 
 Think of your assistant as a tutor who has read all of your course materials and nothing else. When a student asks a question, it looks through your files, finds the relevant parts, and writes an answer that points back to the exact source. It won't make things up from the open internet, and it will tell students where each answer came from.

--- a/apps/docs/docs/tutorials/index.mdx
+++ b/apps/docs/docs/tutorials/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tutorials
+title: Instructor Tutorials
 description: Follow-along walkthroughs that take you from an empty account to a working, shared course assistant.
 sidebar:
   label: Overview


### PR DESCRIPTION
Both changes requested by Prof. Joubin, after she asked what "Tutorials" was for
and how it differed from "For Instructors".

## 1. Renamed the tab to "Instructor Tutorials"

The nav read `For Instructors` / `Tutorials` / `For Students`. Two of those name
an **audience**, one names a **format** — so a professor scanning the tabs
reasonably wonders who the tutorials are for, and the answer only appears after
clicking in. The tutorials index already explained the distinction well; nobody
had a reason to go read it.

The page title now matches the tab.

> "Let's make it intuitive for instructors. So yes please label it Instructor
> Tutorials."

## 2. Signposted the tutorials from the instructor guide

`/docs` redirects to `/instructors`, so the reference guide is where everyone
lands, and it had no pointer to the tutorials at all. Someone in a hurry got the
full feature-by-feature guide with no hint that a five-minute path to a working
assistant existed.

Added a callout immediately after the intro line, close to her suggested wording:

```
:::tip[In a hurry?]
Skip this guide and follow an [Instructor Tutorial](/tutorials) instead. Each one
is a short walkthrough aimed at a single goal, and you finish with something
working: a syllabus Q&A assistant in about five minutes, or a full course
assistant in about fifteen.
:::
```

It names the deliverable and the rough time, which is the specific thing she said
worked about the tutorials:

> "I love how the 3 scenarios each ends with a 'deliverable.' A syllabus AI (very
> basic but useful). A first assistant, etc."

## Notes

Three source files, no content rewrites. Links are by path so the rename breaks
nothing, and the existing reverse pointer in the tutorials index ("The Instructor
guide explains each feature on its own") stays accurate.

`blume doctor` clean, 19 pages, build succeeds. `dist/` is gitignored so no build
output is included.
