### PR TITLE
docs: bring the docs in line with the post-refactor tree

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ node_modules
 .next
 dist
 coverage
+apps/docs/.blume
 
 # Generated files
 packages/db/drizzle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ teachanything/
 │   │       │   ├── chat/         # Chat turn pipeline (context, prompts, execution, persistence)
 │   │       │   ├── file-processor/  # Upload → extract → chunk → embed pipeline
 │   │       │   ├── crawl-processor/ # Discover → fetch → extract → embed pipeline
-│   │       │   └── routers/      # API routers (auth, chatbot, chat, files, admin, analytics, crawler)
+│   │       │   └── routers/      # API routers (auth, chatbot, files, analytics, admin, crawler)
 │   │       ├── lib/              # Client-safe utilities (env, logger, validation, formatting)
 │   │       ├── components/       # React components (Shadcn UI based)
 │   │       └── hooks/            # Custom React hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,13 @@ teachanything/
 everything that must never reach the browser: tRPC routers, Better Auth, the
 chat turn pipeline, the file and crawl processors, rate limiting, QStash, and
 storage clients. `lib/` holds only what is safe to bundle for the client, so it
-reads no server-only environment variables and imports no database, Redis,
-Resend or Supabase client.
+imports no database, Redis, Resend or Supabase client.
+
+`lib/env.ts` is the one deliberate exception: it declares and validates the
+whole schema, server-only keys included, because validation has to happen
+somewhere a server entry point can reach. What it does not do is hand those
+values to the browser. On the client it exposes only the `NEXT_PUBLIC_*` keys
+and throws on anything else.
 
 Two practical consequences:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,17 +85,35 @@ npm run stop             # Stop PostgreSQL container
 ```
 teachanything/
 ├── apps/
-│   └── web/                  # Next.js 16 application
-│       └── src/
-│           ├── app/          # App Router pages & API routes
-│           ├── server/       # tRPC routers & middleware
-│           ├── lib/          # Utilities (auth, email, rate-limit, qstash)
-│           ├── components/   # React components (Shadcn UI)
-│           └── hooks/        # Custom React hooks
+│   ├── web/                  # Next.js 16 application
+│   │   └── src/
+│   │       ├── app/          # App Router pages & API routes
+│   │       ├── server/       # Server-only code (see below)
+│   │       ├── lib/          # Client-safe utilities
+│   │       ├── components/   # React components (Shadcn UI)
+│   │       └── hooks/        # Custom React hooks
+│   └── docs/                 # User guides (Blume static site, served at /docs)
 ├── packages/
 │   ├── db/                   # Database package (Drizzle schema)
-│   └── ai/                   # AI package (LLM client, RAG pipeline)
+│   ├── ai/                   # AI package (LLM client, RAG pipeline, crawler)
+│   └── logger/               # Shared structured logger
 ```
