### PR TITLE
fix(web-sources): remove duplicated hourly limit paragraph

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/web-sources/page.tsx
@@ -65,11 +65,6 @@ export default function WebSourcesPage() {
               {MANUAL_URLS_PER_HOUR} single webpages per hour. These are hourly
               limits, not a cap on how many web sources you can have in total.
             </p>
-            <p className="text-muted-foreground mt-2 text-sm">
-              You can add up to {CRAWL_SOURCES_PER_HOUR} full website crawls and{" "}
-              {MANUAL_URLS_PER_HOUR} single webpages per hour. These are hourly
-              limits, not a cap on how many web sources you can have in total.
-            </p>
           </div>
           <AddWebSourcePanel />
         </div>


### PR DESCRIPTION
The hourly rate-limit explainer on the Web Sources page rendered twice: the same `<p>` block was pasted back to back in `page.tsx`. Dropped the duplicate.

No logic change, copy only.