### PR TITLE
fix(crawler): name the hourly web source limits in errors and on the dashboard

### DIFF
--- a/apps/web/src/__tests__/lib/rate-limits.test.ts
+++ b/apps/web/src/__tests__/lib/rate-limits.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  CRAWL_SOURCES_PER_HOUR,
+  MANUAL_URLS_PER_HOUR,
+  RECRAWLS_PER_HOUR,
+  formatRetryAfter,
+} from "@/lib/constants/rate-limits";
+
+const NOW = 1_700_000_000_000;
+
+describe("formatRetryAfter", () => {
+  it("rounds a partial minute up", () => {
+    expect(formatRetryAfter(NOW + 90_000, NOW)).toBe("2 minutes");
+  });
+
+  it("reports a full hour", () => {
+    expect(formatRetryAfter(NOW + 60 * 60_000, NOW)).toBe("60 minutes");
+  });
+
+  it("singularizes one minute", () => {
+    expect(formatRetryAfter(NOW + 60_000, NOW)).toBe("1 minute");
+  });
+
+  it("clamps a sub-minute remainder to one minute", () => {
+    expect(formatRetryAfter(NOW + 5_000, NOW)).toBe("1 minute");
+  });
+
+  it("clamps a reset that has already passed", () => {
+    expect(formatRetryAfter(NOW - 120_000, NOW)).toBe("1 minute");
+  });
+
+  it("clamps a missing reset timestamp", () => {
+    expect(formatRetryAfter(0, NOW)).toBe("1 minute");
+  });
+});
+
+describe("hourly web source limits", () => {
+  it("keeps the numbers the dashboard copy advertises", () => {
+    expect(CRAWL_SOURCES_PER_HOUR).toBe(5);
+    expect(MANUAL_URLS_PER_HOUR).toBe(20);
+    expect(RECRAWLS_PER_HOUR).toBe(5);
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -24,6 +24,10 @@ import {
   type DashboardSortBy,
 } from "@/components/dashboard/web-sources/DashboardWebSourceTable";
 import { hasActiveCrawl } from "@/components/chatbot/web-sources/utils";
+import {
+  CRAWL_SOURCES_PER_HOUR,
+  MANUAL_URLS_PER_HOUR,
+} from "@/lib/constants/rate-limits";
 
 const ITEMS_PER_PAGE = 20;
 
@@ -217,6 +221,11 @@ export default function WebSourcesPage() {
               {showInlineLoading && (
                 <Loader2 className="ml-2 inline h-4 w-4 animate-spin align-[-2px] text-muted-foreground" />
               )}
+            </p>
+            <p className="text-muted-foreground mt-2 text-sm">
+              You can add up to {CRAWL_SOURCES_PER_HOUR} full website crawls and{" "}
+              {MANUAL_URLS_PER_HOUR} single webpages per hour. These are hourly
+              limits, not a cap on how many web sources you can have in total.
             </p>
           </div>
           <AddWebSourcePanel />

--- a/apps/web/src/components/chatbot/web-sources/WebSourceForms.tsx
+++ b/apps/web/src/components/chatbot/web-sources/WebSourceForms.tsx
@@ -20,6 +20,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  CRAWL_SOURCES_PER_HOUR,
+  MANUAL_URLS_PER_HOUR,
+} from "@/lib/constants/rate-limits";
 
 export function AddFullWebSourceDialog({
   open,
@@ -65,7 +69,8 @@ export function AddFullWebSourceDialog({
           <DialogTitle>Add Full Web Source</DialogTitle>
           <DialogDescription>
             Enter a starting URL. The crawler follows links from that page
-            within the limits you set.
+            within the limits you set. You can start up to{" "}
+            {CRAWL_SOURCES_PER_HOUR} crawls per hour.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4 py-4">
@@ -149,14 +154,17 @@ export function SingleWebpageForm({
   onSubmit: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-2 sm:flex-row">
-      <div className="flex-1">
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+      <div className="flex-1 space-y-1">
         <Input
           placeholder="Add a single page URL..."
           value={manualUrl}
           onChange={(event) => onManualUrlChange(event.target.value)}
           onKeyDown={(event) => event.key === "Enter" && onSubmit()}
         />
+        <p className="text-xs text-muted-foreground">
+          Up to {MANUAL_URLS_PER_HOUR} single webpages per hour.
+        </p>
       </div>
       <TooltipProvider>
         <Tooltip>

--- a/apps/web/src/lib/constants/rate-limits.ts
+++ b/apps/web/src/lib/constants/rate-limits.ts
@@ -1,0 +1,21 @@
+/**
+ * Hourly caps for web-source additions.
+ *
+ * These live in a client-safe module (no redis/env imports) so the dashboard
+ * copy, the tRPC error messages, and the limiter windows in
+ * `lib/rate-limit.ts` all read the same numbers. Keep them in sync by
+ * importing from here, never by re-typing the literal.
+ */
+export const CRAWL_SOURCES_PER_HOUR = 5;
+export const MANUAL_URLS_PER_HOUR = 20;
+export const RECRAWLS_PER_HOUR = 5;
+
+/**
+ * Human-readable wait until a sliding window frees up. `reset` is the epoch-ms
+ * timestamp Upstash returns with a denied request. Clamped to at least one
+ * minute so a sub-minute remainder never renders "in 0 minutes".
+ */
+export function formatRetryAfter(reset: number, now: number = Date.now()) {
+  const minutes = Math.max(1, Math.ceil((reset - now) / 60_000));
+  return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+}

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -2,6 +2,11 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { isServiceAvailable, env } from "./env";
 import { logWarn } from "./logger";
+import {
+  CRAWL_SOURCES_PER_HOUR,
+  MANUAL_URLS_PER_HOUR,
+  RECRAWLS_PER_HOUR,
+} from "./constants/rate-limits";
 
 // Conditionally create Redis client and rate limiters
 const redis = isServiceAvailable("redis")
@@ -127,21 +132,21 @@ export const downloadRateLimit = createLimiter({
 // Rate limiter for adding crawl sources
 // 5 per hour per user (each triggers many page fetches + embeddings)
 export const crawlSourceRateLimit = createLimiter({
-  window: [5, "1 h"],
+  window: [CRAWL_SOURCES_PER_HOUR, "1 h"],
   prefix: "@ratelimit/crawl-source",
 });
 
 // Rate limiter for adding manual URLs
 // 20 per hour per user
 export const manualUrlRateLimit = createLimiter({
-  window: [20, "1 h"],
+  window: [MANUAL_URLS_PER_HOUR, "1 h"],
   prefix: "@ratelimit/manual-url",
 });
 
 // Rate limiter for recrawl requests
 // 5 per hour per user
 export const recrawlRateLimit = createLimiter({
-  window: [5, "1 h"],
+  window: [RECRAWLS_PER_HOUR, "1 h"],
   prefix: "@ratelimit/recrawl",
 });
 

--- a/apps/web/src/server/routers/crawler/procedures/add-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/add-crawl-source.ts
@@ -8,6 +8,10 @@ import {
 import { verifyUrlReachable } from "@teachanything/ai/crawler";
 import { dispatchCrawlJob, processCrawlDiscovery } from "@/lib/crawl-processor";
 import { checkRateLimit, crawlSourceRateLimit } from "@/lib/rate-limit";
+import {
+  CRAWL_SOURCES_PER_HOUR,
+  formatRetryAfter,
+} from "@/lib/constants/rate-limits";
 import { assertOwnedChatbot } from "../helpers";
 import { crawlSourceInput } from "../validation";
 
@@ -18,7 +22,7 @@ export const addCrawlSourceProcedure = protectedProcedure
       await assertOwnedChatbot(ctx, input.chatbotId);
     }
 
-    const { success } = await checkRateLimit(
+    const { success, reset } = await checkRateLimit(
       crawlSourceRateLimit,
       ctx.session.user.id,
       { action: "addCrawlSource" },
@@ -26,7 +30,7 @@ export const addCrawlSourceProcedure = protectedProcedure
     if (!success) {
       throw new TRPCError({
         code: "TOO_MANY_REQUESTS",
-        message: "Too many crawl sources created. Please try again later.",
+        message: `You've reached the hourly limit of ${CRAWL_SOURCES_PER_HOUR} full website crawls. This is an hourly limit, not a total cap on web sources. You can start another crawl in ${formatRetryAfter(reset)}.`,
       });
     }
 

--- a/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
+++ b/apps/web/src/server/routers/crawler/procedures/add-manual-url.ts
@@ -13,6 +13,10 @@ import {
   finalizeCrawlSource,
 } from "@/lib/crawl-processor";
 import { checkRateLimit, manualUrlRateLimit } from "@/lib/rate-limit";
+import {
+  MANUAL_URLS_PER_HOUR,
+  formatRetryAfter,
+} from "@/lib/constants/rate-limits";
 import { assertOwnedChatbot } from "../helpers";
 import { manualUrlInput } from "../validation";
 
@@ -23,7 +27,7 @@ export const addManualUrlProcedure = protectedProcedure
       await assertOwnedChatbot(ctx, input.chatbotId);
     }
 
-    const { success } = await checkRateLimit(
+    const { success, reset } = await checkRateLimit(
       manualUrlRateLimit,
       ctx.session.user.id,
       { action: "addManualUrl" },
@@ -31,7 +35,7 @@ export const addManualUrlProcedure = protectedProcedure
     if (!success) {
       throw new TRPCError({
         code: "TOO_MANY_REQUESTS",
-        message: "Too many manual URL additions. Please try again later.",
+        message: `You've reached the hourly limit of ${MANUAL_URLS_PER_HOUR} single webpages. This is an hourly limit, not a total cap on web sources. You can add another page in ${formatRetryAfter(reset)}.`,
       });
     }
 

--- a/apps/web/src/server/routers/crawler/procedures/recrawl.ts
+++ b/apps/web/src/server/routers/crawler/procedures/recrawl.ts
@@ -4,6 +4,10 @@ import { TRPCError } from "@trpc/server";
 import { crawlSources } from "@teachanything/db/schema";
 import { dispatchCrawlJob, processCrawlDiscovery } from "@/lib/crawl-processor";
 import { checkRateLimit, recrawlRateLimit } from "@/lib/rate-limit";
+import {
+  RECRAWLS_PER_HOUR,
+  formatRetryAfter,
+} from "@/lib/constants/rate-limits";
 import { crawlSourceIdInput } from "../validation";
 import { assertOwnedCrawlSource } from "../helpers";
 
@@ -12,7 +16,7 @@ export const recrawlProcedure = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const source = await assertOwnedCrawlSource(ctx, input.crawlSourceId);
 
-    const { success } = await checkRateLimit(
+    const { success, reset } = await checkRateLimit(
       recrawlRateLimit,
       ctx.session.user.id,
       { action: "recrawl" },
@@ -20,7 +24,7 @@ export const recrawlProcedure = protectedProcedure
     if (!success) {
       throw new TRPCError({
         code: "TOO_MANY_REQUESTS",
-        message: "Too many recrawl requests. Please try again later.",
+        message: `You've reached the hourly limit of ${RECRAWLS_PER_HOUR} re-crawls. You can re-crawl again in ${formatRetryAfter(reset)}.`,
       });
     }
 

--- a/apps/web/src/server/routers/crawler/procedures/toggle-crawl-source.ts
+++ b/apps/web/src/server/routers/crawler/procedures/toggle-crawl-source.ts
@@ -5,6 +5,7 @@ import { TRPCError } from "@trpc/server";
 import { crawlSources } from "@teachanything/db/schema";
 import { logInfo } from "@/lib/logger";
 import { checkRateLimit, recrawlRateLimit } from "@/lib/rate-limit";
+import { formatRetryAfter } from "@/lib/constants/rate-limits";
 import { assertOwnedCrawlSource } from "../helpers";
 
 export const toggleCrawlSourceProcedure = protectedProcedure
@@ -17,7 +18,7 @@ export const toggleCrawlSourceProcedure = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     await assertOwnedCrawlSource(ctx, input.crawlSourceId);
 
-    const { success } = await checkRateLimit(
+    const { success, reset } = await checkRateLimit(
       recrawlRateLimit,
       ctx.session.user.id,
       { action: "toggleCrawlSource" },
@@ -25,7 +26,7 @@ export const toggleCrawlSourceProcedure = protectedProcedure
     if (!success) {
       throw new TRPCError({
         code: "TOO_MANY_REQUESTS",
-        message: "Too many toggle requests. Please try again later.",
+        message: `Too many requests. Please try again in ${formatRetryAfter(reset)}.`,
       });
     }
 


### PR DESCRIPTION
Follow-up to Prof. Joubin's report that adding web sources stopped at what looked like a total cap of 6.

## What changed

**Error messages** now say which hourly limit was hit, that it is hourly, and when it frees up:

- Full crawl: `You've reached the hourly limit of 5 full website crawls. This is an hourly limit, not a total cap on web sources. You can start another crawl in 34 minutes.`
- Single page: `You've reached the hourly limit of 20 single webpages. ... You can add another page in 12 minutes.`
- Re-crawl: names its own limit of 5/hour.
- Toggle enable/disable shares the re-crawl limiter, so it stays generic (`Too many requests. Please try again in X minutes.`) rather than claiming a toggle-specific limit.

**Persistent copy on the dashboard**, since the toast disappears before people read it:

- Web Sources page header: "You can add up to 5 full website crawls and 20 single webpages per hour. These are hourly limits, not a cap on how many web sources you can have in total."
- The Add Full Web Source dialog and the single-page form carry their own limits inline (shared components, so this shows on the chatbot Web Sources tab too).

**Limit values are unchanged** — the professor withdrew the request to raise them once the hourly window was clear. The numbers now live in a client-safe `lib/constants/rate-limits.ts` that both the limiter windows and the UI copy import, so the dashboard can't drift from the real limits.

## Verification

`npm run check-types`, `npm run lint`, `npm run test` (846 tests) all pass. New unit tests cover the retry-time formatter (sub-minute clamp, past timestamp, missing reset, singular/plural) and pin the advertised limit numbers.