+
+**`server/` vs `lib/` is a boundary, not a preference.** `server/` holds
+everything that must never reach the browser: tRPC routers, Better Auth, the
+chat turn pipeline, the file and crawl processors, rate limiting, QStash, and
+storage clients. `lib/` holds only what is safe to bundle for the client, so it
+reads no server-only environment variables and imports no database, Redis,
+Resend or Supabase client.
+
+Two practical consequences:
+
+- A client component may import a **type** from `server/` but never a value.
+- Reading a non-`NEXT_PUBLIC_*` key off `env` in client-reachable code throws at
+  runtime in the browser rather than silently returning `undefined`. If you need
+  a value on the client, add it to the schema with a `NEXT_PUBLIC_` prefix.
+
+Nothing currently enforces this at build time, so it is on review to catch.
 
 ## Pull Request Workflow
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ For developers, see [SETUP.md](./SETUP.md) (environment configuration), [CONTRIB
 teachanything/
 ├── apps/web/           # Next.js application
 │   ├── src/app/        # Pages & API routes
+│   ├── src/server/     # Server-only: tRPC routers, auth, chat pipeline,
+│   │                   #   file/crawl processors, rate limiting, jobs
+│   ├── src/lib/        # Client-safe utilities (env, logger, validation, formatting)
 │   ├── src/components/ # UI components
-│   └── src/server/     # tRPC routers (incl. rag-context, analytics, crawler)
+│   └── src/hooks/      # React hooks
 ├── apps/docs/          # User guides (Blume static site, served at /docs)
 ├── packages/
 │   ├── db/             # Database schema (Drizzle, pgvector, HNSW index)

--- a/SETUP.md
+++ b/SETUP.md
@@ -250,12 +250,15 @@ Visit: http://localhost:3000
 teachanything/
 ├── apps/web/              # Next.js application
 │   ├── src/app/          # Pages & API routes
+│   ├── src/server/       # Server-only (tRPC routers, auth, jobs, storage)
+│   ├── src/lib/          # Client-safe utilities
 │   ├── src/components/   # UI components
-│   ├── src/lib/          # Utilities
-│   └── src/server/       # tRPC routers
+│   └── src/hooks/        # React hooks
+├── apps/docs/            # User guides (served at /docs)
 ├── packages/
 │   ├── db/               # Database schema
-│   └── ai/               # OpenRouter + RAG
+│   ├── ai/               # OpenRouter + RAG
+│   └── logger/           # Structured logger
 ```
 
 ---
@@ -276,7 +279,9 @@ teachanything/
 1. User enters credentials
 2. Better Auth validates
 3. Database hook checks status
-4. Blocks if pending/rejected
+4. Blocks if pending/rejected, and the reason reaches the client, so a user
+   awaiting approval is sent to `/pending` and a rejected one to `/rejected`
+   rather than seeing a generic failure
 5. Allows if approved
 
 **Approval:**
@@ -288,7 +293,8 @@ teachanything/
 
 ### Domain Validation (Optional)
 
-Restrict registration to specific domains:
+Restrict registration to specific domains, either through the admin UI or
+directly:
 
 ```sql
 INSERT INTO "approved_domains" (domain, created_at)
@@ -297,7 +303,23 @@ VALUES
   ('university.edu', NOW());
 ```
 
-If no domains configured → all emails allowed.
+Entries from the database are combined with the `ALLOWED_EMAIL_DOMAINS`
+environment variable. An entry is read one of two ways:
+
+| Entry                   | Matches                                     |
+| ----------------------- | ------------------------------------------- |
+| `gwu.edu` or `@gwu.edu` | that host and its subdomains (`cs.gwu.edu`) |
+| `.edu` or `edu`         | anything under that TLD                     |
+
+Matching is on a label boundary, so a lookalike domain like `evil-gwu.edu` does
+**not** match a `gwu.edu` entry. Entries are case-insensitive.
+
+If no domains are configured → all emails allowed. Blank entries are ignored,
+so an empty `ALLOWED_EMAIL_DOMAINS` also means "no restriction" rather than
+"reject everyone".
+
+The check runs only when the account is created, so tightening the list never
+locks out an existing user.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -314,9 +314,20 @@ environment variable. An entry is read one of two ways:
 Matching is on a label boundary, so a lookalike domain like `evil-gwu.edu` does
 **not** match a `gwu.edu` entry. Entries are case-insensitive.
 
-If no domains are configured → all emails allowed. Blank entries are ignored,
-so an empty `ALLOWED_EMAIL_DOMAINS` also means "no restriction" rather than
-"reject everyone".
+**Unset is not the same as empty.** `ALLOWED_EMAIL_DOMAINS` defaults to
+`.edu,.ac.in,.edu.in`, so leaving it out of your environment restricts
+registration to those TLDs rather than allowing everything:
+
+| `ALLOWED_EMAIL_DOMAINS` | Effective allowlist                                               |
+| ----------------------- | ----------------------------------------------------------------- |
+| unset                   | `.edu,.ac.in,.edu.in` plus any database entries                   |
+| `.edu`                  | `.edu` plus any database entries                                  |
+| `` (explicitly empty)   | database entries only; if there are none, any domain may register |
+
+To turn allowlisting off entirely, set it to an empty string and leave
+`approved_domains` empty. Blank entries within the list are ignored, so a
+trailing comma is harmless and an all-blank list reads as "no restriction"
+rather than "reject everyone".
 
 The check runs only when the account is created, so tightening the list never
 locks out an existing user.

--- a/apps/docs/docs/instructors/index.mdx
+++ b/apps/docs/docs/instructors/index.mdx
@@ -55,7 +55,9 @@ Instructor sign-ups go through a short approval step so only real instructors ge
   </Step>
   <Step title="Wait for approval">
     An administrator reviews new accounts. You'll be able to log in once your
-    account is approved. This is usually quick, but it isn't instant.
+    account is approved. This is usually quick, but it isn't instant. If you try
+    to sign in before then, we'll tell you your account is still waiting rather
+    than just refusing the password.
   </Step>
   <Step title="Log in">
     Once approved, [sign in](https://teachanything.ai/login) and you'll land on

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -48,8 +48,9 @@ ADMIN_EMAILS=admin@example.com
 
 # Registration allowlist. An entry is either a specific institution
 # ("gwu.edu", matching that host and its subdomains) or a TLD wildcard
-# (".edu", matching anything under it). Leave unset to allow any domain;
-# setting it to an empty string does the same.
+# (".edu", matching anything under it). Combined with the approved_domains
+# table. Left unset it defaults to the value shown below, which DOES restrict
+# registration; to allow any domain, set it to an empty string.
 # ALLOWED_EMAIL_DOMAINS=.edu,.ac.in,.edu.in
 # NEXT_PUBLIC_MAX_FILE_SIZE_MB=50
 # Set to "false" to hide the microphone button in the chat input.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -46,8 +46,14 @@ ADMIN_EMAILS=admin@example.com
 # DEFAULTS — override if needed
 # ==============================================================================
 
+# Registration allowlist. An entry is either a specific institution
+# ("gwu.edu", matching that host and its subdomains) or a TLD wildcard
+# (".edu", matching anything under it). Leave unset to allow any domain;
+# setting it to an empty string does the same.
 # ALLOWED_EMAIL_DOMAINS=.edu,.ac.in,.edu.in
 # NEXT_PUBLIC_MAX_FILE_SIZE_MB=50
+# Set to "false" to hide the microphone button in the chat input.
+# NEXT_PUBLIC_VOICE_INPUT_ENABLED=true
 # NEXT_PUBLIC_GITHUB_URL=
 # NEXT_PUBLIC_CONTACT_EMAIL=
 # NEXT_PUBLIC_LINKEDIN_URL=


### PR DESCRIPTION
Follow-up to #458 and #461. Docs only, no code.

#458 moved 13 server-only modules out of `lib/` into `server/` and made `lib/` client-safe. The prose describing the repo did not move with it.

## Stale, now fixed

- **`CONTRIBUTING.md`** listed `lib/  # Utilities (auth, email, rate-limit, qstash)`. All four of those are in `server/` now, so the single line a new contributor reads to learn the layout named the exact modules that moved. Also added the `server/` vs `lib/` boundary and its two practical rules: a client component may import a **type** from `server/` but never a value, and reading a non-`NEXT_PUBLIC_` key off `env` in client-reachable code throws in the browser rather than returning `undefined`. Called out that nothing enforces either at build time.
- **`README.md`** and **`SETUP.md`** described `server/` as "tRPC routers", and neither listed `apps/docs` or `packages/logger`.
- **`AGENTS.md`** listed a `chat` router that `_app.ts` does not mount. The real six: auth, chatbot, files, analytics, admin, crawler.

## Newly documented behavior from #461

- **`SETUP.md`**: a blocked login now reaches the client, so a pending user lands on `/pending` and a rejected one on `/rejected` instead of a generic failure. Added a table for the domain allowlist showing what each entry shape matches, plus three things that were previously only discoverable by reading the code:
  - matching is on a label boundary, so `evil-gwu.edu` does **not** match a `gwu.edu` entry
  - a blank `ALLOWED_EMAIL_DOMAINS` means "no restriction", not "reject everyone"
  - the check runs only at account creation, so tightening the list cannot lock out an existing user
- **`apps/docs`**: the instructor guide said to wait for approval but not what a premature login looks like. It now says they will be told the account is waiting rather than have the password refused.

## `.env.example`

`NEXT_PUBLIC_VOICE_INPUT_ENABLED` was missing entirely, and `ALLOWED_EMAIL_DOMAINS` had no explanation of its two entry shapes. Both added.

(`DIRECT_URL` is in the env schema but referenced nowhere in the codebase, so it is deliberately left undocumented rather than described as if it does something.)

## Verification

`prettier --check`, and `turbo run build` green for both `@teachanything/web` and the docs site.