### PR TITLE
fix(crawler): keep attach/detach pending until the source list refetch lands

### DIFF
--- a/apps/web/src/__tests__/hooks/use-crawler-mutations.test.ts
+++ b/apps/web/src/__tests__/hooks/use-crawler-mutations.test.ts
@@ -1,0 +1,87 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+type MutationOptions = {
+  onSuccess?: (...args: unknown[]) => unknown;
+};
+
+/** `useMutation` options captured per procedure name (attachToChatbot, …). */
+const mockCaptured = new Map<string, MutationOptions>();
+
+jest.unstable_mockModule("@/lib/trpc", () => ({
+  trpc: {
+    crawler: new Proxy(
+      {},
+      {
+        get: (_target, name) => ({
+          useMutation: (options: MutationOptions) => {
+            mockCaptured.set(String(name), options);
+            return {
+              mutate: () => undefined,
+              mutateAsync: async () => undefined,
+              isPending: false,
+              variables: undefined,
+            };
+          },
+        }),
+      },
+    ),
+  },
+}));
+jest.unstable_mockModule("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const { useCrawlerMutations } = await import("@/hooks/use-crawler-mutations");
+const { toast } = await import("sonner");
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const flushMicrotasks = () => new Promise((r) => setTimeout(r, 0));
+
+describe.each(["attachToChatbot", "detachFromChatbot"])(
+  "useCrawlerMutations %s onSuccess",
+  (procedure) => {
+    it("holds the mutation pending until the list refresh settles", async () => {
+      const refresh = deferred();
+      useCrawlerMutations({ refresh: () => refresh.promise });
+
+      let settled = false;
+      const result = Promise.resolve(
+        mockCaptured.get(procedure)?.onSuccess?.(),
+      ).then(() => {
+        settled = true;
+      });
+
+      await flushMicrotasks();
+      expect(settled).toBe(false);
+
+      refresh.resolve();
+      await result;
+      expect(settled).toBe(true);
+    });
+
+    it("fires the toast and attachment refresh before the list refresh settles", () => {
+      const refresh = deferred();
+      const refreshAttachments = jest.fn();
+      useCrawlerMutations({
+        refresh: () => refresh.promise,
+        refreshAttachments,
+        attachSuccessMessage: "attached",
+        detachSuccessMessage: "detached",
+      });
+
+      void mockCaptured.get(procedure)?.onSuccess?.();
+
+      expect(refreshAttachments).toHaveBeenCalledTimes(1);
+      expect(toast.success).toHaveBeenCalledWith(
+        procedure === "attachToChatbot" ? "attached" : "detached",
+      );
+    });
+  },
+);

--- a/apps/web/src/hooks/use-crawler-mutations.ts
+++ b/apps/web/src/hooks/use-crawler-mutations.ts
@@ -34,10 +34,12 @@ export interface CrawlerMutations {
 
 interface UseCrawlerMutationsOptions {
   /**
-   * Refreshes the source list after every successful mutation. Fired without
-   * awaiting, matching the original inline wiring.
+   * Refreshes the source list after every successful mutation. Attach/detach
+   * await it so `isPending` holds until the refetched list lands (the row's
+   * chatbot picker is gated on it); the other mutations fire it without
+   * awaiting.
    */
-  refresh: () => void | Promise<unknown>;
+  refresh: () => Promise<unknown>;
   /**
    * Extra refresh for attach/detach (e.g. invalidate the chatbot's
    * attachable-sources list). Not awaited.
@@ -80,22 +82,22 @@ export function useCrawlerMutations(
 
   const attach = trpc.crawler.attachToChatbot.useMutation({
     onSuccess: () => {
-      void refresh();
       refreshAttachments?.();
       if (attachSuccessMessage) {
         toast.success(attachSuccessMessage);
       }
+      return refresh();
     },
     onError: (error) => showError("Failed to attach", error),
   });
 
   const detach = trpc.crawler.detachFromChatbot.useMutation({
     onSuccess: () => {
-      void refresh();
       refreshAttachments?.();
       if (detachSuccessMessage) {
         toast.success(detachSuccessMessage);
       }
+      return refresh();
     },
     onError: (error) => showError("Failed to remove", error),
   });


### PR DESCRIPTION

The attach/detach pending thing you found while reviewing #458. basically the extracted hook stopped holding `isPending` through the list refetch, and i think the fix is small but it needed a call on the two consumers, so i want to walk through what i did and why.

## summary

so before #458 the dashboard page wired attach and detach with an expression body arrow, `onSuccess: () => refreshSources()`, which returns the `invalidate()` promise. react query awaits whatever `onSuccess` returns before it dispatches success, so `isPending` used to stay true until the refetched list came back. the extracted `useCrawlerMutations` hook fires the refresh with `void` instead, so `isPending` clears as soon as the server responds, and the row's chatbot picker enables again while it's still showing the old attachments. one more click there fires against state that's about to change underneath it.

* attach and detach `onSuccess` now return the `refresh()` promise instead of voiding it
* the `refresh` option is tightened from `() => void | Promise<unknown>` to `() => Promise<unknown>`
* new hook test under `__tests__/hooks` that fails on the old code
* closes #481

## changes

so first i wanted to make sure the mechanism was actually real and not just a reading of the code, and i'm pretty sure it is. tanstack query core 5.100.8 awaits `onSuccess` before dispatching success (line 123 of the mutation file), and the trpc react query 11.17.0 `useMutation` wrapper returns your `onSuccess` result straight through, its default `mutationSuccessOverride` is just `options => options.originalFn()` and we don't configure an override in the trpc client. and the gate on the dashboard is `page.tsx` feeding `attach.isPending || detach.isPending` into the `disabled` prop on every checkbox item in `ChatbotAttachButton`, which is the thing that now opens early.

the decision part. the two call sites genuinely differed before #458, the dashboard awaited and `WebSourcesTab` didn't, so a totally faithful restore would need a per consumer flag like `awaitRefresh`. i went with awaiting in both instead. my reasoning is basically that `WebSourcesTab` not awaiting was an accident of block body syntax rather than a design choice, and it has the exact same stale state window, its attach buttons and the per row remove buttons are gated on the same `isPending` values. a flag whose only reason to exist is that one call site used to be an expression body didn't feel worth carrying. so now the hook's contract is one sentence, attach and detach hold `isPending` until the refetched list lands.

in the hook itself:

* attach and detach `onSuccess` still call `refreshAttachments?.()` and the success toast synchronously first, then `return refresh()`. so toast timing in `WebSourcesTab` is unchanged.
* `refresh` is now typed `() => Promise<unknown>`. both existing callers already return promises (`utils.crawler.getAllCrawlSources.invalidate()` and `useQuery().refetch`), so it compiles today. the point is that a future block body callback like `() => { void invalidate(); }`, which is the exact shape that caused this, becomes a compile error instead of a silent revert. it also matches how `refreshAfterRename` was already typed.
* the doc comment on `refresh` now says which mutations await it. the old one asserted the opposite, which is what made this silent.

in the new test:

* it mocks the trpc client and sonner with `jest.unstable_mockModule`, same pattern as the user deletion test, and captures each `useMutation`'s options. the hook has no react hooks of its own besides the mocked trpc ones, so i just call it as a plain function, no renderer needed.
* for both `attachToChatbot` and `detachFromChatbot` it checks that `onSuccess` doesn't settle until `refresh` resolves, and that the toast and `refreshAttachments` fire before the refresh settles. i stashed the hook change and reran it, and the two "holds pending" cases go red on the old code while the toast ordering ones stay green, so it does catch the actual regression.

other than that i left a few things alone on purpose:

* `toggleCrawlSource` and `removeCrawlSource` have the same shape of window, `EnabledSwitch` can snap back to the stale value and enable again before the refetch. but they were block body at both call sites before and after #458, so that's preexisting rather than part of this regression, and i didn't want to widen the pr past what the issue scoped. i think it deserves its own issue.
* `renameCrawlSource` already awaits for `WebSourcesTab` through `refreshAfterRename` and not for the dashboard, matching both old call sites, so untouched.

and two tradeoffs of awaiting that i think are worth knowing about:

* the query client doesn't override `retry`, so a refetch that fails after a successful attach retries 3 times with backoff, something like 7 seconds or so, and the controls stay disabled that whole time. that's identical to what the dashboard did before #458, but it's new for `WebSourcesTab`.
* `WebSourcesTab`'s bulk "remove selected" runs `detach.mutateAsync` one id at a time through `runSequentially`, so each step now also waits for a refetch. removing n sources costs roughly n extra refetch round trips, in exchange for the remove buttons staying disabled for the whole run. if that ever gets noticeable, a refresh free detach for the bulk path with one refetch after the loop would fix it, but that felt like a separate change.

open questions i'd want your read on:

1. do you want toggle and remove to await too so the hook contract is uniform? i can do that in this pr or a follow up, whichever you prefer.
2. toast before or after the await? rename in the same hook toasts after its awaited refresh. i kept attach and detach toasting first because that's what `WebSourcesTab` did before, but i could see the argument for matching rename.
3. is the bulk remove slowdown fine for now, or do you want the refresh free detach in here?
4. i haven't clicked through it on a throttled network yet, so the manual check in the test plan is still open.

## library choices

no new dependencies.
## test plan

* [x] lint passes with zero warnings
* [x] type check passes
* [x] tests pass across the whole monorepo, roughly 940 in web plus the db and ai packages
* [x] new test goes red against the old hook (verified by stashing the hook change)
* [x] verified the whole chain in installed code: hook returns the promise, trpc wrapper returns it, react query awaits it, `page.tsx` passes it, `ChatbotAttachButton` gates on it
* [ ] manual: on the dashboard web sources page, open a row's chatbot picker on a throttled network and attach. the items should stay disabled until the count and checkbox update, with no window where the old state is clickable
* edge cases i thought about: `refresh` rejecting (neither `refetch()` nor `invalidate()` rejects by default, and it's the same semantics the dashboard had before #458), and a sync throw in `refreshAttachments` or the toast (not possible with the current callers)

## checklist

* [x] pr title follows conventional commit format
* [x] linked to an issue (closes #481)
* [x] `npm run lint` passes
* [x] type check passes
* [x] `npm run test` passes
* [x] no `console.log` statements
* [x] zod validation on new trpc inputs, n/a, no new inputs
* [x] ownership checks on protected resources, n/a
* [x] screenshots for visual changes, n/a
* [x] new dependencies justified, none added
* [x] tests added for new logic
* [x] database migrations if schema changed, n/a
* [x] i understand and can stand behind every change in this pr

